### PR TITLE
updated the order, chat and payment controller to function properly w…

### DIFF
--- a/controllers/payment.js
+++ b/controllers/payment.js
@@ -1,6 +1,7 @@
 const Event = require("../models/Event");
 const Order = require("../models/Order");
 const Payment = require("../models/Payment");
+const ChatContent = require("../models/ChatContent");
 const { createInvoice } = require("../utils/invoice");
 const {
   CreatePayment,
@@ -302,7 +303,19 @@ const UpdatePayment = (req, res) => {
                       },
                     }
                   )
-                    .then((result) => {
+                    .then(async (result) => {
+                      // Enable chat by updating ChatContent message
+                      await ChatContent.updateMany(
+                        {
+                          "other.order": order._id,
+                          contentType: { $in: ["PersonalPackageAccepted", "BiddingOffer", "BiddingBid"] }
+                        },
+                        {
+                          $set: {
+                            "other.orderPaymentDone": true
+                          }
+                        }
+                      );
                       res.status(200).send({ message: "success" });
                     })
                     .catch((error) => {


### PR DESCRIPTION
# Pull Request: Chat Payment Flow & UI Fixes

## 🎯 Overview
This PR fixes critical issues in the chat payment flow, ensures chat is enabled after payment completion, and resolves UI issues including payment amount calculation and message spam.

## 🔧 Backend Changes

### 1. **controllers/payment.js**
**Added ChatContent model import:**
```javascript
const ChatContent = require("../models/ChatContent");
```

**Enhanced payment completion logic (Line 306-318):**
- After successful payment completion (`paymentTotal == orderTotal`), the system now updates ChatContent messages
- Sets `other.orderPaymentDone: true` for all chat messages linked to the paid order
- Applies to content types: `PersonalPackageAccepted`, `BiddingOffer`, `BiddingBid`
- This enables chat functionality immediately after payment

**Impact:** Users can now chat with vendors immediately after completing payment

---

### 2. **controllers/chat.js**
**Enhanced payment validation for bidding (Line 201-217):**
```javascript
} else if (["BiddingOffer", "BiddingBid"].includes(contentType)) {
  const accepted = Boolean(other.accepted);
  const rejected = Boolean(other.rejected);
  
  // Check if payment is done for accepted bids
  if (accepted && other?.order) {
    const order = await Order.findById(other.order)
      .select("amount.due amount.paid status.paymentDone")
      .lean();
    const dueAmount = order?.amount?.due ?? Number.POSITIVE_INFINITY;
    const paymentDone = Boolean(order?.status?.paymentDone);
    paymentOutstanding = !order || (!paymentDone && dueAmount > 0);
  } else {
    paymentOutstanding = !accepted && !rejected;
  }
}
```

**Changes:**
- Previously only checked if bid was accepted/rejected
- Now also validates that the order's payment is actually completed
- Prevents users from bypassing payment and chatting

**Impact:** Enforces payment completion before enabling chat for bidding orders

---

### 3. **controllers/order.js**

#### **Fix 1: Corrected Razorpay Payment Amount (Line 252)**
**Before:**
```javascript
amount: payableToWedsy  // Only 11% booking amount (₹5,500 for ₹50,000 bid)
```

**After:**
```javascript
amount: total  // Full amount including taxes (₹59,000 for ₹50,000 bid)
```

**Impact:** Fixed critical bug where Razorpay was only charging booking amount instead of total amount

#### **Fix 2: Auto-update ChatContent on Order Creation (Line 248-274)**
**Added logic:**
- Finds the specific chat between user and vendor
- Updates only ONE ChatContent message (most recent) instead of all messages
- Links the order to the chat message
- Marks message as accepted

**Before (caused spam):**
```javascript
await ChatContent.updateMany({ /* broad query */ })
```

**After (targeted):**
```javascript
await ChatContent.updateOne(
  {
    chat: chat._id,
    contentType: { $in: ["BiddingOffer", "BiddingBid"] },
    "other.accepted": { $ne: true },
    $or: [{ "other.events": { $in: events } }]
  },
  { $set: { "other.accepted": true, "other.order": result._id } },
  { sort: { createdAt: -1 } }
)
```

**Impact:** Eliminates spam of multiple "Booking confirmed" messages

---

## 📝 Summary of Fixes

| Issue | Root Cause | Solution |
|-------|------------|----------|
| Chat not enabled after payment | ChatContent not updated with payment status | Added `orderPaymentDone` flag update after payment |
| Chat accessible without payment | Only checked accepted/rejected, not payment status | Added order payment validation in chat middleware |
| Razorpay charging wrong amount | Returned `payableToWedsy` instead of `total` | Changed to return full `total` amount |
| Spam "Booking confirmed" messages | `updateMany` updated all similar messages | Changed to `updateOne` with specific chat filter |

---

## 🔄 Flow After Changes

1. **User clicks "Accept & Pay"**
   - Order created with full amount
   - ChatContent updated with `accepted: true` and `order: orderId`

2. **Payment processed via Razorpay**
   - Full amount (price + taxes) charged correctly

3. **Payment successful**
   - Order marked as `paymentDone: true`
   - ChatContent updated with `orderPaymentDone: true`

4. **Chat enabled**
   - Backend validates payment is complete
   - Frontend displays "Booking confirmed" (once)
   - User can now send messages ✅

---

## 🧪 Testing Checklist
- [ ] Create bidding order - verify full amount charged
- [ ] Complete payment - verify single "Booking confirmed" message
- [ ] Verify chat is enabled after payment
- [ ] Verify chat blocked if payment incomplete
- [ ] Test with multiple bids to ensure no spam

---

## ⚠️ Breaking Changes
None - all changes are backward compatible

## 📊 Database Impact
- ChatContent documents updated with new fields: `other.orderPaymentDone`
- No migration required - fields added dynamically