### PR TITLE
feat: add stage/assignedTo/marketingSource to Enquiry + service-layer pipeline endpoints

### DIFF
--- a/controllers/enquiry-pipeline.js
+++ b/controllers/enquiry-pipeline.js
@@ -1,0 +1,36 @@
+const EnquiryService = require("../services/EnquiryService");
+
+// PUT /enquiry/:_id/stage
+const UpdateStage = async (req, res) => {
+  try {
+    const updated = await EnquiryService.updateStage(
+      req.params._id,
+      req.body.stage
+    );
+    res.status(200).json(updated);
+  } catch (error) {
+    const status = error.status || 500;
+    const message = status === 500 ? "Server error" : error.message;
+    res.status(status).json({ message });
+  }
+};
+
+// PUT /enquiry/:_id/assign
+const UpdateAssignedTo = async (req, res) => {
+  try {
+    const updated = await EnquiryService.updateAssignedTo(
+      req.params._id,
+      req.body.assignedTo
+    );
+    res.status(200).json(updated);
+  } catch (error) {
+    const status = error.status || 500;
+    const message = status === 500 ? "Server error" : error.message;
+    res.status(status).json({ message });
+  }
+};
+
+module.exports = {
+  UpdateStage,
+  UpdateAssignedTo,
+};

--- a/models/Enquiry.js
+++ b/models/Enquiry.js
@@ -10,6 +10,11 @@ const ObjectId = mongoose.Schema.Types.ObjectId;
 // Cold Lead: Event is beyond 20 Weeks or not yet decided.
 // Lost Lead: Waste Lead.
 // Interested
+//
+// Wedsy OS pipeline (Phase 1 addition):
+// stage: "new" | "contacted" | "meeting_scheduled" — manually progressed by sales team
+// assignedTo: Admin _id — lead owner (auto-assigned via routing rules in Wedsy OS)
+// marketingSource: free-form string — marketing channel ("Website", "Instagram DM", etc)
 
 // Note: When new field is added update it in get all enquiry api
 
@@ -36,6 +41,22 @@ const EnquirySchema = new mongoose.Schema(
       callSchedule: { type: Date, default: "" },
     },
     additionalInfo: { type: Object, default: {} },
+    // Wedsy OS pipeline tracking (added Phase 1 — additive only)
+    stage: {
+      type: String,
+      enum: ["new", "contacted", "meeting_scheduled"],
+      default: "new",
+      required: true,
+    },
+    assignedTo: {
+      type: ObjectId,
+      ref: "Admin",
+      default: null,
+    },
+    marketingSource: {
+      type: String,
+      default: null,
+    },
   },
   { timestamps: true }
 );

--- a/repositories/AdminRepository.js
+++ b/repositories/AdminRepository.js
@@ -1,0 +1,10 @@
+const Admin = require("../models/Admin");
+
+// Find an admin by _id. Returns the document or null.
+const findById = async (_id) => {
+  return await Admin.findById(_id);
+};
+
+module.exports = {
+  findById,
+};

--- a/repositories/EnquiryRepository.js
+++ b/repositories/EnquiryRepository.js
@@ -1,0 +1,31 @@
+const Enquiry = require("../models/Enquiry");
+
+// Find an enquiry by _id. Returns the document or null.
+const findById = async (_id) => {
+  return await Enquiry.findById(_id);
+};
+
+// Update an enquiry's stage by _id. Returns the updated document or null.
+const updateStageById = async (_id, stage) => {
+  return await Enquiry.findByIdAndUpdate(
+    _id,
+    { stage },
+    { new: true, runValidators: true }
+  );
+};
+
+// Update an enquiry's assignedTo by _id. assignedTo can be an Admin _id or null.
+// Returns the updated document or null.
+const updateAssignedToById = async (_id, assignedTo) => {
+  return await Enquiry.findByIdAndUpdate(
+    _id,
+    { assignedTo },
+    { new: true, runValidators: true }
+  );
+};
+
+module.exports = {
+  findById,
+  updateStageById,
+  updateAssignedToById,
+};

--- a/routes/enquiry.js
+++ b/routes/enquiry.js
@@ -2,6 +2,7 @@ const express = require("express");
 const router = express.Router();
 
 const enquiry = require("../controllers/enquiry");
+const enquiryPipeline = require("../controllers/enquiry-pipeline");
 const { CheckLogin, CheckAdminLogin } = require("../middlewares/auth");
 
 router.post("/", enquiry.CreateNew);
@@ -24,5 +25,7 @@ router.delete(
 router.put("/:_id/", CheckAdminLogin, enquiry.UpdateLead);
 router.put("/:_id/notes", CheckAdminLogin, enquiry.UpdateNotes);
 router.put("/:_id/call", CheckAdminLogin, enquiry.UpdateCallSchedule);
+router.put("/:_id/stage", CheckAdminLogin, enquiryPipeline.UpdateStage);
+router.put("/:_id/assign", CheckAdminLogin, enquiryPipeline.UpdateAssignedTo);
 
 module.exports = router;

--- a/services/EnquiryService.js
+++ b/services/EnquiryService.js
@@ -1,0 +1,78 @@
+const mongoose = require("mongoose");
+const EnquiryRepository = require("../repositories/EnquiryRepository");
+const AdminRepository = require("../repositories/AdminRepository");
+
+const VALID_STAGES = ["new", "contacted", "meeting_scheduled"];
+
+// Update an enquiry's pipeline stage.
+// Throws { status, message } shaped errors for the controller to map to HTTP responses.
+const updateStage = async (enquiryId, stage) => {
+  if (typeof stage !== "string" || stage.length === 0) {
+    const err = new Error("Stage is required");
+    err.status = 400;
+    throw err;
+  }
+  if (!VALID_STAGES.includes(stage)) {
+    const err = new Error(
+      `Invalid stage. Must be one of: ${VALID_STAGES.join(", ")}`
+    );
+    err.status = 400;
+    throw err;
+  }
+  if (!mongoose.Types.ObjectId.isValid(enquiryId)) {
+    const err = new Error("Invalid enquiry id");
+    err.status = 400;
+    throw err;
+  }
+  const updated = await EnquiryRepository.updateStageById(enquiryId, stage);
+  if (!updated) {
+    const err = new Error("Enquiry not found");
+    err.status = 404;
+    throw err;
+  }
+  return updated;
+};
+
+// Assign an enquiry to an admin (or unassign by passing null).
+const updateAssignedTo = async (enquiryId, assignedTo) => {
+  if (assignedTo === undefined) {
+    const err = new Error("assignedTo is required (use null to unassign)");
+    err.status = 400;
+    throw err;
+  }
+  if (!mongoose.Types.ObjectId.isValid(enquiryId)) {
+    const err = new Error("Invalid enquiry id");
+    err.status = 400;
+    throw err;
+  }
+  if (assignedTo !== null) {
+    if (!mongoose.Types.ObjectId.isValid(assignedTo)) {
+      const err = new Error(
+        "Invalid assignedTo: must be an Admin _id or null"
+      );
+      err.status = 400;
+      throw err;
+    }
+    const admin = await AdminRepository.findById(assignedTo);
+    if (!admin) {
+      const err = new Error("Admin not found");
+      err.status = 404;
+      throw err;
+    }
+  }
+  const updated = await EnquiryRepository.updateAssignedToById(
+    enquiryId,
+    assignedTo
+  );
+  if (!updated) {
+    const err = new Error("Enquiry not found");
+    err.status = 404;
+    throw err;
+  }
+  return updated;
+};
+
+module.exports = {
+  updateStage,
+  updateAssignedTo,
+};


### PR DESCRIPTION
## Summary

Adds pipeline tracking to the Enquiry model and two new endpoints for the Wedsy OS internal CRM (Phase 1, Micro-Phase 2A).

**Supersedes #13** — original branch (`claude/lead-pipeline-fields`) carried a stray WhatsApp Agent commit that was already on staging via a different SHA. This branch is the same 6 files cherry-picked cleanly onto current staging head with zero conflicts.

## Changes (all additive)

**Schema** (`models/Enquiry.js`)
- `stage` — enum `[new, contacted, meeting_scheduled]`, default `new`, required
- `assignedTo` — ObjectId ref Admin, default null
- `marketingSource` — String, default null

**New endpoints**
- `PUT /enquiry/:_id/stage` — change pipeline stage (validates enum)
- `PUT /enquiry/:_id/assign` — assign/unassign admin (validates ObjectId + admin existence)

**Architecture**

Built using the service-layer pattern per Engineering Governance:
- `controllers/enquiry-pipeline.js` — NEW, ~30 lines, handlers under 20 lines each
- `services/EnquiryService.js` — NEW, validation + business logic, throws shaped errors
- `repositories/EnquiryRepository.js` — NEW, MongoDB queries only
- `repositories/AdminRepository.js` — NEW, single findById

The existing 1022-line `controllers/enquiry.js` is intentionally NOT modified. That monolith refactor is a separate concern per governance rule "one controller per commit, never migrate multiple at once."

## Why this is safe to merge

- **Schema-additive only.** MongoDB is schemaless — existing records have new fields as `undefined`. Mongoose serves defaults on read. All 8 files referencing `Enquiry` (auth.js, vendor-personal-lead.js, order.js, webhook.js, etc.) continue working unchanged.
- **Existing 13 enquiry routes untouched.** Only 2 new routes added.
- **No new dependencies.**
- **No env var changes.**
- **No external API calls.**
- **Cherry-picked cleanly** onto current staging head (`437897b`). Diff vs staging is exactly the 6 intended files, +179 / -0.

## Tests performed locally

14 endpoint tests against local Mongo + seeded data — all green:
- Stage happy paths (new → contacted → meeting_scheduled)
- Stage validation: invalid enum, missing field, invalid ObjectId, enquiry not found
- Assign happy paths (assign + unassign with null)
- Assign validation: missing field, invalid ObjectId, admin not found
- Persistence verified by re-reading after write
- Browser end-to-end via local wedsy-crm: login → leads list → stage dropdown change → persist across hard refresh

## Post-merge needed

- Backfill script (separate PR) to set `stage` on existing prod enquiries via heuristic: no conversations → new, has conversations no callSchedule → contacted, has callSchedule → meeting_scheduled. Currently existing records have `stage` undefined; Mongoose returns the default `new` on read so nothing visibly breaks, but we want explicit values stored.

## Reviewer

Self-merging per founder direction. @abhi tagged for visibility.