### PR TITLE
feat: add GET /admin endpoint for Wedsy OS assignment dropdown

### DIFF
--- a/controllers/admin.js
+++ b/controllers/admin.js
@@ -1,0 +1,15 @@
+const AdminService = require("../services/AdminService");
+
+// GET /admin
+const GetAll = async (req, res) => {
+  try {
+    const admins = await AdminService.listAdmins();
+    res.status(200).json(admins);
+  } catch (error) {
+    res.status(500).json({ message: "Server error" });
+  }
+};
+
+module.exports = {
+  GetAll,
+};

--- a/repositories/AdminRepository.js
+++ b/repositories/AdminRepository.js
@@ -5,6 +5,13 @@ const findById = async (_id) => {
   return await Admin.findById(_id);
 };
 
+// Find all admins. Excludes password field from response.
+// Sorted by name ascending for stable dropdown ordering.
+const findAll = async () => {
+  return await Admin.find({}, { password: 0 }).sort({ name: 1 }).lean();
+};
+
 module.exports = {
   findById,
+  findAll,
 };

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1,0 +1,9 @@
+const express = require("express");
+const router = express.Router();
+
+const admin = require("../controllers/admin");
+const { CheckAdminLogin } = require("../middlewares/auth");
+
+router.get("/", CheckAdminLogin, admin.GetAll);
+
+module.exports = router;

--- a/routes/router.js
+++ b/routes/router.js
@@ -67,5 +67,6 @@ router.use("/chat", require("./chat"));
 router.use("/settlements", require("./settlements"));
 router.use("/stats", require("./stats"));
 router.use("/vendor-review", require("./vendor-review"));
+router.use("/admin", require("./admin"));
 
 module.exports = router;

--- a/services/AdminService.js
+++ b/services/AdminService.js
@@ -1,0 +1,10 @@
+const AdminRepository = require("../repositories/AdminRepository");
+
+// List all admins. Returns an array (possibly empty). Strips password by repository.
+const listAdmins = async () => {
+  return await AdminRepository.findAll();
+};
+
+module.exports = {
+  listAdmins,
+};


### PR DESCRIPTION
## Summary

Adds a single new endpoint `GET /admin` that returns all admins (minus password), sorted by name. Built to support the Lead Detail assignment dropdown in wedsy-crm.

## Changes (5 files, +42/-0)

- `routes/admin.js` — NEW. `GET /` protected by `CheckAdminLogin`. 9 lines.
- `controllers/admin.js` — NEW. `GetAll` handler under 20 lines. 15 lines.
- `services/AdminService.js` — NEW. `listAdmins()` pass-through to repository. 10 lines.
- `repositories/AdminRepository.js` — extended with `findAll()` (password excluded via projection, sorted by name, `.lean()`). +7 lines.
- `routes/router.js` — mounted `/admin` after `/vendor-review`. +1 line.

## Architecture

Same service-layer pattern as the Enquiry pipeline endpoints (PR #14):
- Route → thin Controller (under 20 lines) → Service (business logic, currently pass-through but ready to add filters/roles) → Repository (Mongo only)
- CommonJS matching existing codebase
- Password field excluded at the repository layer via `{ password: 0 }` projection — never reaches the controller or wire

## Why this is safe to merge

- **New endpoint, no existing route or schema changes.** `/admin` path was confirmed free via grep before adding the mount.
- **No new dependencies.**
- **No env var changes.**
- **No external API calls.**
- **Read-only.** No writes, no notifications, no side effects.
- `CheckAdminLogin` protects the route — unauthenticated callers get 401/403, same as every other admin endpoint.

## Tests performed locally

Local Mongo + 1 seeded admin:
- ✅ Authenticated GET → HTTP 200, JSON array containing admin record with `_id`, `name`, `email`, `phone`, `roles`, timestamps. **No `password` field in response** (verified).
- ✅ Unauthenticated GET → 401/403
- ✅ Bogus JWT → 401/403

## Post-merge

When `GET /admin` is live, wedsy-crm Lead Detail page (next session) can populate an Assignment dropdown with real admin names instead of truncated ObjectIds.

## Reviewer

Self-merging per founder direction. @abhi tagged for visibility.