### PR TITLE
feat(event): brideName + groomName fields on Event schema (Phase 1.5.5 backend)

### DIFF
--- a/controllers/event.js
+++ b/controllers/event.js
@@ -7,7 +7,12 @@ const { sha256 } = require("./eventShare");
 
 const CreateNew = (req, res) => {
   const { user_id, isAdmin } = req.auth;
-  const { name, community, eventDay, date, time, venue, user } = req.body;
+  // Auto-derive name from groomName + brideName if both provided and name is missing.
+  // Keeps downstream code that reads `name` working unchanged.
+  if (req.body.brideName && req.body.groomName && !req.body.name) {
+    req.body.name = `${req.body.groomName} x ${req.body.brideName}`;
+  }
+  const { name, community, eventDay, date, time, venue, user, brideName, groomName } = req.body;
   if (!name || !community || !eventDay || !date || !time || !venue) {
     res.status(400).send({ message: "Incomplete Data" });
   } else {
@@ -15,6 +20,8 @@ const CreateNew = (req, res) => {
     new Event({
       user: isAdmin ? user : user_id,
       name,
+      brideName: brideName || null,
+      groomName: groomName || null,
       community,
       eventDate: date, // Add the eventDate field explicitly
       eventDays: [{ name: eventDay, date, time, venue }],

--- a/models/Event.js
+++ b/models/Event.js
@@ -6,6 +6,8 @@ const EventSchema = new mongoose.Schema(
     user: {type: ObjectId, ref: "User", required: true},
     eventAccess: {type: [String], default: []},
     name: {type: String, required: true},
+    brideName: {type: String, default: null},
+    groomName: {type: String, default: null},
     community: {type: String, default: ""},
     lostResponse: {type: String, default: ""},
     eventPlanner: {type: String, default: ""},


### PR DESCRIPTION
## Summary

Adds brideName + groomName as additive nullable fields on the Event collection. Auto-derives the existing 'name' field for backward compatibility.

## Files
- models/Event.js (+2 lines)
- controllers/event.js (+8/-1 lines) — CreateNew handler

## Compatibility
- Existing events: unaffected. brideName + groomName default to null.
- Old clients: continue working unchanged (only 'name' field used).
- New clients (wedsy-user empty-state Step 1, coming next): send groomName + brideName, backend derives name automatically.

## Deploy
After merge to staging, deploy to EC2 via: ssh wedsy-prod && cd /var/www/wedsy-server && git pull origin staging && pm2 restart wedsy-prod --update-env