### PR TITLE
feat(event): bulk eventDays update support in Update controller (Phase 1.5.6.1)

### DIFF
--- a/controllers/event.js
+++ b/controllers/event.js
@@ -39,13 +39,33 @@ const CreateNew = (req, res) => {
 const Update = (req, res) => {
   const { user_id, isAdmin } = req.auth;
   const { _id } = req.params;
-  const { name, community, eventNotes, eventType, eventDate } = req.body;
+  const { name, community, eventNotes, eventType, eventDate, eventDays } = req.body;
+
+  // Bulk eventDays update: validate format before any DB work.
+  // Each day must carry name/date/time/venue, matching the schema's required
+  // fields and the per-day endpoint's validation contract.
+  if (eventDays !== undefined) {
+    if (!Array.isArray(eventDays)) {
+      res.status(400).send({ message: "eventDays must be an array" });
+      return;
+    }
+    const invalidDay = eventDays.find(
+      (d) => !d || !d.name || !d.date || !d.time || !d.venue
+    );
+    if (invalidDay) {
+      res
+        .status(400)
+        .send({ message: "Each event day must have name, date, time, and venue" });
+      return;
+    }
+  }
 
   const hasMetaUpdate =
     name !== undefined ||
     community !== undefined ||
     eventType !== undefined ||
-    eventDate !== undefined;
+    eventDate !== undefined ||
+    eventDays !== undefined;
 
   if (eventNotes === undefined && !hasMetaUpdate) {
     res.status(400).send({ message: "Incomplete Data" });
@@ -68,6 +88,7 @@ const Update = (req, res) => {
     if (community !== undefined) update.community = community;
     if (eventType !== undefined) update.eventType = eventType;
     if (eventDate !== undefined) update.eventDate = eventDate;
+    if (eventDays !== undefined) update.eventDays = eventDays;
 
     Event.findOneAndUpdate(
       isAdmin ? { _id } : { _id, user: user_id },


### PR DESCRIPTION
## Summary

Extends PUT /event/:_id to accept an `eventDays` array for atomic bulk replacement. Unblocks the upcoming inline event-day editor on wedsy-user (Phase 1.5.6.2).

## Files
- controllers/event.js (+23/-2)

## Behavior
- Old callers: unchanged
- New callers sending `eventDays`: replace the array atomically
- Validation: each day must have name + date + time + venue (matches per-day endpoint contract)
- Per-day endpoint PUT /event/:_id/eventDay/:eventDay: untouched

## Deploy
After staging merge: ssh wedsy-prod && cd /var/www/wedsy-server && git pull origin staging && pm2 restart wedsy-prod --update-env