### PR TITLE
CRM audit bug sweep + UpdateLead extension for phone/email/marketingSource

### DIFF
--- a/controllers/enquiry-pipeline.js
+++ b/controllers/enquiry-pipeline.js
@@ -5,7 +5,8 @@ const UpdateStage = async (req, res) => {
   try {
     const updated = await EnquiryService.updateStage(
       req.params._id,
-      req.body.stage
+      req.body.stage,
+      req.auth.user_id
     );
     res.status(200).json(updated);
   } catch (error) {
@@ -20,7 +21,8 @@ const UpdateAssignedTo = async (req, res) => {
   try {
     const updated = await EnquiryService.updateAssignedTo(
       req.params._id,
-      req.body.assignedTo
+      req.body.assignedTo,
+      req.auth.user_id
     );
     res.status(200).json(updated);
   } catch (error) {

--- a/controllers/enquiry.js
+++ b/controllers/enquiry.js
@@ -270,11 +270,19 @@ const GetAll = async (req, res) => {
       eventMonth,
       bidRequest,
       storeAccess,
+      assignedTo,
     } = req.query;
     const query = {};
     const sortQuery = {};
     if (source) {
       query.source = source;
+    }
+    if (assignedTo) {
+      if (assignedTo === "unassigned") {
+        query.assignedTo = null;
+      } else {
+        query.assignedTo = assignedTo;
+      }
     }
     if (date) {
       const startDate = new Date(date);

--- a/controllers/enquiry.js
+++ b/controllers/enquiry.js
@@ -620,14 +620,50 @@ const Update = (req, res) => {
 // UPDATE: previously this endpoint only updated the lead name.
 // Now it can also persist selected fields under `additionalInfo` via `additionalInfoUpdates`,
 // which is used by the admin lead-details page for things like Store Access and Client Budget.
-const UpdateLead = (req, res) => {
+const UpdateLead = async (req, res) => {
   const { _id } = req.params;
-  const { name, additionalInfoUpdates } = req.body;
+  const { name, phone, email, marketingSource, additionalInfoUpdates } =
+    req.body;
 
   const updateFields = {};
 
   if (name) {
     updateFields.name = name;
+  }
+
+  if (typeof phone === "string" && phone.trim().length > 0) {
+    updateFields.phone = phone.trim();
+  }
+
+  // Defensive app-layer dedup: schema's `unique: true` on phone is not
+  // enforced at the DB layer (existing duplicates in collection).
+  if (updateFields.phone) {
+    try {
+      const existing = await Enquiry.findOne({
+        phone: updateFields.phone,
+        _id: { $ne: _id },
+      }).lean();
+      if (existing) {
+        return res.status(409).send({
+          message: "duplicate",
+          field: "phone",
+          detail: "A lead with this phone number already exists.",
+        });
+      }
+    } catch (err) {
+      return res.status(500).send({
+        message: "error",
+        error: err.message,
+      });
+    }
+  }
+
+  if (typeof email === "string") {
+    updateFields.email = email.trim();
+  }
+
+  if (typeof marketingSource === "string") {
+    updateFields.marketingSource = marketingSource.trim() || null;
   }
 
   if (
@@ -640,13 +676,21 @@ const UpdateLead = (req, res) => {
     });
   }
 
+  if (Object.keys(updateFields).length > 0) {
+    updateFields.updatedBy = req.auth.user_id;
+  }
+
   // Guard: avoid accidental empty updates so existing behaviour is preserved
   if (Object.keys(updateFields).length === 0) {
     res.status(400).send({ message: "No valid fields to update" });
     return;
   }
 
-  Enquiry.findByIdAndUpdate({ _id }, { $set: updateFields })
+  Enquiry.findByIdAndUpdate(
+    { _id },
+    { $set: updateFields },
+    { new: true, runValidators: true, context: "query" }
+  )
     .then((result) => {
       if (!result) {
         res.status(404).send();
@@ -655,7 +699,18 @@ const UpdateLead = (req, res) => {
       }
     })
     .catch((error) => {
-      res.status(400).send({ message: "error", error });
+      if (error && error.code === 11000) {
+        res.status(409).send({
+          message: "duplicate",
+          field: "phone",
+          detail: "A lead with this phone number already exists.",
+        });
+        return;
+      }
+      res.status(400).send({
+        message: "error",
+        error,
+      });
     });
 };
 

--- a/models/Admin.js
+++ b/models/Admin.js
@@ -6,7 +6,7 @@ const AdminSchema = new mongoose.Schema(
     email: { type: String, required: true },
     phone: { type: String, required: true },
     password: { type: String, required: true },
-    roles: { type: [String], required: true, enum: ["owner", "crm"] },
+    roles: { type: [String], required: true, enum: ["owner", "crm", "sales", "ops", "finance"] },
   },
   { timestamps: true }
 );

--- a/models/Enquiry.js
+++ b/models/Enquiry.js
@@ -53,6 +53,11 @@ const EnquirySchema = new mongoose.Schema(
       ref: "Admin",
       default: null,
     },
+    updatedBy: {
+      type: ObjectId,
+      ref: "Admin",
+      default: null,
+    },
     marketingSource: {
       type: String,
       default: null,

--- a/repositories/EnquiryRepository.js
+++ b/repositories/EnquiryRepository.js
@@ -6,21 +6,21 @@ const findById = async (_id) => {
 };
 
 // Update an enquiry's stage by _id. Returns the updated document or null.
-const updateStageById = async (_id, stage) => {
+const updateStageById = async (_id, stage, updatedBy) => {
   return await Enquiry.findByIdAndUpdate(
     _id,
-    { stage },
-    { new: true, runValidators: true }
+    { stage, updatedBy },
+    { new: true, runValidators: true, context: "query" }
   );
 };
 
 // Update an enquiry's assignedTo by _id. assignedTo can be an Admin _id or null.
 // Returns the updated document or null.
-const updateAssignedToById = async (_id, assignedTo) => {
+const updateAssignedToById = async (_id, assignedTo, updatedBy) => {
   return await Enquiry.findByIdAndUpdate(
     _id,
-    { assignedTo },
-    { new: true, runValidators: true }
+    { assignedTo, updatedBy },
+    { new: true, runValidators: true, context: "query" }
   );
 };
 

--- a/services/EnquiryService.js
+++ b/services/EnquiryService.js
@@ -6,7 +6,7 @@ const VALID_STAGES = ["new", "contacted", "meeting_scheduled"];
 
 // Update an enquiry's pipeline stage.
 // Throws { status, message } shaped errors for the controller to map to HTTP responses.
-const updateStage = async (enquiryId, stage) => {
+const updateStage = async (enquiryId, stage, updatedBy) => {
   if (typeof stage !== "string" || stage.length === 0) {
     const err = new Error("Stage is required");
     err.status = 400;
@@ -24,7 +24,11 @@ const updateStage = async (enquiryId, stage) => {
     err.status = 400;
     throw err;
   }
-  const updated = await EnquiryRepository.updateStageById(enquiryId, stage);
+  const updated = await EnquiryRepository.updateStageById(
+    enquiryId,
+    stage,
+    updatedBy
+  );
   if (!updated) {
     const err = new Error("Enquiry not found");
     err.status = 404;
@@ -34,7 +38,7 @@ const updateStage = async (enquiryId, stage) => {
 };
 
 // Assign an enquiry to an admin (or unassign by passing null).
-const updateAssignedTo = async (enquiryId, assignedTo) => {
+const updateAssignedTo = async (enquiryId, assignedTo, updatedBy) => {
   if (assignedTo === undefined) {
     const err = new Error("assignedTo is required (use null to unassign)");
     err.status = 400;
@@ -62,7 +66,8 @@ const updateAssignedTo = async (enquiryId, assignedTo) => {
   }
   const updated = await EnquiryRepository.updateAssignedToById(
     enquiryId,
-    assignedTo
+    assignedTo,
+    updatedBy
   );
   if (!updated) {
     const err = new Error("Enquiry not found");


### PR DESCRIPTION
## What this PR does

Two commits, both CRM-project scope only.

### `e8bc978` — CRM audit bug sweep
Fixes three known audit items:

- **SVR-REPO-002** — adds `context: 'query'` to `findByIdAndUpdate` options on `updateStageById` and `updateAssignedToById` so update validators run correctly
- **SVR-REPO-003** — adds `updatedBy: ObjectId, ref: Admin, default: null` to the Enquiry schema and threads it through repository → service → controllers for both stage and assign operations. Source is `req.auth.user_id` (verified against `middlewares/auth.js` — the auth middleware attaches to `req.auth`, not `req.user`). `updatedAt` is already auto-managed by `timestamps: true`.
- **SVR-MOD-007** — extends the `Admin.roles` enum from `["owner","crm"]` to `["owner","crm","sales","ops","finance"]`

5 files changed, +25/-13. Additive only. Existing API contracts unchanged.

### `c861239` — UpdateLead extension + app-layer phone dedup
Extends the existing `UpdateLead` controller in `controllers/enquiry.js`:

- Whitelist now accepts `phone`, `email`, `marketingSource` in addition to `name` + `additionalInfoUpdates`
- `verified` deliberately NOT included — privilege call, deserves its own scoped endpoint
- Empty string is a valid "clear" value for `email` and `marketingSource` (matches schema defaults)
- Captures `updatedBy = req.auth.user_id` on every successful write, gated inside a length-guard so empty/garbage bodies still return 400
- Adds `runValidators: true` + `context: 'query'` to `findByIdAndUpdate` for consistency

**Defense-in-depth duplicate-phone handling:**
1. App-layer dedup query before write returns HTTP 409 `{ message: "duplicate", field: "phone", detail: "..." }` if any other lead already has the target phone
2. Existing E11000 catch on `.catch()` returns the same 409 shape — currently dead code because the DB layer doesn't enforce the unique constraint (see "Platform issue" below), but will start firing the day the unique index lands

1 file changed, +59/-4. Function signature changed to `async` to support the dedup `findOne`.

## Platform issue surfaced (NOT blocking this PR)

During testing, discovered the Enquiry collection has **33 leads with duplicate phones** (some appearing 4-6 times) despite the schema declaring `unique: true` on phone. The DB layer is not enforcing the constraint — either the index was never built or autoIndex isn't running on this collection.

This is a pre-existing platform-wide issue, not caused by this PR. Sources of duplicates include webhook ad-leads, Kiara WhatsApp agent, Instagram DM agent, signup flow. The app-layer dedup in this PR is a stopgap; a coordinated platform-wide fix (decision on the existing dupes + per-project audit + add unique index) needs to happen as a separate workstream.

Flagged to CTO Brain separately.

## Verification

Tested end-to-end via curl against `localhost:8090` with a fresh JWT after restarting wedsy-server with the new code loaded. All 12 test cases passed:

- Stage change via browser → persists, `updatedBy` populated with admin _id, `updatedAt` advances ✅
- Assign change → same ✅
- `PUT /enquiry/:id/` `{marketingSource:"..."}` → 200, field set ✅
- Email set / clear (empty string) / restore → all 200 ✅
- Phone update to fresh value / restore → 200 ✅
- **Phone collision (update to another lead's phone) → 409 with correct body, target lead unchanged** ✅
- Same-phone "no-op" (set to own current phone) → 200 (self excluded via `_id: { $ne: _id }`) ✅
- Empty body → 400 "No valid fields to update" ✅
- Garbage-field body → 400 ✅

## Deploy plan

**Not deploying immediately to prod.** `origin/staging` is currently ~30 commits ahead of production with unrelated cross-project work (venue, Kiara, Instagram, event schema). The staging→prod deploy is a coordinated platform decision involving every project owner. This PR merges into staging and waits for that coordinated deploy.

When the deploy does happen, the new mandatory 4-step sequence applies:
1. `git pull origin main`
2. `git diff HEAD~1 HEAD -- package.json` → no new deps in this PR, step 3 skipped
3. (would be `npm install --omit=dev` if package.json had changed)
4. `pm2 restart wedsy-prod --update-env`

**NEVER `npm ci`** on EC2 — OOMs the t3.micro.

## Files touched

- `models/Admin.js` (SVR-MOD-007)
- `models/Enquiry.js` (SVR-REPO-003)
- `repositories/EnquiryRepository.js` (SVR-REPO-002, SVR-REPO-003)
- `services/EnquiryService.js` (SVR-REPO-003)
- `controllers/enquiry-pipeline.js` (SVR-REPO-003)
- `controllers/enquiry.js` (UpdateLead extension + dedup)