### PR TITLE
RBAC Phase 2B Slices 1–2: Departments + Roles foundation + Admin extension/migration

### DIFF
--- a/controllers/department.js
+++ b/controllers/department.js
@@ -1,0 +1,15 @@
+const DepartmentService = require("../services/DepartmentService");
+
+// GetAll — GET /department
+const GetAll = async (req, res) => {
+  try {
+    const result = await DepartmentService.getAll();
+    res.status(200).json(result);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+module.exports = {
+  GetAll,
+};

--- a/controllers/role.js
+++ b/controllers/role.js
@@ -1,0 +1,15 @@
+const RoleService = require("../services/RoleService");
+
+// GetAll — GET /role
+const GetAll = async (req, res) => {
+  try {
+    const result = await RoleService.getAll();
+    res.status(200).json(result);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+module.exports = {
+  GetAll,
+};

--- a/models/Admin.js
+++ b/models/Admin.js
@@ -1,4 +1,5 @@
 const mongoose = require("mongoose");
+const ObjectId = mongoose.Schema.Types.ObjectId;
 
 const AdminSchema = new mongoose.Schema(
   {
@@ -7,6 +8,17 @@ const AdminSchema = new mongoose.Schema(
     phone: { type: String, required: true },
     password: { type: String, required: true },
     roles: { type: [String], required: true, enum: ["owner", "crm", "sales", "ops", "finance"] },
+    // --- Wedsy OS RBAC Phase 2B (additive, optional — legacy roles[] unchanged) ---
+    roleId: { type: ObjectId, ref: "Role", default: null },
+    departmentId: { type: ObjectId, ref: "Department", default: null },
+    reportingManagerId: { type: ObjectId, ref: "Admin", default: null },
+    status: { type: String, enum: ["active", "inactive", "on_leave"], default: "active" },
+    joinedAt: { type: Date, default: null },
+    meta: {
+      designation: { type: String, default: "" },
+      employeeId: { type: String, default: "" },
+      profilePhoto: { type: String, default: "" },
+    },
   },
   { timestamps: true }
 );

--- a/models/Department.js
+++ b/models/Department.js
@@ -1,0 +1,13 @@
+const mongoose = require("mongoose");
+
+const DepartmentSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true },
+    description: { type: String, default: "" },
+    isSystem: { type: Boolean, default: false },
+    deletedAt: { type: Date, default: null },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model("Department", DepartmentSchema);

--- a/models/Role.js
+++ b/models/Role.js
@@ -1,0 +1,16 @@
+const mongoose = require("mongoose");
+const ObjectId = mongoose.Schema.Types.ObjectId;
+
+const RoleSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true },
+    departmentId: { type: ObjectId, ref: "Department", required: true },
+    description: { type: String, default: "" },
+    permissions: { type: [String], default: [] },
+    isSystem: { type: Boolean, default: false },
+    deletedAt: { type: Date, default: null },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model("Role", RoleSchema);

--- a/repositories/DepartmentRepository.js
+++ b/repositories/DepartmentRepository.js
@@ -1,0 +1,9 @@
+const Department = require("../models/Department");
+
+const findAllActive = async () => {
+  return await Department.find({ deletedAt: null }).sort({ name: 1 }).lean();
+};
+
+module.exports = {
+  findAllActive,
+};

--- a/repositories/RoleRepository.js
+++ b/repositories/RoleRepository.js
@@ -1,0 +1,9 @@
+const Role = require("../models/Role");
+
+const findAllActive = async () => {
+  return await Role.find({ deletedAt: null }).sort({ name: 1 }).lean();
+};
+
+module.exports = {
+  findAllActive,
+};

--- a/routes/department.js
+++ b/routes/department.js
@@ -1,0 +1,9 @@
+const express = require("express");
+const router = express.Router();
+
+const department = require("../controllers/department");
+const { CheckAdminLogin } = require("../middlewares/auth");
+
+router.get("/", CheckAdminLogin, department.GetAll);
+
+module.exports = router;

--- a/routes/role.js
+++ b/routes/role.js
@@ -1,0 +1,9 @@
+const express = require("express");
+const router = express.Router();
+
+const role = require("../controllers/role");
+const { CheckAdminLogin } = require("../middlewares/auth");
+
+router.get("/", CheckAdminLogin, role.GetAll);
+
+module.exports = router;

--- a/routes/router.js
+++ b/routes/router.js
@@ -69,6 +69,8 @@ router.use("/settlements", require("./settlements"));
 router.use("/stats", require("./stats"));
 router.use("/vendor-review", require("./vendor-review"));
 router.use("/admin", require("./admin"));
+router.use("/department", require("./department"));
+router.use("/role", require("./role"));
 router.use("/venues", require("./venue"));
 router.use("/venue-owner", require("./venueOwner"));
 router.use("/conversations", require("./conversation"));

--- a/scripts/rbac-phase-2b-migrate-admins.js
+++ b/scripts/rbac-phase-2b-migrate-admins.js
@@ -1,0 +1,97 @@
+/**
+ * RBAC Phase 2B — Admin migration (Slice 2)
+ * Maps legacy Admin.roles[] -> roleId + departmentId, and seeds default
+ * status / joinedAt / meta / reportingManagerId on existing admins.
+ *
+ * Mapping:
+ *   roles includes "owner" -> Founder role + Founders dept (owner wins over crm)
+ *   roles includes "crm"   -> Sales Executive role + Sales dept
+ *   neither                -> roleId/departmentId left null + warning
+ *
+ * Idempotent: only sets fields currently null/missing. Legacy roles[] never modified.
+ * LOCAL DEV DB ONLY — aborts if DATABASE_URL is not localhost.
+ * Run: node scripts/rbac-phase-2b-migrate-admins.js
+ */
+
+require("dotenv").config();
+const mongoose = require("mongoose");
+const Admin = require("../models/Admin");
+const Role = require("../models/Role");
+const Department = require("../models/Department");
+
+const dbUrl = process.env.DATABASE_URL || "";
+if (!dbUrl.startsWith("mongodb://localhost")) {
+  console.error("ABORT: DATABASE_URL is not a localhost URI. This migration runs on the local dev DB only.");
+  console.error(`DATABASE_URL = ${dbUrl || "(empty)"}`);
+  process.exit(1);
+}
+
+(async () => {
+  try {
+    await mongoose.connect(dbUrl);
+    console.log(`Connected to ${dbUrl}`);
+
+    const [founderRole, foundersDept, salesExecRole, salesDept] = await Promise.all([
+      Role.findOne({ name: "Founder" }),
+      Department.findOne({ name: "Founders" }),
+      Role.findOne({ name: "Sales Executive" }),
+      Department.findOne({ name: "Sales" }),
+    ]);
+
+    if (!founderRole || !foundersDept || !salesExecRole || !salesDept) {
+      console.error("ABORT: required seed records missing. Run rbac-phase-2b-seed-roles.js first.");
+      console.error({ founderRole: !!founderRole, foundersDept: !!foundersDept, salesExecRole: !!salesExecRole, salesDept: !!salesDept });
+      process.exitCode = 1;
+      return;
+    }
+
+    const admins = await Admin.find({}).lean(); // lean -> missing fields are undefined, not schema defaults
+    console.log(`Found ${admins.length} admins`);
+
+    let migrated = 0;
+    let noop = 0;
+
+    for (const admin of admins) {
+      const set = {};
+
+      if (admin.roleId == null) {
+        if (Array.isArray(admin.roles) && admin.roles.includes("owner")) {
+          set.roleId = founderRole._id;
+          set.departmentId = foundersDept._id;
+        } else if (Array.isArray(admin.roles) && admin.roles.includes("crm")) {
+          set.roleId = salesExecRole._id;
+          set.departmentId = salesDept._id;
+        } else {
+          console.warn(`[admin] no role mapping for ${admin.email} (roles: ${JSON.stringify(admin.roles)}) — roleId left null`);
+        }
+      }
+
+      if (admin.status == null) set.status = "active";
+      if (admin.joinedAt == null) set.joinedAt = new Date();
+      if (typeof admin.reportingManagerId === "undefined") set.reportingManagerId = null;
+      if (admin.meta == null) set.meta = { designation: "", employeeId: "", profilePhoto: "" };
+
+      if (Object.keys(set).length === 0) {
+        console.log(`[admin] no-op (already migrated): ${admin.email}`);
+        noop++;
+        continue;
+      }
+
+      await Admin.updateOne({ _id: admin._id }, { $set: set }, { runValidators: true });
+      console.log(`[admin] migrated ${admin.email} ->`, set);
+      migrated++;
+    }
+
+    console.log(`\nMigration complete. Migrated: ${migrated}, no-op: ${noop}`);
+
+    const after = await Admin.find({}, { name: 1, email: 1, roles: 1, roleId: 1, departmentId: 1, status: 1, joinedAt: 1, meta: 1 }).lean();
+    console.log("\nPost-migration admins:");
+    console.dir(after, { depth: null });
+  } catch (error) {
+    console.error("Migration error:", error);
+    process.exitCode = 1;
+  } finally {
+    await mongoose.disconnect();
+    console.log("Disconnected.");
+  }
+})();

--- a/scripts/rbac-phase-2b-seed-roles.js
+++ b/scripts/rbac-phase-2b-seed-roles.js
@@ -1,0 +1,89 @@
+/**
+ * RBAC Phase 2B — Seed script (Slice 1)
+ * Seeds 4 default departments + 8 default roles with skeleton permissions.
+ * Idempotent: existing records (matched by name) are left untouched.
+ * LOCAL DEV DB ONLY — aborts if DATABASE_URL is not localhost.
+ *
+ * Run: node scripts/rbac-phase-2b-seed-roles.js
+ */
+
+require("dotenv").config();
+const mongoose = require("mongoose");
+const Department = require("../models/Department");
+const Role = require("../models/Role");
+
+// --- HARD PROD GUARD: this script must never touch prod ---
+const dbUrl = process.env.DATABASE_URL || "";
+if (!dbUrl.startsWith("mongodb://localhost")) {
+  console.error("ABORT: DATABASE_URL is not a localhost URI. This seed runs on the local dev DB only.");
+  console.error(`DATABASE_URL = ${dbUrl || "(empty)"}`);
+  process.exit(1);
+}
+
+const DEPARTMENTS = [
+  { name: "Founders", description: "Founders and company leadership" },
+  { name: "Sales", description: "Lead conversion and pipeline" },
+  { name: "Operations", description: "Project execution and delivery" },
+  { name: "Client Servicing", description: "Client relationship and account management" },
+];
+
+const ROLES = [
+  { name: "Founder", department: "Founders", permissions: ["*:*:all"] },
+  { name: "CRM Admin", department: "Founders", permissions: ["users:*:all", "roles:*:all", "settings:*:all"] },
+  { name: "Sales Manager", department: "Sales", permissions: ["leads:view:team", "leads:edit:team", "leads:assign:team"] },
+  { name: "Sales Executive", department: "Sales", permissions: ["leads:view:own", "leads:edit:own"] },
+  { name: "Operations Manager", department: "Operations", permissions: ["projects:view:department", "tasks:view:department"] },
+  { name: "Operations Executive", department: "Operations", permissions: ["projects:view:own", "tasks:view:own"] },
+  { name: "Client Servicing Manager", department: "Client Servicing", permissions: ["projects:view:team", "tasks:view:team"] },
+  { name: "Client Servicing Executive", department: "Client Servicing", permissions: ["projects:view:own", "tasks:view:own"] },
+];
+
+(async () => {
+  try {
+    await mongoose.connect(dbUrl);
+    console.log(`Connected to ${dbUrl}`);
+
+    const deptByName = {};
+    for (const d of DEPARTMENTS) {
+      let dept = await Department.findOne({ name: d.name });
+      if (dept) {
+        console.log(`[dept] exists, skipped: ${d.name}`);
+      } else {
+        dept = await Department.create({ name: d.name, description: d.description, isSystem: true });
+        console.log(`[dept] created: ${d.name}`);
+      }
+      deptByName[d.name] = dept._id;
+    }
+
+    for (const r of ROLES) {
+      const departmentId = deptByName[r.department];
+      if (!departmentId) {
+        console.warn(`[role] SKIP ${r.name} — department not found: ${r.department}`);
+        continue;
+      }
+      const existing = await Role.findOne({ name: r.name });
+      if (existing) {
+        console.log(`[role] exists, skipped: ${r.name}`);
+      } else {
+        await Role.create({
+          name: r.name,
+          departmentId,
+          description: "",
+          permissions: r.permissions,
+          isSystem: true,
+        });
+        console.log(`[role] created: ${r.name} -> ${r.department}`);
+      }
+    }
+
+    const deptCount = await Department.countDocuments({ deletedAt: null });
+    const roleCount = await Role.countDocuments({ deletedAt: null });
+    console.log(`\nSeed complete. Departments: ${deptCount}, Roles: ${roleCount}`);
+  } catch (error) {
+    console.error("Seed error:", error);
+    process.exitCode = 1;
+  } finally {
+    await mongoose.disconnect();
+    console.log("Disconnected.");
+  }
+})();

--- a/services/DepartmentService.js
+++ b/services/DepartmentService.js
@@ -1,0 +1,9 @@
+const DepartmentRepository = require("../repositories/DepartmentRepository");
+
+const getAll = async () => {
+  return await DepartmentRepository.findAllActive();
+};
+
+module.exports = {
+  getAll,
+};

--- a/services/RoleService.js
+++ b/services/RoleService.js
@@ -1,0 +1,9 @@
+const RoleRepository = require("../repositories/RoleRepository");
+
+const getAll = async () => {
+  return await RoleRepository.findAllActive();
+};
+
+module.exports = {
+  getAll,
+};


### PR DESCRIPTION
RBAC Phase 2B — foundation slices (1 & 2). Backend-only, additive. Separate from PR #18 (already merged).

Slice 1 — Department + Role foundation (8f29cab)
- New Department + Role models (deletedAt soft-delete, isSystem flag)
- Full service-layer stack (repo/service/controller/route), CommonJS
- Read-only, admin-gated GET /department and GET /role
- Idempotent seed: 4 departments + 8 roles + skeleton permissions

Slice 2 — Admin extension + migration (377ea2e)
- Admin extended with roleId, departmentId (denormalized), reportingManagerId, status (enum), joinedAt, meta — all additive; legacy roles[] untouched
- Idempotent admin migration: owner -> Founder/Founders, crm -> Sales Executive/Sales

Testing: seed + migration each run twice on local dev DB (wedsy-db-dev); idempotency confirmed; endpoints mounted + admin-gated. Both scripts hard-guard to localhost — no prod access.

Not in this PR (later slices): enforcement middleware (Slice 3), matrix UI (Slice 4), production admin migration (coordinated deploy).

Staging integration only — do not deploy to prod from this.