### PR TITLE
RBAC Phase 2B Slice 3: permission enforcement middleware

### DIFF
--- a/middlewares/requirePermission.js
+++ b/middlewares/requirePermission.js
@@ -1,0 +1,120 @@
+const AdminRepository = require("../repositories/AdminRepository");
+const RoleRepository = require("../repositories/RoleRepository");
+
+const SCOPE_RANK = { own: 0, team: 1, department: 2, all: 3 };
+
+// team-traversal cache: adminId -> { ids:[], expires:ms }
+const TEAM_CACHE_TTL_MS = 5 * 60 * 1000;
+const teamCache = new Map();
+
+const parsePermission = (str) => {
+  const [resource, action, scope] = String(str).split(":");
+  return { resource, action, scope };
+};
+
+// Do the granted permission strings satisfy the required one?
+// Wildcards (*) allowed on resource and action. Scope expands: all >= department >= team >= own.
+// effectiveScope = broadest granted scope for the matched resource:action (used to build the filter).
+const permissionSatisfies = (grantedPerms, requiredStr) => {
+  const req = parsePermission(requiredStr);
+  const requiredRank = SCOPE_RANK[req.scope];
+  let bestRank = -1;
+
+  for (const g of grantedPerms || []) {
+    const gp = parsePermission(g);
+    const resourceMatch = gp.resource === "*" || gp.resource === req.resource;
+    const actionMatch = gp.action === "*" || gp.action === req.action;
+    if (!resourceMatch || !actionMatch) continue;
+    const gRank = SCOPE_RANK[gp.scope];
+    if (gRank === undefined) continue;
+    if (gRank > bestRank) bestRank = gRank;
+  }
+
+  if (bestRank < 0 || bestRank < requiredRank) return { allowed: false, effectiveScope: null };
+  const effectiveScope = Object.keys(SCOPE_RANK).find((k) => SCOPE_RANK[k] === bestRank);
+  return { allowed: true, effectiveScope };
+};
+
+// BFS over reportingManagerId -> all transitive subordinate ids. Cycle-safe. 5-min cached.
+const getSubordinateIds = async (adminId) => {
+  const key = String(adminId);
+  const cached = teamCache.get(key);
+  if (cached && cached.expires > Date.now()) return cached.ids;
+
+  const all = new Set();
+  let frontier = [adminId];
+  while (frontier.length) {
+    const subs = await AdminRepository.findByReportingManagerIds(frontier);
+    const newIds = [];
+    for (const s of subs) {
+      const id = String(s._id);
+      if (id !== key && !all.has(id)) {
+        all.add(id);
+        newIds.push(s._id);
+      }
+    }
+    if (!newIds.length) break;
+    frontier = newIds;
+  }
+  const ids = [...all];
+  teamCache.set(key, { ids, expires: Date.now() + TEAM_CACHE_TTL_MS });
+  return ids;
+};
+
+const getDepartmentMemberIds = async (departmentId) => {
+  if (!departmentId) return [];
+  const members = await AdminRepository.findIdsByDepartment(departmentId);
+  return members.map((m) => m._id);
+};
+
+// Mongo filter limiting records to the admin's scope. ownerField references the owning admin (e.g. "assignedTo").
+const buildScopeFilter = async (scope, admin, ownerField) => {
+  if (scope === "all" || !ownerField) return {};
+  if (scope === "own") return { [ownerField]: admin._id };
+  if (scope === "team") {
+    const subs = await getSubordinateIds(admin._id);
+    return { [ownerField]: { $in: [admin._id, ...subs] } };
+  }
+  if (scope === "department") {
+    const members = await getDepartmentMemberIds(admin.departmentId);
+    return { [ownerField]: { $in: members } };
+  }
+  return { [ownerField]: admin._id };
+};
+
+// Express middleware factory. MUST run after CheckAdminLogin (needs req.auth.user_id). Fail-closed.
+const requirePermission = (requiredStr, options = {}) => {
+  const ownerField = options.ownerField || null;
+  return async (req, res, next) => {
+    try {
+      const adminId = req.auth && req.auth.user_id;
+      if (!adminId) return res.status(403).json({ message: "Forbidden" });
+
+      const admin = await AdminRepository.findById(adminId);
+      if (!admin || !admin.roleId) return res.status(403).json({ message: "Forbidden" });
+
+      const role = await RoleRepository.findById(admin.roleId);
+      if (!role || !Array.isArray(role.permissions)) return res.status(403).json({ message: "Forbidden" });
+
+      const { allowed, effectiveScope } = permissionSatisfies(role.permissions, requiredStr);
+      if (!allowed) return res.status(403).json({ message: "Forbidden", required: requiredStr });
+
+      req.scope = effectiveScope;
+      req.scopeFilter = await buildScopeFilter(effectiveScope, admin, ownerField);
+      next();
+    } catch (error) {
+      return res.status(500).json({ message: error.message });
+    }
+  };
+};
+
+module.exports = {
+  requirePermission,
+  parsePermission,
+  permissionSatisfies,
+  buildScopeFilter,
+  getSubordinateIds,
+  getDepartmentMemberIds,
+  SCOPE_RANK,
+  _teamCache: teamCache,
+};

--- a/repositories/AdminRepository.js
+++ b/repositories/AdminRepository.js
@@ -6,12 +6,23 @@ const findById = async (_id) => {
 };
 
 // Find all admins. Excludes password field from response.
-// Sorted by name ascending for stable dropdown ordering.
 const findAll = async () => {
   return await Admin.find({}, { password: 0 }).sort({ name: 1 }).lean();
+};
+
+// Admins whose reportingManagerId is in the given set (one level). Used by team-scope BFS.
+const findByReportingManagerIds = async (managerIds) => {
+  return await Admin.find({ reportingManagerId: { $in: managerIds } }, { _id: 1 }).lean();
+};
+
+// Admin ids in a given department. Used by department-scope filter.
+const findIdsByDepartment = async (departmentId) => {
+  return await Admin.find({ departmentId }, { _id: 1 }).lean();
 };
 
 module.exports = {
   findById,
   findAll,
+  findByReportingManagerIds,
+  findIdsByDepartment,
 };

--- a/repositories/RoleRepository.js
+++ b/repositories/RoleRepository.js
@@ -4,6 +4,11 @@ const findAllActive = async () => {
   return await Role.find({ deletedAt: null }).sort({ name: 1 }).lean();
 };
 
+const findById = async (_id) => {
+  return await Role.findById(_id).lean();
+};
+
 module.exports = {
   findAllActive,
+  findById,
 };

--- a/routes/role.js
+++ b/routes/role.js
@@ -3,7 +3,8 @@ const router = express.Router();
 
 const role = require("../controllers/role");
 const { CheckAdminLogin } = require("../middlewares/auth");
+const { requirePermission } = require("../middlewares/requirePermission");
 
-router.get("/", CheckAdminLogin, role.GetAll);
+router.get("/", CheckAdminLogin, requirePermission("roles:view:all"), role.GetAll);
 
 module.exports = router;

--- a/scripts/rbac-phase-2b-verify-enforcement.js
+++ b/scripts/rbac-phase-2b-verify-enforcement.js
@@ -1,0 +1,116 @@
+/**
+ * RBAC Phase 2B — Slice 3 enforcement verification (LOCAL DEV ONLY).
+ * Part A: assert the permission gate for all 8 seeded roles against "roles:view:all".
+ * Part B: assert own/team/department/all scope filters against real Enquiry data,
+ *         using a TEMPORARY owner->crm reporting link + 2 temporarily-assigned leads,
+ *         all reverted in the finally block (non-destructive).
+ * Aborts if DATABASE_URL is not localhost.
+ * Run: node scripts/rbac-phase-2b-verify-enforcement.js
+ */
+
+require("dotenv").config();
+const mongoose = require("mongoose");
+const Admin = require("../models/Admin");
+const Role = require("../models/Role");
+const Enquiry = require("../models/Enquiry");
+const {
+  permissionSatisfies,
+  buildScopeFilter,
+  getSubordinateIds,
+  _teamCache,
+} = require("../middlewares/requirePermission");
+
+const dbUrl = process.env.DATABASE_URL || "";
+if (!dbUrl.startsWith("mongodb://localhost")) {
+  console.error("ABORT: DATABASE_URL is not a localhost URI. Verification runs on the local dev DB only.");
+  console.error(`DATABASE_URL = ${dbUrl || "(empty)"}`);
+  process.exit(1);
+}
+
+let pass = 0;
+let fail = 0;
+const check = (label, cond) => {
+  console.log(`${cond ? "PASS" : "FAIL"}  ${label}`);
+  cond ? pass++ : fail++;
+};
+
+(async () => {
+  let restore = null;
+  try {
+    await mongoose.connect(dbUrl);
+    console.log(`Connected to ${dbUrl}\n`);
+
+    // ---------- Part A: permission gate ----------
+    console.log("=== Part A - gate: roles:view:all ===");
+    const roles = await Role.find({ deletedAt: null }).sort({ name: 1 }).lean();
+    const EXPECT_PASS = new Set(["Founder", "CRM Admin"]);
+    for (const r of roles) {
+      const { allowed } = permissionSatisfies(r.permissions, "roles:view:all");
+      const shouldPass = EXPECT_PASS.has(r.name);
+      check(`${r.name} -> ${allowed ? "ALLOW" : "DENY"} (expected ${shouldPass ? "ALLOW" : "DENY"})`, allowed === shouldPass);
+    }
+
+    // ---------- Part B: scope filters ----------
+    console.log("\n=== Part B - scope filters (assignedTo) ===");
+    const owner = await Admin.findOne({ roles: "owner" });
+    const crm = await Admin.findOne({ roles: "crm" });
+    const totalLeads = await Enquiry.countDocuments({});
+    const someLeads = await Enquiry.find({}).limit(2).select({ _id: 1, assignedTo: 1 }).lean();
+
+    if (!owner || !crm || someLeads.length < 2) {
+      console.warn("SKIP Part B - need owner + crm admins and at least 2 enquiries.");
+    } else {
+      restore = {
+        crmId: crm._id,
+        crmReporting: crm.reportingManagerId ?? null,
+        leadA: { id: someLeads[0]._id, assignedTo: someLeads[0].assignedTo ?? null },
+        leadB: { id: someLeads[1]._id, assignedTo: someLeads[1].assignedTo ?? null },
+      };
+
+      await Admin.updateOne({ _id: crm._id }, { $set: { reportingManagerId: owner._id } });
+      await Enquiry.updateOne({ _id: someLeads[0]._id }, { $set: { assignedTo: owner._id } });
+      await Enquiry.updateOne({ _id: someLeads[1]._id }, { $set: { assignedTo: crm._id } });
+      _teamCache.clear();
+
+      const ownerFresh = await Admin.findById(owner._id);
+      const subs = await getSubordinateIds(owner._id);
+      check("team traversal: owner's subordinates include crm", subs.map(String).includes(String(crm._id)));
+
+      const fOwn = await buildScopeFilter("own", ownerFresh, "assignedTo");
+      const fTeam = await buildScopeFilter("team", ownerFresh, "assignedTo");
+      const fDept = await buildScopeFilter("department", ownerFresh, "assignedTo");
+      const fAll = await buildScopeFilter("all", ownerFresh, "assignedTo");
+
+      const cOwn = await Enquiry.countDocuments(fOwn);
+      const cTeam = await Enquiry.countDocuments(fTeam);
+      const cDept = await Enquiry.countDocuments(fDept);
+      const cAll = await Enquiry.countDocuments(fAll);
+
+      console.log(`  own filter:        ${JSON.stringify(fOwn)} -> ${cOwn} leads`);
+      console.log(`  team filter:       ${JSON.stringify(fTeam)} -> ${cTeam} leads`);
+      console.log(`  department filter: ${JSON.stringify(fDept)} -> ${cDept} leads`);
+      console.log(`  all filter:        ${JSON.stringify(fAll)} -> ${cAll} leads`);
+
+      check("own >= 1 (owner's assigned lead)", cOwn >= 1);
+      check("team > own (team includes crm's lead)", cTeam > cOwn);
+      check("team >= 2 (owner + crm leads)", cTeam >= 2);
+      check("department == own (owner alone in Founders dept)", cDept === cOwn);
+      check("all == total enquiries", cAll === totalLeads);
+    }
+
+    console.log(`\nResult: ${pass} passed, ${fail} failed.`);
+    if (fail > 0) process.exitCode = 1;
+  } catch (error) {
+    console.error("Verification error:", error);
+    process.exitCode = 1;
+  } finally {
+    if (restore) {
+      await Admin.updateOne({ _id: restore.crmId }, { $set: { reportingManagerId: restore.crmReporting } });
+      await Enquiry.updateOne({ _id: restore.leadA.id }, { $set: { assignedTo: restore.leadA.assignedTo } });
+      await Enquiry.updateOne({ _id: restore.leadB.id }, { $set: { assignedTo: restore.leadB.assignedTo } });
+      console.log("Reverted temporary hierarchy + lead assignments.");
+    }
+    await mongoose.disconnect();
+    console.log("Disconnected.");
+  }
+})();


### PR DESCRIPTION
RBAC Phase 2B Slice 3 — permission enforcement. Backend-only. Separate from PR #18 / #19.

- middlewares/requirePermission.js: parse resource:action:scope, wildcard-aware match, scope expansion own->team->department->all, reportingManagerId team-traversal (cycle-safe, 5-min cache), Mongo filter injection or 403, fail-closed
- RoleRepository.findById + AdminRepository.findByReportingManagerIds / findIdsByDepartment
- Wired as proof on GET /role only (roles:view:all). Shared GET /enquiry deliberately untouched — enforcement there is a cross-project change, deferred to a coordinated step.
- scripts/rbac-phase-2b-verify-enforcement.js: local-only, non-destructive

Testing (local dev DB): GET /role unauth -> 400, Founder token -> 200 + 8 roles. Verify script 14/14 — gate correct for all 8 roles, own/team/department/all filters correct against real Enquiry data.

Not in this PR: expanding enforcement to other routes, matrix UI (Slice 4), prod migration (Slice 5+). Staging integration only — do not deploy to prod.