### PR TITLE
RBAC role permission write endpoint: PUT /role/:id

### DIFF
--- a/controllers/role.js
+++ b/controllers/role.js
@@ -10,6 +10,18 @@ const GetAll = async (req, res) => {
   }
 };
 
+// UpdatePermissions — PUT /role/:id
+const UpdatePermissions = async (req, res) => {
+  try {
+    const { permissions, description } = req.body || {};
+    const updated = await RoleService.updatePermissions(req.params.id, { permissions, description });
+    res.status(200).json(updated);
+  } catch (error) {
+    res.status(error.status || 500).json({ message: error.message });
+  }
+};
+
 module.exports = {
   GetAll,
+  UpdatePermissions,
 };

--- a/repositories/RoleRepository.js
+++ b/repositories/RoleRepository.js
@@ -8,7 +8,16 @@ const findById = async (_id) => {
   return await Role.findById(_id).lean();
 };
 
+const updateById = async (_id, fields) => {
+  return await Role.findByIdAndUpdate(
+    _id,
+    { $set: fields },
+    { new: true, runValidators: true, context: "query" }
+  ).lean();
+};
+
 module.exports = {
   findAllActive,
   findById,
+  updateById,
 };

--- a/routes/role.js
+++ b/routes/role.js
@@ -6,5 +6,6 @@ const { CheckAdminLogin } = require("../middlewares/auth");
 const { requirePermission } = require("../middlewares/requirePermission");
 
 router.get("/", CheckAdminLogin, requirePermission("roles:view:all"), role.GetAll);
+router.put("/:id", CheckAdminLogin, requirePermission("roles:edit:all"), role.UpdatePermissions);
 
 module.exports = router;

--- a/scripts/rbac-phase-2b-verify-role-write.js
+++ b/scripts/rbac-phase-2b-verify-role-write.js
@@ -1,0 +1,100 @@
+/**
+ * RBAC Phase 2B — role-write verification (LOCAL DEV ONLY, non-destructive).
+ * Exercises RoleService.updatePermissions + the validator directly.
+ * Aborts if DATABASE_URL is not localhost.
+ * Run: node scripts/rbac-phase-2b-verify-role-write.js
+ */
+
+require("dotenv").config();
+const mongoose = require("mongoose");
+const Role = require("../models/Role");
+const RoleService = require("../services/RoleService");
+const { validatePermissions } = require("../utils/rbacPermissions");
+
+const dbUrl = process.env.DATABASE_URL || "";
+if (!dbUrl.startsWith("mongodb://localhost")) {
+  console.error("ABORT: DATABASE_URL is not a localhost URI. Verification runs on the local dev DB only.");
+  console.error(`DATABASE_URL = ${dbUrl || "(empty)"}`);
+  process.exit(1);
+}
+
+let pass = 0;
+let fail = 0;
+const check = (label, cond) => {
+  console.log(`${cond ? "PASS" : "FAIL"}  ${label}`);
+  cond ? pass++ : fail++;
+};
+const expectThrow = async (label, status, fn) => {
+  try {
+    await fn();
+    check(`${label} (expected ${status})`, false);
+  } catch (e) {
+    check(`${label} -> ${e.status || "?"} ${e.message}`, e.status === status);
+  }
+};
+
+(async () => {
+  let restore = null;
+  try {
+    await mongoose.connect(dbUrl);
+    console.log(`Connected to ${dbUrl}\n`);
+
+    console.log("=== validator ===");
+    check("valid set accepted", validatePermissions(["leads:view:team", "roles:*:all", "*:*:all"]).valid === true);
+    check("malformed rejected", validatePermissions(["leads:view"]).valid === false);
+    check("unknown resource rejected", validatePermissions(["widgets:view:all"]).valid === false);
+    check("unknown action rejected", validatePermissions(["leads:frobnicate:all"]).valid === false);
+    check("bad scope rejected", validatePermissions(["leads:view:galaxy"]).valid === false);
+    check("scope wildcard rejected", validatePermissions(["leads:view:*"]).valid === false);
+
+    console.log("\n=== guards ===");
+    const founder = await Role.findOne({ name: "Founder" }).lean();
+    const sales = await Role.findOne({ name: "Sales Executive" }).lean();
+    if (!founder || !sales) {
+      console.warn("SKIP guard/happy-path — Founder or Sales Executive role missing (run the seed first).");
+    } else {
+      await expectThrow("Founder protected", 403, () =>
+        RoleService.updatePermissions(String(founder._id), { permissions: ["*:*:all"] })
+      );
+      await expectThrow("invalid permissions", 400, () =>
+        RoleService.updatePermissions(String(sales._id), { permissions: ["leads:frobnicate:all"] })
+      );
+      await expectThrow("invalid id", 400, () =>
+        RoleService.updatePermissions("not-an-objectid", { permissions: [] })
+      );
+      await expectThrow("unknown id", 404, () =>
+        RoleService.updatePermissions(String(new mongoose.Types.ObjectId()), { permissions: [] })
+      );
+
+      console.log("\n=== happy path (mutate + restore) ===");
+      restore = { id: sales._id, permissions: sales.permissions, description: sales.description ?? "" };
+      const updated = await RoleService.updatePermissions(String(sales._id), {
+        permissions: ["leads:view:team", "leads:edit:team", "leads:view:team"],
+        description: "verify-temp",
+      });
+      check("update returned a role", !!(updated && updated._id));
+      check(
+        "permissions persisted + deduped",
+        JSON.stringify(updated.permissions) === JSON.stringify(["leads:view:team", "leads:edit:team"])
+      );
+      check("description persisted", updated.description === "verify-temp");
+      check("name unchanged", updated.name === "Sales Executive");
+      check("isSystem unchanged", updated.isSystem === true);
+    }
+
+    console.log(`\nResult: ${pass} passed, ${fail} failed.`);
+    if (fail > 0) process.exitCode = 1;
+  } catch (error) {
+    console.error("Verification error:", error);
+    process.exitCode = 1;
+  } finally {
+    if (restore) {
+      await Role.findByIdAndUpdate(restore.id, {
+        $set: { permissions: restore.permissions, description: restore.description },
+      });
+      console.log("Restored Sales Executive permissions + description.");
+    }
+    await mongoose.disconnect();
+    console.log("Disconnected.");
+  }
+})();

--- a/services/RoleService.js
+++ b/services/RoleService.js
@@ -1,9 +1,38 @@
+const mongoose = require("mongoose");
 const RoleRepository = require("../repositories/RoleRepository");
+const { validatePermissions } = require("../utils/rbacPermissions");
+
+const err = (status, message) => Object.assign(new Error(message), { status });
 
 const getAll = async () => {
   return await RoleRepository.findAllActive();
 };
 
+// Update a role's permissions (and optionally description). Permissions-only:
+// name / departmentId / isSystem are never changed here. The Founder role is protected.
+const updatePermissions = async (_id, { permissions, description } = {}) => {
+  if (!mongoose.Types.ObjectId.isValid(_id)) {
+    throw err(400, "Invalid role id.");
+  }
+  const role = await RoleRepository.findById(_id);
+  if (!role || role.deletedAt) {
+    throw err(404, "Role not found.");
+  }
+  if (role.name === "Founder") {
+    throw err(403, "The Founder role is protected and cannot be edited.");
+  }
+  const { valid, errors } = validatePermissions(permissions);
+  if (!valid) {
+    throw err(400, `Invalid permissions: ${errors.join("; ")}`);
+  }
+  const fields = { permissions: [...new Set(permissions)] };
+  if (typeof description === "string") {
+    fields.description = description;
+  }
+  return await RoleRepository.updateById(_id, fields);
+};
+
 module.exports = {
   getAll,
+  updatePermissions,
 };

--- a/utils/rbacPermissions.js
+++ b/utils/rbacPermissions.js
@@ -1,0 +1,39 @@
+/**
+ * RBAC permission vocabulary + validation. Single source of truth on the server.
+ * A permission string is "resource:action:scope":
+ *   resource in RESOURCES or "*"
+ *   action   in ACTIONS or "*"
+ *   scope    in SCOPES (concrete only — no "*")
+ */
+
+const RESOURCES = [
+  "leads", "projects", "tasks", "content", "internal_ops",
+  "attendance", "incentives", "users", "roles", "reports", "settings",
+];
+const ACTIONS = ["view", "create", "edit", "delete", "assign", "export", "approve"];
+const SCOPES = ["own", "team", "department", "all"];
+
+function validatePermissions(permissions) {
+  const errors = [];
+  if (!Array.isArray(permissions)) {
+    return { valid: false, errors: ["permissions must be an array of strings"] };
+  }
+  for (const p of permissions) {
+    if (typeof p !== "string") {
+      errors.push(`not a string: ${JSON.stringify(p)}`);
+      continue;
+    }
+    const parts = p.split(":");
+    if (parts.length !== 3) {
+      errors.push(`malformed (expected resource:action:scope): "${p}"`);
+      continue;
+    }
+    const [resource, action, scope] = parts;
+    if (resource !== "*" && !RESOURCES.includes(resource)) errors.push(`unknown resource in "${p}"`);
+    if (action !== "*" && !ACTIONS.includes(action)) errors.push(`unknown action in "${p}"`);
+    if (!SCOPES.includes(scope)) errors.push(`invalid scope in "${p}" (must be one of ${SCOPES.join("|")})`);
+  }
+  return { valid: errors.length === 0, errors };
+}
+
+module.exports = { RESOURCES, ACTIONS, SCOPES, validatePermissions };


### PR DESCRIPTION
RBAC role-write endpoint. Backend-only. Builds on the merged RBAC foundation/enforcement (PRs #18–#20).

- utils/rbacPermissions.js: permission vocabulary (RESOURCES / ACTIONS / SCOPES) + strict validatePermissions (resource:action:scope; wildcard resource/action; concrete scope only)
- PUT /role/:id, gated CheckAdminLogin + requirePermission("roles:edit:all"): updates a role's permissions (+ optional description). name / departmentId / isSystem immutable here; Founder role protected (403); permissions deduped; errors mapped 400/403/404.
- RoleService.updatePermissions + RoleRepository.updateById (findByIdAndUpdate, runValidators, context:"query")
- scripts/rbac-phase-2b-verify-role-write.js — local-only, non-destructive

Testing (local dev DB): verify script 15/15 (validator 6, guards 4, happy-path 5). Live HTTP: unauth → 400, Founder lock → 403, bad perms → 400, happy → 200 with updated doc.

Not in this PR: editable matrix frontend (next, wedsy-crm), delete/create-role endpoints, prod admin migration. Staging integration only — do not deploy to prod.