### PR TITLE
RBAC Slice 5 Part A: protected flag on Role model

### DIFF
--- a/models/Role.js
+++ b/models/Role.js
@@ -8,6 +8,7 @@ const RoleSchema = new mongoose.Schema(
     description: { type: String, default: "" },
     permissions: { type: [String], default: [] },
     isSystem: { type: Boolean, default: false },
+    protected: { type: Boolean, default: false },
     deletedAt: { type: Date, default: null },
   },
   { timestamps: true }

--- a/scripts/rbac-phase-2b-set-protected.js
+++ b/scripts/rbac-phase-2b-set-protected.js
@@ -1,0 +1,47 @@
+/**
+ * RBAC Slice 5 — set protected:true on the Founder role (idempotent).
+ * LOCAL DEV DB ONLY — aborts if DATABASE_URL is not localhost.
+ * Run: node scripts/rbac-phase-2b-set-protected.js
+ */
+
+require("dotenv").config();
+const mongoose = require("mongoose");
+const Role = require("../models/Role");
+
+const dbUrl = process.env.DATABASE_URL || "";
+if (!dbUrl.startsWith("mongodb://localhost")) {
+  console.error("ABORT: DATABASE_URL is not a localhost URI. This script runs on the local dev DB only.");
+  console.error(`DATABASE_URL = ${dbUrl || "(empty)"}`);
+  process.exit(1);
+}
+
+(async () => {
+  try {
+    await mongoose.connect(dbUrl);
+    console.log(`Connected to ${dbUrl}`);
+
+    const founder = await Role.findOne({ name: "Founder" });
+    if (!founder) {
+      console.error("ABORT: Founder role not found. Run rbac-phase-2b-seed-roles.js first.");
+      process.exitCode = 1;
+      return;
+    }
+
+    if (founder.protected === true) {
+      console.log("No-op: Founder role already protected.");
+    } else {
+      await Role.updateOne({ _id: founder._id }, { $set: { protected: true } });
+      console.log(`Set protected:true on Founder role (${founder._id}).`);
+    }
+
+    const check = await Role.find({}, { name: 1, protected: 1 }).sort({ name: 1 }).lean();
+    console.log("\nRoles protected status:");
+    console.dir(check, { depth: null });
+  } catch (error) {
+    console.error("Error:", error);
+    process.exitCode = 1;
+  } finally {
+    await mongoose.disconnect();
+    console.log("Disconnected.");
+  }
+})();

--- a/scripts/rbac-phase-2b-verify-protected.js
+++ b/scripts/rbac-phase-2b-verify-protected.js
@@ -1,0 +1,76 @@
+/**
+ * RBAC Slice 5 — verify the protected-flag guard (LOCAL DEV ONLY, non-destructive).
+ * Asserts: Founder (protected) -> 403 on updatePermissions; a non-protected role -> editable (then reverted).
+ * Aborts if DATABASE_URL is not localhost.
+ * Run: node scripts/rbac-phase-2b-verify-protected.js
+ */
+
+require("dotenv").config();
+const mongoose = require("mongoose");
+const Role = require("../models/Role");
+const RoleService = require("../services/RoleService");
+
+const dbUrl = process.env.DATABASE_URL || "";
+if (!dbUrl.startsWith("mongodb://localhost")) {
+  console.error("ABORT: DATABASE_URL is not a localhost URI. Verification runs on the local dev DB only.");
+  console.error(`DATABASE_URL = ${dbUrl || "(empty)"}`);
+  process.exit(1);
+}
+
+let pass = 0;
+let fail = 0;
+const check = (label, cond) => {
+  console.log(`${cond ? "PASS" : "FAIL"}  ${label}`);
+  cond ? pass++ : fail++;
+};
+const expectThrow = async (label, status, fn) => {
+  try {
+    await fn();
+    check(`${label} (expected ${status})`, false);
+  } catch (e) {
+    check(`${label} -> ${e.status || "?"} ${e.message}`, e.status === status);
+  }
+};
+
+(async () => {
+  let restore = null;
+  try {
+    await mongoose.connect(dbUrl);
+    console.log(`Connected to ${dbUrl}\n`);
+
+    const founder = await Role.findOne({ name: "Founder" }).lean();
+    const sales = await Role.findOne({ name: "Sales Executive" }).lean();
+    if (!founder || !sales) {
+      console.warn("SKIP — Founder or Sales Executive role missing (run seed first).");
+    } else {
+      check("Founder.protected === true (run set-protected first if this fails)", founder.protected === true);
+
+      await expectThrow("protected Founder rejected", 403, () =>
+        RoleService.updatePermissions(String(founder._id), { permissions: ["*:*:all"] })
+      );
+
+      restore = { id: sales._id, permissions: sales.permissions };
+      const updated = await RoleService.updatePermissions(String(sales._id), {
+        permissions: ["leads:view:team", "leads:edit:team"],
+      });
+      check("non-protected role editable", !!(updated && updated._id));
+      check(
+        "permissions persisted",
+        JSON.stringify(updated.permissions) === JSON.stringify(["leads:view:team", "leads:edit:team"])
+      );
+    }
+
+    console.log(`\nResult: ${pass} passed, ${fail} failed.`);
+    if (fail > 0) process.exitCode = 1;
+  } catch (error) {
+    console.error("Verification error:", error);
+    process.exitCode = 1;
+  } finally {
+    if (restore) {
+      await Role.findByIdAndUpdate(restore.id, { $set: { permissions: restore.permissions } });
+      console.log("Restored Sales Executive permissions.");
+    }
+    await mongoose.disconnect();
+    console.log("Disconnected.");
+  }
+})();

--- a/services/RoleService.js
+++ b/services/RoleService.js
@@ -9,7 +9,7 @@ const getAll = async () => {
 };
 
 // Update a role's permissions (and optionally description). Permissions-only:
-// name / departmentId / isSystem are never changed here. The Founder role is protected.
+// name / departmentId / isSystem are never changed here. Protected roles cannot be edited.
 const updatePermissions = async (_id, { permissions, description } = {}) => {
   if (!mongoose.Types.ObjectId.isValid(_id)) {
     throw err(400, "Invalid role id.");
@@ -18,8 +18,8 @@ const updatePermissions = async (_id, { permissions, description } = {}) => {
   if (!role || role.deletedAt) {
     throw err(404, "Role not found.");
   }
-  if (role.name === "Founder") {
-    throw err(403, "The Founder role is protected and cannot be edited.");
+  if (role.protected === true) {
+    throw err(403, "This role is protected and cannot be edited.");
   }
   const { valid, errors } = validatePermissions(permissions);
   if (!valid) {


### PR DESCRIPTION
Replaces the name-based Founder guard with a real protected flag on the Role model.

- models/Role.js: add protected (Boolean, default false), additive
- RoleService.updatePermissions guard now checks role.protected === true (was role.name === "Founder")
- scripts/rbac-phase-2b-set-protected.js: idempotent, localhost-guarded — sets protected:true on the Founder role
- scripts/rbac-phase-2b-verify-protected.js: local-only, non-destructive

GET /role returns full docs (.lean(), no projection) so protected flows to the frontend automatically.

Tested on local dev DB: set-protected sets Founder only (re-run no-op); verify 4/4 — protected Founder still 403, non-protected role editable + persisted + reverted.

Note: the set-protected script must run against prod as part of the coordinated deploy (alongside the admin migration) before this guard is relied on in prod — otherwise the Founder role has protected:undefined and would be editable. Staging integration only — do not deploy to prod.