### PR TITLE
feat: venue-journey admin routes for CRM Lead Detail (§11)

### DIFF
--- a/controllers/venue-journey.js
+++ b/controllers/venue-journey.js
@@ -1,0 +1,26 @@
+const VenueJourneyService = require("../services/VenueJourneyService");
+
+// GET /admin/enquiries/:enquiryId/venue-journey
+const GetVenueJourney = async (req, res) => {
+  try {
+    const result = await VenueJourneyService.getJourneyForEnquiry(req.params.enquiryId);
+    res.status(200).json(result);
+  } catch (error) {
+    res.status(error.status || 500).json({ message: error.message });
+  }
+};
+
+// GET /admin/venue-conversations/:conversationId/messages
+const GetVenueConversationMessages = async (req, res) => {
+  try {
+    const result = await VenueJourneyService.getConversationMessages(req.params.conversationId);
+    res.status(200).json(result);
+  } catch (error) {
+    res.status(error.status || 500).json({ message: error.message });
+  }
+};
+
+module.exports = {
+  GetVenueJourney,
+  GetVenueConversationMessages,
+};

--- a/repositories/VenueJourneyRepository.js
+++ b/repositories/VenueJourneyRepository.js
@@ -1,0 +1,58 @@
+const Enquiry = require("../models/Enquiry");
+const User = require("../models/User");
+const Venue = require("../models/Venue");
+const VenueEnquiry = require("../models/VenueEnquiry");
+const VenueConversation = require("../models/VenueConversation");
+const VenueMessage = require("../models/VenueMessage");
+
+const findEnquiryById = async (_id) => {
+  return await Enquiry.findById(_id).lean();
+};
+
+// Resolve the lead's User by phone (leads carry phone, not a user ref).
+const findUserByPhone = async (phone) => {
+  if (!phone) return null;
+  return await User.findOne({ phone }).select({ name: 1, phone: 1, email: 1 }).lean();
+};
+
+// Venue enquiries that belong to this couple: by userId OR by phone match
+// (VenueEnquiry stores phone in either `phone` or `couplePhone`, both legacy/preferred).
+const findVenueEnquiries = async ({ userId, phone }) => {
+  const or = [];
+  if (userId) or.push({ userId });
+  if (phone) or.push({ phone }, { couplePhone: phone });
+  if (or.length === 0) return [];
+  return await VenueEnquiry.find({ $or: or })
+    .populate("venueId", "name slug coverPhoto venueType city")
+    .sort({ createdAt: -1 })
+    .lean();
+};
+
+// Conversations require a userId (schema-required), so only resolvable when the lead has a User.
+const findVenueConversations = async ({ userId }) => {
+  if (!userId) return [];
+  return await VenueConversation.find({ userId })
+    .populate("venueId", "name slug coverPhoto venueType city")
+    .populate("enquiryId", "eventDate guestCount stage")
+    .sort({ lastMessageAt: -1 })
+    .lean();
+};
+
+const findMessagesByConversationId = async (conversationId) => {
+  return await VenueMessage.find({ conversationId })
+    .sort({ createdAt: 1 })
+    .lean();
+};
+
+const findConversationById = async (_id) => {
+  return await VenueConversation.findById(_id).lean();
+};
+
+module.exports = {
+  findEnquiryById,
+  findUserByPhone,
+  findVenueEnquiries,
+  findVenueConversations,
+  findMessagesByConversationId,
+  findConversationById,
+};

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -2,8 +2,11 @@ const express = require("express");
 const router = express.Router();
 
 const admin = require("../controllers/admin");
+const venueJourney = require("../controllers/venue-journey");
 const { CheckAdminLogin } = require("../middlewares/auth");
 
 router.get("/", CheckAdminLogin, admin.GetAll);
+router.get("/enquiries/:enquiryId/venue-journey", CheckAdminLogin, venueJourney.GetVenueJourney);
+router.get("/venue-conversations/:conversationId/messages", CheckAdminLogin, venueJourney.GetVenueConversationMessages);
 
 module.exports = router;

--- a/scripts/verify-venue-journey.js
+++ b/scripts/verify-venue-journey.js
@@ -1,0 +1,73 @@
+/**
+ * Verify the venue-journey service against real local data (LOCAL DEV ONLY, read-only).
+ * Test lead: the "rohaan" enquiry 6592cdff4c8c51d04ec02d82 (phone +918197105896),
+ * which links via User to real venue enquiries/conversations.
+ * Aborts if DATABASE_URL is not localhost. Run: node scripts/verify-venue-journey.js
+ */
+
+require("dotenv").config();
+const mongoose = require("mongoose");
+const VenueJourneyService = require("../services/VenueJourneyService");
+
+const dbUrl = process.env.DATABASE_URL || "";
+if (!dbUrl.startsWith("mongodb://localhost")) {
+  console.error("ABORT: DATABASE_URL is not a localhost URI.");
+  console.error(`DATABASE_URL = ${dbUrl || "(empty)"}`);
+  process.exit(1);
+}
+
+const TEST_ENQUIRY_ID = "6592cdff4c8c51d04ec02d82";
+
+let pass = 0, fail = 0;
+const check = (label, cond) => { console.log(`${cond ? "PASS" : "FAIL"}  ${label}`); cond ? pass++ : fail++; };
+
+(async () => {
+  try {
+    await mongoose.connect(dbUrl);
+    console.log(`Connected to ${dbUrl}\n`);
+
+    console.log("=== getJourneyForEnquiry (rohaan lead) ===");
+    const journey = await VenueJourneyService.getJourneyForEnquiry(TEST_ENQUIRY_ID);
+    console.log(`lead: ${journey.lead.name} (${journey.lead.phone})`);
+    console.log(`user: ${journey.user ? journey.user.name + " / " + journey.user._id : "null"}`);
+    console.log(`venue enquiries: ${journey.enquiries.length}`);
+    console.log(`conversations: ${journey.conversations.length}`);
+    if (journey.enquiries[0]) {
+      const e = journey.enquiries[0];
+      console.log(`  sample enquiry: venue=${e.venueId ? e.venueId.name : "(unpopulated)"} stage=${e.stage} eventDate=${e.eventDate}`);
+    }
+    if (journey.conversations[0]) {
+      const c = journey.conversations[0];
+      console.log(`  sample convo: venue=${c.venueId ? c.venueId.name : "(unpopulated)"} status=${c.status}`);
+    }
+    check("journey resolved a user for the rohaan lead", journey.user != null);
+    check("journey returned at least one venue enquiry", journey.enquiries.length > 0);
+    check("enquiry venueId populated to an object", !journey.enquiries[0] || (journey.enquiries[0].venueId == null || typeof journey.enquiries[0].venueId === "object"));
+
+    console.log("\n=== error paths ===");
+    try { await VenueJourneyService.getJourneyForEnquiry("not-an-id"); check("invalid enquiry id rejected", false); }
+    catch (e) { check(`invalid enquiry id -> ${e.status}`, e.status === 400); }
+    try { await VenueJourneyService.getJourneyForEnquiry(String(new mongoose.Types.ObjectId())); check("unknown enquiry rejected", false); }
+    catch (e) { check(`unknown enquiry -> ${e.status}`, e.status === 404); }
+
+    console.log("\n=== getConversationMessages ===");
+    if (journey.conversations[0]) {
+      const msgs = await VenueJourneyService.getConversationMessages(String(journey.conversations[0]._id));
+      console.log(`messages in first conversation: ${msgs.messages.length} (local snapshot has 0 venuemessages — empty is expected)`);
+      check("getConversationMessages returns a messages array", Array.isArray(msgs.messages));
+    } else {
+      console.log("no conversations to test messages against — skipping");
+    }
+    try { await VenueJourneyService.getConversationMessages(String(new mongoose.Types.ObjectId())); check("unknown conversation rejected", false); }
+    catch (e) { check(`unknown conversation -> ${e.status}`, e.status === 404); }
+
+    console.log(`\nResult: ${pass} passed, ${fail} failed.`);
+    if (fail > 0) process.exitCode = 1;
+  } catch (error) {
+    console.error("Verification error:", error);
+    process.exitCode = 1;
+  } finally {
+    await mongoose.disconnect();
+    console.log("Disconnected.");
+  }
+})();

--- a/services/VenueJourneyService.js
+++ b/services/VenueJourneyService.js
@@ -1,0 +1,48 @@
+const mongoose = require("mongoose");
+const VenueJourneyRepository = require("../repositories/VenueJourneyRepository");
+
+const err = (status, message) => Object.assign(new Error(message), { status });
+
+// Aggregate the full venue journey for a CRM lead: lead -> user (by phone) -> venue enquiries + conversations.
+const getJourneyForEnquiry = async (enquiryId) => {
+  if (!mongoose.Types.ObjectId.isValid(enquiryId)) {
+    throw err(400, "Invalid enquiry id.");
+  }
+  const lead = await VenueJourneyRepository.findEnquiryById(enquiryId);
+  if (!lead) {
+    throw err(404, "Lead not found.");
+  }
+
+  const phone = lead.phone || null;
+  const user = await VenueJourneyRepository.findUserByPhone(phone);
+  const userId = user ? user._id : null;
+
+  const [enquiries, conversations] = await Promise.all([
+    VenueJourneyRepository.findVenueEnquiries({ userId, phone }),
+    VenueJourneyRepository.findVenueConversations({ userId }),
+  ]);
+
+  return {
+    lead: { _id: lead._id, name: lead.name, phone: lead.phone },
+    user: user ? { _id: user._id, name: user.name, phone: user.phone } : null,
+    enquiries,
+    conversations,
+  };
+};
+
+const getConversationMessages = async (conversationId) => {
+  if (!mongoose.Types.ObjectId.isValid(conversationId)) {
+    throw err(400, "Invalid conversation id.");
+  }
+  const convo = await VenueJourneyRepository.findConversationById(conversationId);
+  if (!convo) {
+    throw err(404, "Conversation not found.");
+  }
+  const messages = await VenueJourneyRepository.findMessagesByConversationId(conversationId);
+  return { conversationId, messages };
+};
+
+module.exports = {
+  getJourneyForEnquiry,
+  getConversationMessages,
+};


### PR DESCRIPTION
CRM-owned admin routes for the Lead Detail Venues sub-tab (Venue handoff §11). Backend-only. No Venue Booking files touched.

- GET /admin/enquiries/:enquiryId/venue-journey — resolves lead -> User (by phone) -> venue enquiries (userId OR phone/couplePhone) + conversations; populates venue (name/slug/coverPhoto/venueType/city) + enquiry (eventDate/guestCount/stage). Aggregating route keyed by the lead, since CRM leads carry phone not userId.
- GET /admin/venue-conversations/:conversationId/messages — VenueMessages by conversation, adminAuth. CRM-owned parallel route; deliberately does NOT modify Venue Booking's coupleOrVenueAuth or their conversation route.
- VenueJourneyService + VenueJourneyRepository (requires models/Venue so the populate ref registers), controller, 2 routes appended to routes/admin.js.
- scripts/verify-venue-journey.js — local-only, read-only.

Tested on local dev DB against the rohaan lead: verify script 7/7; live GET 200 with 2 enquiries + 2 conversations fully populated; unauth -> 400.

Deferred (per §11): "Venues browsed" (VenueView model exists on disk, V1.5). Not the §13 full venue admin module (Phase 6, gated on RBAC-in-prod + the Option A/B decision). Staging integration only — do not deploy to prod.