### PR TITLE
feat: additive dateFrom/dateTo range filter on GET /enquiry

### DIFF
--- a/controllers/enquiry.js
+++ b/controllers/enquiry.js
@@ -271,6 +271,8 @@ const GetAll = async (req, res) => {
       bidRequest,
       storeAccess,
       assignedTo,
+      dateFrom,
+      dateTo,
     } = req.query;
     const query = {};
     const sortQuery = {};
@@ -293,6 +295,26 @@ const GetAll = async (req, res) => {
         $gte: startDate,
         $lt: endDate,
       };
+    }
+    if (!date && (dateFrom || dateTo)) {
+      const range = {};
+      if (dateFrom) {
+        const start = new Date(dateFrom);
+        if (!isNaN(start.getTime())) {
+          start.setHours(0, 0, 0, 0);
+          range.$gte = start;
+        }
+      }
+      if (dateTo) {
+        const end = new Date(dateTo);
+        if (!isNaN(end.getTime())) {
+          end.setHours(23, 59, 59, 999);
+          range.$lte = end;
+        }
+      }
+      if (Object.keys(range).length > 0) {
+        query.createdAt = range;
+      }
     }
     if (search) {
       const safeSearch = escapeRegExp(search);


### PR DESCRIPTION
- GET /enquiry now accepts optional dateFrom / dateTo for created-date range filtering
- Existing single `date` param unchanged and takes precedence when set
- Invalid date strings skipped silently (no 400, no crash)
- Shared endpoint (admin-web also uses it) — change is purely additive

Tested on local dev DB: range 28-31 May returns 4 leads; single date=31 May still returns 2; no params returns normally.