### PR TITLE
feat: dynamic stages backend (Stage collection, enum change, management routes, activity log)

### DIFF
--- a/controllers/activity.js
+++ b/controllers/activity.js
@@ -1,0 +1,16 @@
+const ActivityLogService = require("../services/ActivityLogService");
+
+// GET /activity?limit=&skip=&entityType=
+const GetAll = async (req, res) => {
+  try {
+    const limit = req.query.limit ? parseInt(req.query.limit, 10) : undefined;
+    const skip = req.query.skip ? parseInt(req.query.skip, 10) : undefined;
+    const entityType = req.query.entityType || undefined;
+    const result = await ActivityLogService.getRecent({ limit, skip, entityType });
+    res.status(200).json(result);
+  } catch (error) {
+    res.status(error.status || 500).json({ message: error.message });
+  }
+};
+
+module.exports = { GetAll };

--- a/controllers/stage.js
+++ b/controllers/stage.js
@@ -1,4 +1,5 @@
 const StageService = require("../services/StageService");
+
 // GET /stages
 const GetAll = async (req, res) => {
   try {
@@ -8,4 +9,54 @@ const GetAll = async (req, res) => {
     res.status(error.status || 500).json({ message: error.message });
   }
 };
-module.exports = { GetAll };
+
+// POST /stages
+const Create = async (req, res) => {
+  try {
+    const { name, color, category } = req.body || {};
+    const stage = await StageService.createStage({ name, color, category });
+    res.status(201).json(stage);
+  } catch (error) {
+    res.status(error.status || 500).json({ message: error.message });
+  }
+};
+
+// PUT /stages/:id
+const Update = async (req, res) => {
+  try {
+    const { name, color, category, order } = req.body || {};
+    const stage = await StageService.updateStage(req.params.id, {
+      name,
+      color,
+      category,
+      order,
+    });
+    res.status(200).json(stage);
+  } catch (error) {
+    res.status(error.status || 500).json({ message: error.message });
+  }
+};
+
+// PUT /stages/reorder  (note: route must be registered BEFORE /:id)
+const Reorder = async (req, res) => {
+  try {
+    const { orderedIds } = req.body || {};
+    const result = await StageService.reorderStages(orderedIds);
+    res.status(200).json(result);
+  } catch (error) {
+    res.status(error.status || 500).json({ message: error.message });
+  }
+};
+
+// DELETE /stages/:id?moveTo=<slug>  (also accepts body.moveTo as a fallback)
+const Delete = async (req, res) => {
+  try {
+    const moveTo = (req.query && req.query.moveTo) || (req.body && req.body.moveTo);
+    const result = await StageService.deleteStage(req.params.id, moveTo);
+    res.status(200).json(result);
+  } catch (error) {
+    res.status(error.status || 500).json({ message: error.message });
+  }
+};
+
+module.exports = { GetAll, Create, Update, Reorder, Delete };

--- a/controllers/stage.js
+++ b/controllers/stage.js
@@ -1,0 +1,11 @@
+const StageService = require("../services/StageService");
+// GET /stages
+const GetAll = async (req, res) => {
+  try {
+    const result = await StageService.getAllStages();
+    res.status(200).json(result);
+  } catch (error) {
+    res.status(error.status || 500).json({ message: error.message });
+  }
+};
+module.exports = { GetAll };

--- a/controllers/stage.js
+++ b/controllers/stage.js
@@ -14,7 +14,11 @@ const GetAll = async (req, res) => {
 const Create = async (req, res) => {
   try {
     const { name, color, category } = req.body || {};
-    const stage = await StageService.createStage({ name, color, category });
+    const actorId = req.auth && req.auth.user_id;
+    const stage = await StageService.createStage(
+      { name, color, category },
+      actorId
+    );
     res.status(201).json(stage);
   } catch (error) {
     res.status(error.status || 500).json({ message: error.message });
@@ -25,12 +29,12 @@ const Create = async (req, res) => {
 const Update = async (req, res) => {
   try {
     const { name, color, category, order } = req.body || {};
-    const stage = await StageService.updateStage(req.params.id, {
-      name,
-      color,
-      category,
-      order,
-    });
+    const actorId = req.auth && req.auth.user_id;
+    const stage = await StageService.updateStage(
+      req.params.id,
+      { name, color, category, order },
+      actorId
+    );
     res.status(200).json(stage);
   } catch (error) {
     res.status(error.status || 500).json({ message: error.message });
@@ -41,7 +45,8 @@ const Update = async (req, res) => {
 const Reorder = async (req, res) => {
   try {
     const { orderedIds } = req.body || {};
-    const result = await StageService.reorderStages(orderedIds);
+    const actorId = req.auth && req.auth.user_id;
+    const result = await StageService.reorderStages(orderedIds, actorId);
     res.status(200).json(result);
   } catch (error) {
     res.status(error.status || 500).json({ message: error.message });
@@ -52,7 +57,8 @@ const Reorder = async (req, res) => {
 const Delete = async (req, res) => {
   try {
     const moveTo = (req.query && req.query.moveTo) || (req.body && req.body.moveTo);
-    const result = await StageService.deleteStage(req.params.id, moveTo);
+    const actorId = req.auth && req.auth.user_id;
+    const result = await StageService.deleteStage(req.params.id, moveTo, actorId);
     res.status(200).json(result);
   } catch (error) {
     res.status(error.status || 500).json({ message: error.message });

--- a/models/ActivityLog.js
+++ b/models/ActivityLog.js
@@ -1,0 +1,16 @@
+const mongoose = require("mongoose");
+const ObjectId = mongoose.Schema.Types.ObjectId;
+const ActivityLogSchema = new mongoose.Schema(
+  {
+    actorId: { type: ObjectId, ref: "Admin", default: null },  // who did it (admin)
+    action: { type: String, required: true },   // e.g. "stage.created", "stage.renamed", "stage.reordered", "stage.deleted"
+    entityType: { type: String, default: "stage" }, // "stage" for now; extensible later ("lead", "project")
+    entityId: { type: String, default: null },   // id/slug of the affected entity
+    summary: { type: String, default: "" },       // human-readable one-liner
+    meta: { type: Object, default: {} },          // structured extras (e.g. { from, to, movedLeads })
+  },
+  { timestamps: true }
+);
+ActivityLogSchema.index({ createdAt: -1 });
+ActivityLogSchema.index({ entityType: 1, createdAt: -1 });
+module.exports = mongoose.models.ActivityLog || mongoose.model("ActivityLog", ActivityLogSchema);

--- a/models/Enquiry.js
+++ b/models/Enquiry.js
@@ -44,7 +44,6 @@ const EnquirySchema = new mongoose.Schema(
     // Wedsy OS pipeline tracking (added Phase 1 — additive only)
     stage: {
       type: String,
-      enum: ["new", "contacted", "meeting_scheduled"],
       default: "new",
       required: true,
     },

--- a/models/Stage.js
+++ b/models/Stage.js
@@ -1,0 +1,18 @@
+const mongoose = require("mongoose");
+
+const StageSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true },         // display name e.g. "Meeting Scheduled"
+    slug: { type: String, required: true, unique: true }, // stored value e.g. "meeting_scheduled"
+    order: { type: Number, required: true, default: 0 },  // column/sort position
+    color: { type: String, default: "#4B1528" },
+    category: { type: String, enum: ["open", "won", "lost"], default: "open" },
+    isSystem: { type: Boolean, default: false },     // system stages can't be deleted
+    deletedAt: { type: Date, default: null },         // soft delete
+  },
+  { timestamps: true }
+);
+
+StageSchema.index({ order: 1 });
+
+module.exports = mongoose.models.Stage || mongoose.model("Stage", StageSchema);

--- a/repositories/ActivityLogRepository.js
+++ b/repositories/ActivityLogRepository.js
@@ -1,0 +1,14 @@
+const ActivityLog = require("../models/ActivityLog");
+// Register Admin so populate("actorId") works in standalone-script context too.
+require("../models/Admin");
+const create = async (doc) => ActivityLog.create(doc);
+const findRecent = async ({ limit = 50, skip = 0, entityType } = {}) => {
+  const q = {};
+  if (entityType) q.entityType = entityType;
+  const [items, total] = await Promise.all([
+    ActivityLog.find(q).sort({ createdAt: -1 }).skip(skip).limit(limit).populate("actorId", "name email").lean(),
+    ActivityLog.countDocuments(q),
+  ]);
+  return { items, total };
+};
+module.exports = { create, findRecent };

--- a/repositories/StageRepository.js
+++ b/repositories/StageRepository.js
@@ -1,5 +1,61 @@
 const Stage = require("../models/Stage");
-const findAll = async () => Stage.find({ deletedAt: null }).sort({ order: 1 }).lean();
-const findBySlug = async (slug) => Stage.findOne({ slug, deletedAt: null }).lean();
+const Enquiry = require("../models/Enquiry");
+
+const findAll = async () =>
+  Stage.find({ deletedAt: null }).sort({ order: 1 }).lean();
+
+const findBySlug = async (slug) =>
+  Stage.findOne({ slug, deletedAt: null }).lean();
+
+const findById = async (id) =>
+  Stage.findOne({ _id: id, deletedAt: null }).lean();
+
 const countAll = async () => Stage.countDocuments({ deletedAt: null });
-module.exports = { findAll, findBySlug, countAll };
+
+const create = async (doc) => {
+  const created = await Stage.create(doc);
+  return created.toObject();
+};
+
+const updateById = async (id, fields) =>
+  Stage.findByIdAndUpdate(id, { $set: fields }, { new: true }).lean();
+
+const softDeleteById = async (id) =>
+  Stage.findByIdAndUpdate(
+    id,
+    { $set: { deletedAt: new Date() } },
+    { new: true }
+  ).lean();
+
+const maxOrder = async () => {
+  const top = await Stage.find({ deletedAt: null })
+    .sort({ order: -1 })
+    .limit(1)
+    .lean();
+  return top.length ? top[0].order : -1;
+};
+
+// Lead-side helpers — read/update the Enquiry.stage value only (no schema change).
+const countLeadsInStage = async (slug) =>
+  Enquiry.countDocuments({ stage: slug });
+
+const reassignLeads = async (fromSlug, toSlug) => {
+  const res = await Enquiry.updateMany(
+    { stage: fromSlug },
+    { $set: { stage: toSlug } }
+  );
+  return res.modifiedCount;
+};
+
+module.exports = {
+  findAll,
+  findBySlug,
+  findById,
+  countAll,
+  create,
+  updateById,
+  softDeleteById,
+  maxOrder,
+  countLeadsInStage,
+  reassignLeads,
+};

--- a/repositories/StageRepository.js
+++ b/repositories/StageRepository.js
@@ -1,0 +1,5 @@
+const Stage = require("../models/Stage");
+const findAll = async () => Stage.find({ deletedAt: null }).sort({ order: 1 }).lean();
+const findBySlug = async (slug) => Stage.findOne({ slug, deletedAt: null }).lean();
+const countAll = async () => Stage.countDocuments({ deletedAt: null });
+module.exports = { findAll, findBySlug, countAll };

--- a/routes/activity.js
+++ b/routes/activity.js
@@ -1,0 +1,15 @@
+const express = require("express");
+const router = express.Router();
+const activity = require("../controllers/activity");
+const { CheckAdminLogin } = require("../middlewares/auth");
+const { requirePermission } = require("../middlewares/requirePermission");
+
+// Gated settings:view:all so Founder + CRM Admin can view the log.
+router.get(
+  "/",
+  CheckAdminLogin,
+  requirePermission("settings:view:all"),
+  activity.GetAll
+);
+
+module.exports = router;

--- a/routes/router.js
+++ b/routes/router.js
@@ -71,6 +71,7 @@ router.use("/vendor-review", require("./vendor-review"));
 router.use("/admin", require("./admin"));
 router.use("/department", require("./department"));
 router.use("/role", require("./role"));
+router.use("/stages", require("./stage"));
 router.use("/venues", require("./venue"));
 router.use("/venue-owner", require("./venueOwner"));
 router.use("/conversations", require("./conversation"));

--- a/routes/router.js
+++ b/routes/router.js
@@ -72,6 +72,7 @@ router.use("/admin", require("./admin"));
 router.use("/department", require("./department"));
 router.use("/role", require("./role"));
 router.use("/stages", require("./stage"));
+router.use("/activity", require("./activity"));
 router.use("/venues", require("./venue"));
 router.use("/venue-owner", require("./venueOwner"));
 router.use("/conversations", require("./conversation"));

--- a/routes/stage.js
+++ b/routes/stage.js
@@ -1,0 +1,7 @@
+const express = require("express");
+const router = express.Router();
+const stage = require("../controllers/stage");
+const { CheckAdminLogin } = require("../middlewares/auth");
+// Read is available to any admin (Stage 1). Write/manage routes added in Stage 3 with RBAC.
+router.get("/", CheckAdminLogin, stage.GetAll);
+module.exports = router;

--- a/routes/stage.js
+++ b/routes/stage.js
@@ -2,6 +2,37 @@ const express = require("express");
 const router = express.Router();
 const stage = require("../controllers/stage");
 const { CheckAdminLogin } = require("../middlewares/auth");
-// Read is available to any admin (Stage 1). Write/manage routes added in Stage 3 with RBAC.
+const { requirePermission } = require("../middlewares/requirePermission");
+
+// Read is available to any authenticated admin.
 router.get("/", CheckAdminLogin, stage.GetAll);
+
+// Write/manage routes — RBAC-gated. "settings:edit:all" covers create/update/reorder;
+// "settings:delete:all" covers delete. Founder *:*:all and CRM Admin satisfy both.
+router.post(
+  "/",
+  CheckAdminLogin,
+  requirePermission("settings:edit:all"),
+  stage.Create
+);
+// "/reorder" must come BEFORE "/:id" so it isn't captured as an id param.
+router.put(
+  "/reorder",
+  CheckAdminLogin,
+  requirePermission("settings:edit:all"),
+  stage.Reorder
+);
+router.put(
+  "/:id",
+  CheckAdminLogin,
+  requirePermission("settings:edit:all"),
+  stage.Update
+);
+router.delete(
+  "/:id",
+  CheckAdminLogin,
+  requirePermission("settings:delete:all"),
+  stage.Delete
+);
+
 module.exports = router;

--- a/scripts/seed-stages.js
+++ b/scripts/seed-stages.js
@@ -1,0 +1,27 @@
+/**
+ * Seed the Stage collection with the current 3 CRM stages. LOCAL DEV ONLY.
+ * Idempotent: upserts by slug, won't duplicate on re-run. Run: node scripts/seed-stages.js
+ */
+require("dotenv").config();
+const mongoose = require("mongoose");
+const Stage = require("../models/Stage");
+
+const dbUrl = process.env.DATABASE_URL || "";
+if (!dbUrl.startsWith("mongodb://localhost")) {
+  console.error("ABORT: DATABASE_URL is not localhost."); process.exit(1);
+}
+const SEED = [
+  { name: "New", slug: "new", order: 0, color: "#4B1528", category: "open", isSystem: true },
+  { name: "Contacted", slug: "contacted", order: 1, color: "#8B5A00", category: "open", isSystem: false },
+  { name: "Meeting Scheduled", slug: "meeting_scheduled", order: 2, color: "#2D5F3F", category: "open", isSystem: false },
+];
+(async () => {
+  await mongoose.connect(dbUrl);
+  for (const s of SEED) {
+    await Stage.updateOne({ slug: s.slug }, { $set: s }, { upsert: true });
+    console.log("upserted:", s.slug);
+  }
+  const count = await Stage.countDocuments({ deletedAt: null });
+  console.log("total stages:", count);
+  await mongoose.disconnect();
+})();

--- a/scripts/verify-activity-log.js
+++ b/scripts/verify-activity-log.js
@@ -1,0 +1,154 @@
+/**
+ * Verify ActivityLog wiring through StageService (LOCAL DEV ONLY).
+ * Exercises createStage / updateStage (rename) / deleteStage and asserts each writes
+ * the expected ActivityLog entry. Self-cleans: hard-deletes the temp stage and any
+ * ActivityLog rows it created. Aborts if DATABASE_URL is not localhost.
+ *
+ * Run: node scripts/verify-activity-log.js
+ */
+
+require("dotenv").config();
+const mongoose = require("mongoose");
+const Stage = require("../models/Stage");
+const ActivityLog = require("../models/ActivityLog");
+const StageService = require("../services/StageService");
+const ActivityLogService = require("../services/ActivityLogService");
+
+const dbUrl = process.env.DATABASE_URL || "";
+if (!dbUrl.startsWith("mongodb://localhost")) {
+  console.error("ABORT: DATABASE_URL is not localhost.");
+  console.error(`DATABASE_URL = ${dbUrl || "(empty)"}`);
+  process.exit(1);
+}
+
+const TEST_NAME = "Temp Log Test";
+const TEST_SLUG = "temp_log_test";
+const FAKE_ACTOR = new mongoose.Types.ObjectId();
+
+let pass = 0;
+let fail = 0;
+const check = (label, cond) => {
+  console.log(`${cond ? "PASS" : "FAIL"}  ${label}`);
+  cond ? pass++ : fail++;
+};
+
+(async () => {
+  let createdStageId = null;
+  try {
+    await mongoose.connect(dbUrl);
+    console.log(`Connected to ${dbUrl}\n`);
+
+    // ---------- Step 1: createStage logs "stage.created" ----------
+    console.log(`=== Step 1: createStage('${TEST_NAME}') ===`);
+    const created = await StageService.createStage(
+      { name: TEST_NAME },
+      FAKE_ACTOR
+    );
+    createdStageId = created._id;
+    check(`stage created with slug='${TEST_SLUG}'`, created.slug === TEST_SLUG);
+
+    const r1 = await ActivityLogService.getRecent({
+      entityType: "stage",
+      limit: 5,
+    });
+    const createdLog = r1.items.find(
+      (i) => i.action === "stage.created" && i.entityId === TEST_SLUG
+    );
+    check("activity log contains 'stage.created' for this stage", !!createdLog);
+    check(
+      `created log has non-empty summary ('${createdLog?.summary}')`,
+      !!(createdLog && createdLog.summary && createdLog.summary.length > 0)
+    );
+    check(
+      "created log has createdAt timestamp",
+      !!(createdLog && createdLog.createdAt instanceof Date)
+    );
+    // The populate(actorId) above returns null for our synthetic id (no matching Admin
+    // doc), so check the raw stored value instead — that's the contract we care about.
+    const rawCreatedLog = await ActivityLog.findOne({
+      action: "stage.created",
+      entityId: TEST_SLUG,
+    }).lean();
+    check(
+      "raw created log actorId matches the actorId we passed in",
+      !!(rawCreatedLog && String(rawCreatedLog.actorId) === String(FAKE_ACTOR))
+    );
+
+    // ---------- Step 2: updateStage (rename) logs "stage.renamed" ----------
+    console.log(`\n=== Step 2: rename to '${TEST_NAME} Done' ===`);
+    const renamed = await StageService.updateStage(
+      String(createdStageId),
+      { name: `${TEST_NAME} Done` },
+      FAKE_ACTOR
+    );
+    check(
+      "name changed but slug unchanged",
+      renamed.name === `${TEST_NAME} Done` && renamed.slug === TEST_SLUG
+    );
+
+    const r2 = await ActivityLogService.getRecent({
+      entityType: "stage",
+      limit: 5,
+    });
+    const renamedLog = r2.items.find(
+      (i) => i.action === "stage.renamed" && i.entityId === TEST_SLUG
+    );
+    check("activity log contains 'stage.renamed'", !!renamedLog);
+    check(
+      `renamed log has non-empty summary ('${renamedLog?.summary}')`,
+      !!(renamedLog && renamedLog.summary && renamedLog.summary.length > 0)
+    );
+
+    // ---------- Step 3: deleteStage logs "stage.deleted" with movedTo ----------
+    console.log("\n=== Step 3: deleteStage with moveTo='new' ===");
+    const delResult = await StageService.deleteStage(
+      String(createdStageId),
+      "new",
+      FAKE_ACTOR
+    );
+    check(
+      `delete returned movedTo='new' (movedLeads=${delResult.movedLeads})`,
+      delResult.movedTo === "new"
+    );
+
+    const r3 = await ActivityLogService.getRecent({
+      entityType: "stage",
+      limit: 5,
+    });
+    const deletedLog = r3.items.find(
+      (i) => i.action === "stage.deleted" && i.entityId === TEST_SLUG
+    );
+    check("activity log contains 'stage.deleted'", !!deletedLog);
+    check(
+      "deleted log meta.movedTo === 'new'",
+      deletedLog?.meta?.movedTo === "new"
+    );
+    check(
+      `deleted log has non-empty summary ('${deletedLog?.summary}')`,
+      !!(deletedLog && deletedLog.summary && deletedLog.summary.length > 0)
+    );
+
+    console.log(`\nResult: ${pass} passed, ${fail} failed.`);
+    if (fail > 0) process.exitCode = 1;
+  } catch (error) {
+    console.error("Verification error:", error);
+    process.exitCode = 1;
+  } finally {
+    // ---------- Cleanup ----------
+    // Hard-delete the temp stage doc (whether soft-deleted or still active).
+    await Stage.deleteOne({ slug: TEST_SLUG }).catch(() => {});
+    if (createdStageId) {
+      await Stage.deleteOne({ _id: createdStageId }).catch(() => {});
+    }
+    // Hard-delete the activity rows tied to this test slug.
+    const purge = await ActivityLog.deleteMany({
+      entityType: "stage",
+      entityId: TEST_SLUG,
+    }).catch(() => ({ deletedCount: 0 }));
+    console.log(
+      `Cleanup: removed ${purge.deletedCount || 0} activity rows for entityId='${TEST_SLUG}'.`
+    );
+    await mongoose.disconnect();
+    console.log("Disconnected.");
+  }
+})();

--- a/scripts/verify-stage-enum-change.js
+++ b/scripts/verify-stage-enum-change.js
@@ -1,0 +1,113 @@
+/**
+ * Verify the Stage 2 dynamic-stages change end-to-end (LOCAL DEV ONLY).
+ * Proves the Enquiry.stage enum is gone AND the service now validates against the Stage collection.
+ * Picks a real enquiry, exercises updateStage with valid + invalid slugs, restores the original stage.
+ * Aborts if DATABASE_URL is not localhost. Run: node scripts/verify-stage-enum-change.js
+ */
+
+require("dotenv").config();
+const mongoose = require("mongoose");
+const Enquiry = require("../models/Enquiry");
+const EnquiryService = require("../services/EnquiryService");
+const StageRepository = require("../repositories/StageRepository");
+
+const dbUrl = process.env.DATABASE_URL || "";
+if (!dbUrl.startsWith("mongodb://localhost")) {
+  console.error("ABORT: DATABASE_URL is not localhost.");
+  console.error(`DATABASE_URL = ${dbUrl || "(empty)"}`);
+  process.exit(1);
+}
+
+let pass = 0;
+let fail = 0;
+const check = (label, cond) => {
+  console.log(`${cond ? "PASS" : "FAIL"}  ${label}`);
+  cond ? pass++ : fail++;
+};
+
+(async () => {
+  let restore = null;
+  try {
+    await mongoose.connect(dbUrl);
+    console.log(`Connected to ${dbUrl}\n`);
+
+    // ---------- Pick a test enquiry ----------
+    const target = await Enquiry.findOne({}).lean();
+    if (!target) {
+      console.error("ABORT: no enquiries in local DB to test against.");
+      process.exitCode = 1;
+      return;
+    }
+    restore = { id: target._id, stage: target.stage };
+    console.log(
+      `Test enquiry: ${target._id} (name=${target.name}, current stage="${target.stage}")\n`
+    );
+
+    // ---------- Test A: valid slug succeeds ----------
+    console.log("=== Test A: valid slug 'contacted' ===");
+    try {
+      const updated = await EnquiryService.updateStage(
+        String(target._id),
+        "contacted",
+        null
+      );
+      check(
+        "updateStage('contacted') returned an enquiry",
+        !!(updated && updated._id)
+      );
+      check(
+        "enquiry.stage === 'contacted' after valid update",
+        updated.stage === "contacted"
+      );
+    } catch (e) {
+      check(`Test A unexpectedly threw: ${e.status} ${e.message}`, false);
+    }
+
+    // ---------- Test B: invalid slug rejected with 400 ----------
+    console.log("\n=== Test B: invalid slug 'not_a_real_stage' ===");
+    try {
+      await EnquiryService.updateStage(
+        String(target._id),
+        "not_a_real_stage",
+        null
+      );
+      check("invalid slug should have thrown (it didn't)", false);
+    } catch (e) {
+      check(
+        `invalid slug threw with status ${e.status} (${e.message})`,
+        e.status === 400
+      );
+    }
+
+    // ---------- Test C: a seeded slug resolves via the repo ----------
+    console.log("\n=== Test C: StageRepository.findBySlug('meeting_scheduled') ===");
+    const seeded = await StageRepository.findBySlug("meeting_scheduled");
+    check(
+      `findBySlug('meeting_scheduled') returned a stage doc (name=${seeded?.name})`,
+      !!(seeded && seeded.slug === "meeting_scheduled")
+    );
+
+    // ---------- Bonus: confirm the enquiry doc reflects Test A's write ----------
+    const afterA = await Enquiry.findById(target._id).lean();
+    check(
+      "post-Test-A read confirms stage persisted as 'contacted'",
+      afterA && afterA.stage === "contacted"
+    );
+
+    console.log(`\nResult: ${pass} passed, ${fail} failed.`);
+    if (fail > 0) process.exitCode = 1;
+  } catch (error) {
+    console.error("Verification error:", error);
+    process.exitCode = 1;
+  } finally {
+    if (restore) {
+      await Enquiry.updateOne(
+        { _id: restore.id },
+        { $set: { stage: restore.stage } }
+      );
+      console.log(`\nRestored enquiry ${restore.id} to stage="${restore.stage}".`);
+    }
+    await mongoose.disconnect();
+    console.log("Disconnected.");
+  }
+})();

--- a/scripts/verify-stage-management.js
+++ b/scripts/verify-stage-management.js
@@ -1,0 +1,162 @@
+/**
+ * Verify the Stage 3a management endpoints at the SERVICE layer (LOCAL DEV ONLY).
+ * Exercises createStage / updateStage (rename) / deleteStage (with reassign), plus the
+ * system-stage and missing-moveTo guards. Restores any test data on exit so the DB is
+ * left as it was. Aborts if DATABASE_URL is not localhost.
+ *
+ * Run: node scripts/verify-stage-management.js
+ */
+
+require("dotenv").config();
+const mongoose = require("mongoose");
+const Stage = require("../models/Stage");
+const Enquiry = require("../models/Enquiry");
+const StageService = require("../services/StageService");
+const StageRepository = require("../repositories/StageRepository");
+
+const dbUrl = process.env.DATABASE_URL || "";
+if (!dbUrl.startsWith("mongodb://localhost")) {
+  console.error("ABORT: DATABASE_URL is not localhost.");
+  console.error(`DATABASE_URL = ${dbUrl || "(empty)"}`);
+  process.exit(1);
+}
+
+let pass = 0;
+let fail = 0;
+const check = (label, cond) => {
+  console.log(`${cond ? "PASS" : "FAIL"}  ${label}`);
+  cond ? pass++ : fail++;
+};
+const expectThrow = async (label, status, fn) => {
+  try {
+    await fn();
+    check(`${label} (expected ${status})`, false);
+  } catch (e) {
+    check(`${label} -> ${e.status || "?"} ${e.message}`, e.status === status);
+  }
+};
+
+(async () => {
+  let createdStageId = null;
+  let restoreLead = null;
+  try {
+    await mongoose.connect(dbUrl);
+    console.log(`Connected to ${dbUrl}\n`);
+
+    // ---------- Step 1: create "Site Visit" ----------
+    console.log("=== Step 1: createStage('Site Visit') ===");
+    const beforeMax = await StageRepository.maxOrder();
+    const created = await StageService.createStage({ name: "Site Visit" });
+    createdStageId = created._id;
+    check("created stage has slug 'site_visit'", created.slug === "site_visit");
+    check("created stage name is 'Site Visit'", created.name === "Site Visit");
+    check(
+      `created order > previous max (${created.order} > ${beforeMax})`,
+      created.order > beforeMax
+    );
+    check("category defaults to 'open'", created.category === "open");
+
+    // ---------- Step 2: duplicate create -> 409 ----------
+    console.log("\n=== Step 2: duplicate createStage rejected ===");
+    await expectThrow("duplicate 'Site Visit' rejected", 409, () =>
+      StageService.createStage({ name: "Site Visit" })
+    );
+
+    // ---------- Step 3: rename without changing slug ----------
+    console.log("\n=== Step 3: rename to 'Site Visit Done' ===");
+    const renamed = await StageService.updateStage(String(createdStageId), {
+      name: "Site Visit Done",
+    });
+    check("renamed name = 'Site Visit Done'", renamed.name === "Site Visit Done");
+    check("slug unchanged after rename ('site_visit')", renamed.slug === "site_visit");
+
+    // ---------- Step 4: delete with reassign (move leads to 'new') ----------
+    console.log("\n=== Step 4: deleteStage with moveTo='new' (reassigns leads) ===");
+    const testLead = await Enquiry.findOne({}).lean();
+    if (!testLead) {
+      console.warn("SKIP Step 4 lead-related checks — no enquiries in local DB.");
+    } else {
+      restoreLead = { id: testLead._id, stage: testLead.stage };
+      await Enquiry.updateOne(
+        { _id: testLead._id },
+        { $set: { stage: "site_visit" } }
+      );
+
+      const result = await StageService.deleteStage(
+        String(createdStageId),
+        "new"
+      );
+      check(
+        `deleteStage returned movedLeads >= 1 (got ${result.movedLeads})`,
+        result.movedLeads >= 1
+      );
+      check("deleteStage returned movedTo 'new'", result.movedTo === "new");
+
+      const afterLead = await Enquiry.findById(testLead._id).lean();
+      check(
+        `test lead's stage is now 'new' (was 'site_visit')`,
+        afterLead.stage === "new"
+      );
+
+      const stillThere = await StageRepository.findBySlug("site_visit");
+      check("stage no longer visible via findBySlug (soft-deleted)", !stillThere);
+
+      const raw = await Stage.findById(createdStageId).lean();
+      check(
+        "soft-delete stamped deletedAt on the stage doc",
+        raw && raw.deletedAt instanceof Date
+      );
+      // After soft-delete the doc is no longer fetchable via the active repo —
+      // mark createdStageId as already gone so cleanup uses a hard deleteOne by slug.
+    }
+
+    // ---------- Step 5: can't delete a system stage ----------
+    console.log("\n=== Step 5: deleteStage on 'new' (system) rejected ===");
+    const newStage = await Stage.findOne({ slug: "new" }).lean();
+    if (!newStage) {
+      console.warn("SKIP — 'new' system stage missing (run seed-stages.js).");
+    } else {
+      await expectThrow("system stage delete rejected", 400, () =>
+        StageService.deleteStage(String(newStage._id), "contacted")
+      );
+    }
+
+    // ---------- Step 6: deleteStage without moveTo -> 400 ----------
+    console.log("\n=== Step 6: deleteStage without moveTo ===");
+    // Need a non-system, still-active stage to target this against. Create+attempt+cleanup.
+    const tmp = await StageService.createStage({ name: "Tmp Delete Target" });
+    await expectThrow("missing moveTo rejected", 400, () =>
+      StageService.deleteStage(String(tmp._id), "")
+    );
+    await expectThrow("undefined moveTo rejected", 400, () =>
+      StageService.deleteStage(String(tmp._id), undefined)
+    );
+    // hard-clean the tmp stage
+    await Stage.deleteOne({ _id: tmp._id });
+
+    console.log(`\nResult: ${pass} passed, ${fail} failed.`);
+    if (fail > 0) process.exitCode = 1;
+  } catch (error) {
+    console.error("Verification error:", error);
+    process.exitCode = 1;
+  } finally {
+    // ---------- Cleanup ----------
+    if (createdStageId) {
+      // hard-remove the test stage (soft-deleted or otherwise) so subsequent runs are clean
+      await Stage.deleteOne({ _id: createdStageId }).catch(() => {});
+      // also defensively remove any leftover by slug in case create/delete state is mixed
+      await Stage.deleteOne({ slug: "site_visit", isSystem: { $ne: true } }).catch(
+        () => {}
+      );
+    }
+    if (restoreLead) {
+      await Enquiry.updateOne(
+        { _id: restoreLead.id },
+        { $set: { stage: restoreLead.stage } }
+      ).catch(() => {});
+      console.log(`Restored lead ${restoreLead.id} stage="${restoreLead.stage}".`);
+    }
+    await mongoose.disconnect();
+    console.log("Disconnected.");
+  }
+})();

--- a/scripts/verify-stages.js
+++ b/scripts/verify-stages.js
@@ -1,0 +1,23 @@
+/**
+ * Verify Stage model + service (LOCAL DEV ONLY, read-only). Run after seeding.
+ * node scripts/verify-stages.js
+ */
+require("dotenv").config();
+const mongoose = require("mongoose");
+const StageService = require("../services/StageService");
+const dbUrl = process.env.DATABASE_URL || "";
+if (!dbUrl.startsWith("mongodb://localhost")) { console.error("ABORT: not localhost"); process.exit(1); }
+let pass = 0, fail = 0;
+const check = (l, c) => { console.log(`${c ? "PASS" : "FAIL"}  ${l}`); c ? pass++ : fail++; };
+(async () => {
+  await mongoose.connect(dbUrl);
+  const { stages } = await StageService.getAllStages();
+  console.log("stages:", stages.map(s => `${s.order}:${s.slug}(${s.name})`).join(", "));
+  check("at least 3 stages seeded", stages.length >= 3);
+  check("stages sorted by order ascending", stages.every((s, i) => i === 0 || stages[i-1].order <= s.order));
+  check("each stage has slug + name", stages.every(s => s.slug && s.name));
+  check("'new' stage is isSystem", (stages.find(s => s.slug === "new") || {}).isSystem === true);
+  console.log(`\nResult: ${pass} passed, ${fail} failed.`);
+  await mongoose.disconnect();
+  if (fail > 0) process.exitCode = 1;
+})();

--- a/services/ActivityLogService.js
+++ b/services/ActivityLogService.js
@@ -1,0 +1,13 @@
+const ActivityLogRepository = require("../repositories/ActivityLogRepository");
+// Fire-and-safe: logging must NEVER break the primary action. Always wrapped in try/catch by caller, but also guard here.
+const record = async ({ actorId, action, entityType = "stage", entityId, summary, meta }) => {
+  try {
+    return await ActivityLogRepository.create({ actorId: actorId || null, action, entityType, entityId: entityId != null ? String(entityId) : null, summary: summary || "", meta: meta || {} });
+  } catch (e) {
+    // Never throw from logging — return null so the primary action still succeeds.
+    console.error("ActivityLog.record failed:", e.message);
+    return null;
+  }
+};
+const getRecent = async (opts) => ActivityLogRepository.findRecent(opts);
+module.exports = { record, getRecent };

--- a/services/EnquiryService.js
+++ b/services/EnquiryService.js
@@ -1,8 +1,7 @@
 const mongoose = require("mongoose");
 const EnquiryRepository = require("../repositories/EnquiryRepository");
 const AdminRepository = require("../repositories/AdminRepository");
-
-const VALID_STAGES = ["new", "contacted", "meeting_scheduled"];
+const StageRepository = require("../repositories/StageRepository");
 
 // Update an enquiry's pipeline stage.
 // Throws { status, message } shaped errors for the controller to map to HTTP responses.
@@ -12,10 +11,9 @@ const updateStage = async (enquiryId, stage, updatedBy) => {
     err.status = 400;
     throw err;
   }
-  if (!VALID_STAGES.includes(stage)) {
-    const err = new Error(
-      `Invalid stage. Must be one of: ${VALID_STAGES.join(", ")}`
-    );
+  const validStage = await StageRepository.findBySlug(stage);
+  if (!validStage) {
+    const err = new Error(`Invalid stage: ${stage}`);
     err.status = 400;
     throw err;
   }

--- a/services/StageService.js
+++ b/services/StageService.js
@@ -1,5 +1,6 @@
 const mongoose = require("mongoose");
 const StageRepository = require("../repositories/StageRepository");
+const ActivityLogService = require("./ActivityLogService");
 
 const VALID_CATEGORIES = ["open", "won", "lost"];
 
@@ -22,7 +23,7 @@ const getAllStages = async () => {
   return { stages };
 };
 
-const createStage = async ({ name, color, category } = {}) => {
+const createStage = async ({ name, color, category } = {}, actorId) => {
   if (typeof name !== "string" || name.trim().length === 0) {
     throw err(400, "name is required");
   }
@@ -43,12 +44,23 @@ const createStage = async ({ name, color, category } = {}) => {
   const order = (await StageRepository.maxOrder()) + 1;
   const doc = { name: name.trim(), slug, category: cat, order };
   if (typeof color === "string" && color.length) doc.color = color;
-  return await StageRepository.create(doc);
+  const created = await StageRepository.create(doc);
+
+  await ActivityLogService.record({
+    actorId,
+    action: "stage.created",
+    entityType: "stage",
+    entityId: created.slug,
+    summary: `Created stage "${created.name}"`,
+    meta: { slug: created.slug, name: created.name },
+  });
+
+  return created;
 };
 
 // Rename / recolor / reorder a single stage. NEVER changes slug — leads store the slug,
 // so renaming is display-only to keep existing leads valid.
-const updateStage = async (id, { name, color, category, order } = {}) => {
+const updateStage = async (id, { name, color, category, order } = {}, actorId) => {
   if (!mongoose.Types.ObjectId.isValid(id)) throw err(400, "Invalid stage id");
   const existing = await StageRepository.findById(id);
   if (!existing) throw err(404, "Stage not found");
@@ -74,11 +86,25 @@ const updateStage = async (id, { name, color, category, order } = {}) => {
   }
 
   if (Object.keys(fields).length === 0) return existing;
-  return await StageRepository.updateById(id, fields);
+  const updated = await StageRepository.updateById(id, fields);
+
+  const renamed = "name" in fields && fields.name !== existing.name;
+  await ActivityLogService.record({
+    actorId,
+    action: renamed ? "stage.renamed" : "stage.updated",
+    entityType: "stage",
+    entityId: updated.slug,
+    summary: renamed
+      ? `Renamed stage to "${updated.name}"`
+      : `Updated stage "${updated.name}"`,
+    meta: { changed: fields, previousName: existing.name },
+  });
+
+  return updated;
 };
 
 // Bulk reorder. Sets each stage's order to its index in the provided id array.
-const reorderStages = async (orderedIds) => {
+const reorderStages = async (orderedIds, actorId) => {
   if (!Array.isArray(orderedIds) || orderedIds.length === 0) {
     throw err(400, "orderedIds must be a non-empty array");
   }
@@ -91,10 +117,20 @@ const reorderStages = async (orderedIds) => {
     await StageRepository.updateById(orderedIds[i], { order: i });
   }
   const stages = await StageRepository.findAll();
+
+  await ActivityLogService.record({
+    actorId,
+    action: "stage.reordered",
+    entityType: "stage",
+    entityId: null,
+    summary: "Reordered pipeline stages",
+    meta: { order: stages.map((s) => s.slug) },
+  });
+
   return { stages };
 };
 
-const deleteStage = async (id, moveToSlug) => {
+const deleteStage = async (id, moveToSlug, actorId) => {
   if (!mongoose.Types.ObjectId.isValid(id)) throw err(400, "Invalid stage id");
   const existing = await StageRepository.findById(id);
   if (!existing) throw err(404, "Stage not found");
@@ -118,6 +154,15 @@ const deleteStage = async (id, moveToSlug) => {
     moveToSlug
   );
   await StageRepository.softDeleteById(id);
+
+  await ActivityLogService.record({
+    actorId,
+    action: "stage.deleted",
+    entityType: "stage",
+    entityId: existing.slug,
+    summary: `Deleted stage "${existing.name}", moved ${movedLeads} leads to "${moveToSlug}"`,
+    meta: { movedLeads, movedTo: moveToSlug, deletedName: existing.name },
+  });
 
   return { deleted: String(id), movedLeads, movedTo: moveToSlug };
 };

--- a/services/StageService.js
+++ b/services/StageService.js
@@ -1,6 +1,131 @@
+const mongoose = require("mongoose");
 const StageRepository = require("../repositories/StageRepository");
+
+const VALID_CATEGORIES = ["open", "won", "lost"];
+
+const err = (status, message) =>
+  Object.assign(new Error(message), { status });
+
+// Derive a URL-safe slug from a display name. Lowercase, trim, non-alphanumerics → "_",
+// collapse repeats, strip leading/trailing underscores.
+function slugify(name) {
+  return String(name)
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .replace(/_+/g, "_");
+}
+
 const getAllStages = async () => {
   const stages = await StageRepository.findAll();
   return { stages };
 };
-module.exports = { getAllStages };
+
+const createStage = async ({ name, color, category } = {}) => {
+  if (typeof name !== "string" || name.trim().length === 0) {
+    throw err(400, "name is required");
+  }
+  const slug = slugify(name);
+  if (!slug) throw err(400, "name produces an empty slug");
+
+  const cat = category || "open";
+  if (!VALID_CATEGORIES.includes(cat)) {
+    throw err(
+      400,
+      `Invalid category. Must be one of: ${VALID_CATEGORIES.join(", ")}`
+    );
+  }
+
+  const existing = await StageRepository.findBySlug(slug);
+  if (existing) throw err(409, "Stage already exists");
+
+  const order = (await StageRepository.maxOrder()) + 1;
+  const doc = { name: name.trim(), slug, category: cat, order };
+  if (typeof color === "string" && color.length) doc.color = color;
+  return await StageRepository.create(doc);
+};
+
+// Rename / recolor / reorder a single stage. NEVER changes slug — leads store the slug,
+// so renaming is display-only to keep existing leads valid.
+const updateStage = async (id, { name, color, category, order } = {}) => {
+  if (!mongoose.Types.ObjectId.isValid(id)) throw err(400, "Invalid stage id");
+  const existing = await StageRepository.findById(id);
+  if (!existing) throw err(404, "Stage not found");
+
+  const fields = {};
+  if (typeof name === "string" && name.trim().length > 0) {
+    fields.name = name.trim();
+  }
+  if (typeof color === "string" && color.length > 0) {
+    fields.color = color;
+  }
+  if (typeof category === "string") {
+    if (!VALID_CATEGORIES.includes(category)) {
+      throw err(
+        400,
+        `Invalid category. Must be one of: ${VALID_CATEGORIES.join(", ")}`
+      );
+    }
+    fields.category = category;
+  }
+  if (typeof order === "number" && Number.isFinite(order)) {
+    fields.order = order;
+  }
+
+  if (Object.keys(fields).length === 0) return existing;
+  return await StageRepository.updateById(id, fields);
+};
+
+// Bulk reorder. Sets each stage's order to its index in the provided id array.
+const reorderStages = async (orderedIds) => {
+  if (!Array.isArray(orderedIds) || orderedIds.length === 0) {
+    throw err(400, "orderedIds must be a non-empty array");
+  }
+  for (const id of orderedIds) {
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      throw err(400, `Invalid stage id in orderedIds: ${id}`);
+    }
+  }
+  for (let i = 0; i < orderedIds.length; i++) {
+    await StageRepository.updateById(orderedIds[i], { order: i });
+  }
+  const stages = await StageRepository.findAll();
+  return { stages };
+};
+
+const deleteStage = async (id, moveToSlug) => {
+  if (!mongoose.Types.ObjectId.isValid(id)) throw err(400, "Invalid stage id");
+  const existing = await StageRepository.findById(id);
+  if (!existing) throw err(404, "Stage not found");
+  if (existing.isSystem === true) {
+    throw err(400, "Cannot delete a system stage");
+  }
+  const total = await StageRepository.countAll();
+  if (total <= 1) throw err(400, "Cannot delete the only stage");
+
+  if (typeof moveToSlug !== "string" || moveToSlug.length === 0) {
+    throw err(400, "moveTo is required to delete a stage");
+  }
+  if (moveToSlug === existing.slug) {
+    throw err(400, "moveTo must be a different stage");
+  }
+  const target = await StageRepository.findBySlug(moveToSlug);
+  if (!target) throw err(400, `moveTo slug not found: ${moveToSlug}`);
+
+  const movedLeads = await StageRepository.reassignLeads(
+    existing.slug,
+    moveToSlug
+  );
+  await StageRepository.softDeleteById(id);
+
+  return { deleted: String(id), movedLeads, movedTo: moveToSlug };
+};
+
+module.exports = {
+  getAllStages,
+  createStage,
+  updateStage,
+  reorderStages,
+  deleteStage,
+};

--- a/services/StageService.js
+++ b/services/StageService.js
@@ -1,0 +1,6 @@
+const StageRepository = require("../repositories/StageRepository");
+const getAllStages = async () => {
+  const stages = await StageRepository.findAll();
+  return { stages };
+};
+module.exports = { getAllStages };


### PR DESCRIPTION
Full dynamic-stages backend in one PR (4 sequential commits):
- Stage 1 (71eb9b1): Stage collection + GET /stages + seed of current 3 stages
- Stage 2 (85a3c98): removed Enquiry.stage enum, moved validation to app-code against the Stage collection. Only CRM writes Enquiry.stage (venue stage is on the separate VenueEnquiry model). Stored values unaffected.
- Stage 3a (e6e6dd9): stage management routes — create/rename/reorder/delete-with-reassign, RBAC-gated (settings:edit:all / settings:delete:all). Delete forces a destination + reassigns leads; blocks deleting system/last stage.
- Stage 3b (825fab5): ActivityLog collection + GET /activity, logs stage actions, fire-and-safe.

CRM-owned + additive. Verified locally (verify scripts + live HTTP). Staging integration only — not deployed to prod.