### PR TITLE
feat: disqualify + approval backend with reopen

### DIFF
--- a/controllers/disqualify.js
+++ b/controllers/disqualify.js
@@ -1,0 +1,90 @@
+const EnquiryService = require("../services/EnquiryService");
+const EnquiryRepository = require("../repositories/EnquiryRepository");
+const AdminRepository = require("../repositories/AdminRepository");
+const RoleRepository = require("../repositories/RoleRepository");
+const { permissionSatisfies } = require("../middlewares/requirePermission");
+
+// Walk UP the assigned admin's reportingManagerId chain and check whether `actorId`
+// appears anywhere in it (i.e. is the assigned person's manager, transitively).
+// Depth-capped and cycle-safe.
+const isManagerOfAssigned = async (actorId, assignedToId) => {
+  if (!actorId || !assignedToId) return false;
+  let currentId = assignedToId;
+  const seen = new Set();
+  for (let depth = 0; depth < 10 && currentId; depth++) {
+    const key = String(currentId);
+    if (seen.has(key)) break;
+    seen.add(key);
+    const admin = await AdminRepository.findById(currentId);
+    if (!admin || !admin.reportingManagerId) break;
+    if (String(admin.reportingManagerId) === String(actorId)) return true;
+    currentId = admin.reportingManagerId;
+  }
+  return false;
+};
+
+// Does this admin's role grant a leads:approve permission at any scope?
+// (own is the lowest rank, so any leads:approve:* — or a broader wildcard — satisfies it.)
+const actorHasApprovePermission = async (actorId) => {
+  if (!actorId) return false;
+  const admin = await AdminRepository.findById(actorId);
+  if (!admin || !admin.roleId) return false;
+  const role = await RoleRepository.findById(admin.roleId);
+  if (!role || !Array.isArray(role.permissions)) return false;
+  return permissionSatisfies(role.permissions, "leads:approve:own").allowed;
+};
+
+// POST /enquiry/:_id/disqualify
+const RequestDisqualify = async (req, res) => {
+  try {
+    const updated = await EnquiryService.requestDisqualification(
+      req.params._id,
+      { reason: req.body.reason, note: req.body.note },
+      req.auth.user_id
+    );
+    res.status(200).json(updated);
+  } catch (error) {
+    const status = error.status || 500;
+    const message = status === 500 ? "Server error" : error.message;
+    res.status(status).json({ message });
+  }
+};
+
+// PUT /enquiry/:_id/disqualify-decision
+// Eligibility is computed here (no requirePermission gate on the route) so the assigned
+// person's MANAGER can approve even without a broad leads:approve permission.
+const DecideDisqualify = async (req, res) => {
+  try {
+    const actorId = req.auth.user_id;
+    const enquiry = await EnquiryRepository.findById(req.params._id);
+    if (!enquiry) {
+      return res.status(404).json({ message: "Enquiry not found" });
+    }
+
+    const canApprove_permission = await actorHasApprovePermission(actorId);
+    const canApprove_manager = await isManagerOfAssigned(
+      actorId,
+      enquiry.assignedTo
+    );
+    const canApprove = canApprove_permission || canApprove_manager;
+
+    const updated = await EnquiryService.decideDisqualification(
+      req.params._id,
+      { decision: req.body.decision, note: req.body.note },
+      actorId,
+      canApprove
+    );
+    res.status(200).json(updated);
+  } catch (error) {
+    const status = error.status || 500;
+    const message = status === 500 ? "Server error" : error.message;
+    res.status(status).json({ message });
+  }
+};
+
+module.exports = {
+  RequestDisqualify,
+  DecideDisqualify,
+  isManagerOfAssigned,
+  actorHasApprovePermission,
+};

--- a/models/Enquiry.js
+++ b/models/Enquiry.js
@@ -61,6 +61,20 @@ const EnquirySchema = new mongoose.Schema(
       type: String,
       default: null,
     },
+    // Wedsy OS disqualify + approval (Stage 3a — additive only). isLost above is unchanged.
+    lostStatus: {
+      type: String,
+      enum: ["none", "pending", "approved", "rejected"],
+      default: "none",
+    },
+    lostReason: { type: String, default: "" },
+    lostNote: { type: String, default: "" },
+    lostRequestedBy: { type: ObjectId, ref: "Admin", default: null },
+    lostRequestedAt: { type: Date, default: null },
+    lostDecidedBy: { type: ObjectId, ref: "Admin", default: null },
+    lostDecidedAt: { type: Date, default: null },
+    lostDecisionNote: { type: String, default: "" },
+    stageBeforeLost: { type: String, default: "" },
   },
   { timestamps: true }
 );

--- a/repositories/EnquiryRepository.js
+++ b/repositories/EnquiryRepository.js
@@ -24,8 +24,18 @@ const updateAssignedToById = async (_id, assignedTo, updatedBy) => {
   );
 };
 
+// Set arbitrary fields on an enquiry by _id. Returns the updated document or null.
+const updateFieldsById = async (_id, fields) => {
+  return await Enquiry.findByIdAndUpdate(
+    _id,
+    { $set: fields },
+    { new: true, runValidators: true, context: "query" }
+  );
+};
+
 module.exports = {
   findById,
   updateStageById,
   updateAssignedToById,
+  updateFieldsById,
 };

--- a/routes/enquiry.js
+++ b/routes/enquiry.js
@@ -3,7 +3,9 @@ const router = express.Router();
 
 const enquiry = require("../controllers/enquiry");
 const enquiryPipeline = require("../controllers/enquiry-pipeline");
+const disqualify = require("../controllers/disqualify");
 const { CheckLogin, CheckAdminLogin } = require("../middlewares/auth");
+const { requirePermission } = require("../middlewares/requirePermission");
 
 router.post("/", enquiry.CreateNew);
 router.get("/", CheckAdminLogin, enquiry.GetAll);
@@ -27,5 +29,18 @@ router.put("/:_id/notes", CheckAdminLogin, enquiry.UpdateNotes);
 router.put("/:_id/call", CheckAdminLogin, enquiry.UpdateCallSchedule);
 router.put("/:_id/stage", CheckAdminLogin, enquiryPipeline.UpdateStage);
 router.put("/:_id/assign", CheckAdminLogin, enquiryPipeline.UpdateAssignedTo);
+// Requesting a disqualification needs edit rights on the lead (Sales Executive has leads:edit:own).
+router.post(
+  "/:_id/disqualify",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own"),
+  disqualify.RequestDisqualify
+);
+// No requirePermission here — eligibility (manager OR leads:approve) is computed in the controller.
+router.put(
+  "/:_id/disqualify-decision",
+  CheckAdminLogin,
+  disqualify.DecideDisqualify
+);
 
 module.exports = router;

--- a/scripts/scrape-wmg-airport-venues.js
+++ b/scripts/scrape-wmg-airport-venues.js
@@ -1,0 +1,716 @@
+/* eslint-disable no-console */
+require("dotenv").config();
+const mongoose = require("mongoose");
+const puppeteer = require("puppeteer");
+
+const Venue = require("../models/Venue");
+
+const MONGO_URI = process.env.MONGODB_ATLAS_URL || process.env.DATABASE_URL;
+if (!MONGO_URI) {
+  console.error("MONGODB_ATLAS_URL or DATABASE_URL must be set");
+  process.exit(1);
+}
+
+// Location-based listing pages on WedMeGood. Each is paginated independently;
+// cross-listing duplicates (e.g. a Yelahanka venue also tagged North) are
+// deduped on normalized name before we visit detail pages.
+const LISTING_URLS = [
+  "https://www.wedmegood.com/vendors/bangalore/wedding-venues/near-bangalore-airport/",
+  "https://www.wedmegood.com/vendors/bangalore/wedding-venues/bannerghatta-main-road/",
+  "https://www.wedmegood.com/vendors/bangalore/wedding-venues/yelahanka/",
+  "https://www.wedmegood.com/vendors/bangalore/wedding-venues/whitefield/",
+  "https://www.wedmegood.com/vendors/bangalore/wedding-venues/sarjapur-road/",
+  "https://www.wedmegood.com/vendors/bangalore/wedding-venues/hebbal/",
+  "https://www.wedmegood.com/vendors/bangalore/wedding-venues/koramangala/",
+  "https://www.wedmegood.com/vendors/bangalore/wedding-venues/jp-nagar/",
+  "https://www.wedmegood.com/vendors/bangalore/wedding-venues/electronic-city/",
+  "https://www.wedmegood.com/vendors/bangalore/wedding-venues/north-bangalore/",
+  "https://www.wedmegood.com/vendors/bangalore/wedding-venues/south-bangalore/",
+];
+
+const DIRECT_DETAIL_URLS = [
+  "https://www.wedmegood.com/wedding-venues/Crown-Estate-25860475",
+  "https://www.wedmegood.com/wedding-venues/ritam--the-wedding-venue--24885789",
+];
+
+const HOTEL_CHAINS = [
+  "taj", "itc", "marriott", "radisson", "sheraton", "leela", "oberoi",
+  "hyatt", "hilton", "westin", "novotel", "holiday inn", "courtyard",
+  "vivanta", "trident",
+];
+
+const UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function normalizeName(name) {
+  if (!name) return "";
+  return name
+    .toLowerCase()
+    .replace(/^the\s+/i, "")
+    .replace(/^a\s+/i, "")
+    .replace(/[^a-z0-9 ]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function generateSlug(name) {
+  return String(name || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+}
+
+function classifyVenueType(name, description) {
+  const text = (name + " " + (description || "")).toLowerCase();
+  if (HOTEL_CHAINS.some((h) => text.includes(h))) return "hotel";
+  if (/banquet|hall|convention/.test(text)) return "banquet_hall";
+  if (/\bclub\b|golf/.test(text)) return "club";
+  if (/farmhouse|farm\b/.test(text)) return "farmhouse";
+  return "resort";
+}
+
+function escapeRegex(s) {
+  return String(s).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// WMG detail URLs look like /wedding-venues/<slug>-<numeric-id>.
+// Derive a human-ish name from that slug as a fallback.
+function nameFromDetailUrl(url) {
+  try {
+    const u = new URL(url);
+    const last = u.pathname.split("/").filter(Boolean).pop() || "";
+    const stripped = last.replace(/-\d+$/, "").replace(/-+/g, " ").replace(/\s+/g, " ").trim();
+    if (!stripped) return "";
+    return stripped
+      .split(" ")
+      .map((w) => (w.length ? w[0].toUpperCase() + w.slice(1).toLowerCase() : w))
+      .join(" ");
+  } catch (_) {
+    return "";
+  }
+}
+
+// Names that are clearly nav/category/section headings, not venues.
+function isSectionOrCategoryName(name) {
+  if (!name) return true;
+  const n = name.trim();
+  if (n.length < 3 || n.length > 90) return true;
+  const low = n.toLowerCase();
+  // Category nav labels.
+  if (/^(bridal wear|photographers?|mehendi artists?|makeup artists?|wedding planners?|invitations?|jewellery|videographers?|wedding cards?)$/i.test(low)) return true;
+  // Listing-page section headings.
+  if (/^(wedding venues|best .*for wedding|venues in |top \d+|browse |explore |all venues)/i.test(low)) return true;
+  // Trailing count parentheses: "Foo (93)".
+  if (/\(\s*\d+\s*\)\s*$/.test(n)) return true;
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Scrape listing — collect cards across all pages
+// ---------------------------------------------------------------------------
+
+async function scrapeListing(browser, url) {
+  console.log(`\n[listing] ${url}`);
+  const page = await browser.newPage();
+  await page.setUserAgent(UA);
+  const all = [];
+  const seen = new Set();
+
+  // Capture any query params (e.g. ?venue_type=64,67) on the original URL.
+  // WMG's pagination links sometimes drop these — we re-attach them after
+  // each Next-button navigation so the filter survives across pages.
+  let originalParams = null;
+  try {
+    const parsed = new URL(url);
+    if (parsed.search) originalParams = parsed.searchParams;
+  } catch (_) { /* malformed URL — skip preservation */ }
+
+  try {
+    await page.goto(url, { waitUntil: "networkidle2", timeout: 90000 });
+    await sleep(2500);
+
+    // Scroll to trigger lazy-loaded tiles and bring pagination control into view.
+    for (let i = 0; i < 8; i++) {
+      await page.evaluate(() => window.scrollBy(0, window.innerHeight));
+      await sleep(700);
+    }
+
+    let pageNum = 1;
+    while (true) {
+      const cards = await page.evaluate(() => {
+        const out = [];
+        // WMG venue tiles link to /wedding-venues/<slug>-<numeric-id>.
+        const anchors = Array.from(document.querySelectorAll('a[href*="/wedding-venues/"]'));
+        const seenHref = new Set();
+        for (const a of anchors) {
+          const href = a.href;
+          if (!href || seenHref.has(href)) continue;
+          if (!/\/wedding-venues\/[^/]+-\d+\/?$/i.test(href)) continue; // skip categories / listings
+          seenHref.add(href);
+
+          // Tile cover image: nearest <img> inside the tile.
+          const tile = a.closest('[class*="card"], [class*="tile"], [class*="vendor"], li, article, div') || a;
+          const img = tile.querySelector("img");
+          let cover = "";
+          if (img) {
+            cover =
+              img.src ||
+              img.getAttribute("data-src") ||
+              img.getAttribute("data-original") ||
+              "";
+            const srcset = img.getAttribute("srcset");
+            if (!cover && srcset) cover = srcset.split(",")[0].trim().split(" ")[0];
+          }
+
+          // Name: derive from URL slug (anchor text is empty on WMG tiles).
+          let name = "";
+          try {
+            const u = new URL(href);
+            const last = u.pathname.split("/").filter(Boolean).pop() || "";
+            const stripped = last.replace(/-\d+$/, "").replace(/-+/g, " ").trim();
+            if (stripped) {
+              name = stripped
+                .split(" ")
+                .map((w) => (w.length ? w[0].toUpperCase() + w.slice(1).toLowerCase() : w))
+                .join(" ");
+            }
+          } catch (_) { /* ignore */ }
+          if (!name) continue;
+
+          // Capacity (if surfaced on the tile).
+          const tileText = (tile.innerText || "").trim();
+          const lines = tileText.split("\n").map((l) => l.trim()).filter(Boolean);
+          const capLine = lines.find((l) => /pax|guests|capacity/i.test(l));
+          let capacityMin = 0;
+          let capacityMax = 0;
+          if (capLine) {
+            const nums = capLine.match(/\d+/g);
+            if (nums && nums.length >= 2) {
+              capacityMin = parseInt(nums[0], 10);
+              capacityMax = parseInt(nums[1], 10);
+            } else if (nums && nums.length === 1) {
+              capacityMax = parseInt(nums[0], 10);
+            }
+          }
+          const address =
+            lines.find((l) => /bangalore|bengaluru/i.test(l) && l.length < 140) || "";
+
+          out.push({ name, address, coverPhoto: cover, capacityMin, capacityMax, detailUrl: href });
+        }
+        return out;
+      });
+
+      let added = 0;
+      for (const c of cards) {
+        if (isSectionOrCategoryName(c.name)) continue;
+        const key = normalizeName(c.name);
+        if (!key || seen.has(key)) continue;
+        seen.add(key);
+        all.push(c);
+        added++;
+      }
+      console.log(`  [listing] page ${pageNum}: +${added} (total ${all.length})`);
+
+      const advanced = await page.evaluate(() => {
+        const btns = Array.from(document.querySelectorAll("a, button"));
+        const next = btns.find((el) => {
+          const t = (el.innerText || el.getAttribute("aria-label") || "").trim().toLowerCase();
+          return /^next$|^›$|^>$|next page/.test(t) && !el.hasAttribute("disabled");
+        });
+        if (next) {
+          next.scrollIntoView();
+          next.click();
+          return true;
+        }
+        return false;
+      });
+
+      if (!advanced) break;
+      await sleep(2500);
+
+      // Re-attach any query params that WMG's Next click stripped off.
+      if (originalParams) {
+        try {
+          const current = new URL(page.url());
+          let missing = false;
+          for (const [k, v] of originalParams) {
+            if (!current.searchParams.has(k)) {
+              current.searchParams.set(k, v);
+              missing = true;
+            }
+          }
+          if (missing) {
+            await page.goto(current.toString(), { waitUntil: "networkidle2", timeout: 90000 });
+            await sleep(1500);
+          }
+        } catch (e) {
+          console.warn(`  [listing] could not preserve query params: ${e.message}`);
+        }
+      }
+
+      pageNum++;
+      if (pageNum > 30) break; // safety
+    }
+  } catch (err) {
+    console.warn(`[listing] error: ${err.message}`);
+  } finally {
+    await page.close();
+  }
+
+  console.log(`[listing] total unique cards: ${all.length}`);
+  return all;
+}
+
+// ---------------------------------------------------------------------------
+// Scrape one WMG detail page
+// ---------------------------------------------------------------------------
+
+async function scrapeDetail(browser, url) {
+  const page = await browser.newPage();
+  await page.setUserAgent(UA);
+  try {
+    const resp = await page.goto(url, { waitUntil: "domcontentloaded", timeout: 60000 });
+    if (resp && (resp.status() === 403 || resp.status() === 429 || resp.status() >= 500)) {
+      const blocked = await page.evaluate(() => /cloudflare|error 1015|rate.?limit|attention required/i.test(document.body.innerText || ""));
+      if (blocked) return { __blocked: true, status: resp.status() };
+    }
+    await sleep(1500);
+    // Even on a 200, Cloudflare's challenge page can render — sniff body text.
+    const blockedBody = await page.evaluate(() => /error 1015|cloudflare ray id|attention required|just a moment\./i.test(document.body.innerText || ""));
+    if (blockedBody) return { __blocked: true, status: resp ? resp.status() : 0 };
+
+    // Click any "Read More" / "Show more" toggles so the full description renders.
+    try {
+      const clicked = await page.evaluate(() => {
+        const els = Array.from(document.querySelectorAll("button, a, span, div"));
+        let did = false;
+        for (const el of els) {
+          const t = (el.innerText || "").trim().toLowerCase();
+          if (/^(read more|show more|view more)$/.test(t)) {
+            el.click();
+            did = true;
+          }
+        }
+        return did;
+      });
+      if (clicked) await sleep(800);
+    } catch (_) { /* ignore */ }
+
+    // Small scroll to nudge venue-gallery lazy-loading without scrolling so
+    // far that the "Shop Bridal Wear" widget at the bottom kicks in and
+    // floods the page with unrelated catalog content.
+    await page.evaluate(() => window.scrollBy(0, 800));
+    await sleep(400);
+    await page.evaluate(() => window.scrollBy(0, 800));
+    await sleep(400);
+
+    return await page.evaluate(() => {
+      // ---- Name ----
+      // WMG detail pages have exactly one h1 = the venue name.
+      const nameEl = document.querySelector("h1");
+      const name = ((nameEl?.innerText || "").trim().split("\n")[0]) || "";
+
+      // ---- Address ----
+      // h2 of the form: "About <Name> - Wedding Venues, <area>, Bangalore"
+      const aboutH2 = Array.from(document.querySelectorAll("h2")).find((h) =>
+        /^about\s+/i.test((h.innerText || "").trim())
+      );
+      let address = "";
+      if (aboutH2) {
+        const t = (aboutH2.innerText || "").replace(/\s+/g, " ").trim();
+        // Take everything after the first " - " (or the venue name).
+        const dashSplit = t.split(/\s-\s/);
+        const tail = dashSplit.length > 1 ? dashSplit.slice(1).join(" - ") : t;
+        // Trim "Wedding Venues," prefix if present.
+        address = tail.replace(/^Wedding Venues,?\s*/i, "").trim();
+      }
+      if (!address) {
+        // Fallback: line in body containing Bangalore/Bengaluru, > 15 chars, that doesn't look nav.
+        const allLines = (document.body.innerText || "").split("\n").map((l) => l.trim()).filter(Boolean);
+        address = allLines.find(
+          (l) =>
+            /bangalore|bengaluru/i.test(l) &&
+            l.length > 15 &&
+            l.length < 200 &&
+            !/^(home|venues|vendors|photos|blog|real weddings|near|in|all|wedding planners?)/i.test(l) &&
+            !/download app|favourite wedding/i.test(l)
+        ) || "";
+      }
+
+      // ---- Description ----
+      // Strictly: walk siblings of the "About <name>" h2. No greedy fallback —
+      // we'd rather return empty than poison existing data with chrome text.
+      const BAD_DESC = /download app|favourite wedding planning|write a review|wedmegood is your personal|browse through the site|wedding inspiration|copyright|terms (of|&) (use|service)|privacy policy|all rights reserved|follow us|bridal wear|crop top|lehenga|sherwani|saree by|gown by|amaltas couture|sitara by|wedcommerce|cloudflare|error 1015|rate.?limit/i;
+      let description = "";
+      if (aboutH2) {
+        let chunks = [];
+        let sib = aboutH2.nextElementSibling;
+        while (sib && !/^h[12]$/i.test(sib.tagName)) {
+          const t = (sib.innerText || "").trim();
+          if (t && !BAD_DESC.test(t) && t.length < 4000) chunks.push(t);
+          sib = sib.nextElementSibling;
+        }
+        description = chunks.join("\n\n").trim();
+      }
+      // Final venue-specificity check: require the description to mention either
+      // the venue name OR a location word, and exceed a minimum length.
+      const venueNameLow = (name || "").toLowerCase();
+      const looksVenueSpecific =
+        description.length > 80 &&
+        (
+          (venueNameLow && description.toLowerCase().includes(venueNameLow.split(" ")[0])) ||
+          /bangalore|bengaluru|karnataka|venue|wedding/i.test(description)
+        ) &&
+        !BAD_DESC.test(description);
+      if (!looksVenueSpecific) description = "";
+
+      // ---- Photos ----
+      // Real venue photos live on image.wedmegood.com under /resized/*X/<digits>/...
+      // UI assets are under /resized/*/images/icons/ or /images/<file>.
+      // Bridal-wear catalog images live under /wedcommerce/media/catalog/product/.
+      const BAD_PHOTO = /\/images\/(icons|logos|svgs|illustrations|wmg-)|badge|logo|sprite|placeholder|app-store|play-store|service-badge|search_icon|write_a_review|download_app|WMG-logo|wmg-|wedcommerce|catalog\/product/i;
+      const photos = Array.from(document.querySelectorAll("img"))
+        .map((img) => img.src || img.getAttribute("data-src") || img.getAttribute("data-original") || "")
+        .filter(
+          (u) =>
+            u &&
+            /^https?:/.test(u) &&
+            /\.(jpe?g|png|webp)(\?|$)/i.test(u) &&
+            /image\.wedmegood\.com|images\.wedmegood\.com/i.test(u) &&
+            !BAD_PHOTO.test(u)
+        );
+      const uniquePhotos = Array.from(new Set(photos));
+      const coverPhoto = uniquePhotos[0] || "";
+
+      // Whole-body lines for downstream field heuristics.
+      const lines = (document.body.innerText || "").split("\n").map((l) => l.trim()).filter(Boolean);
+
+      // Phone: prefer a tel: link, then a phone-shaped line.
+      let phone = "";
+      const telLink = document.querySelector('a[href^="tel:"]');
+      if (telLink) phone = telLink.getAttribute("href").replace(/^tel:/, "").trim();
+      if (!phone) {
+        const phoneLine = lines.find((l) => /(\+91|^0?[6-9])\s?\d{4,}/.test(l) && l.length < 40);
+        if (phoneLine) {
+          const m = phoneLine.match(/\+?\d[\d\s\-]{7,}/);
+          if (m) phone = m[0].trim();
+        }
+      }
+
+      // Per-plate veg / non-veg pricing.
+      let priceVeg = 0;
+      let priceNonVeg = 0;
+      for (const l of lines) {
+        const low = l.toLowerCase();
+        if (/per\s*plate/.test(low) || /veg.*₹|veg.*rs|veg.*inr/.test(low) || /₹.*veg/.test(low)) {
+          if (/non[\s-]?veg/.test(low)) {
+            const m = l.match(/(?:₹|rs\.?|inr)\s*([\d,]+)/i);
+            if (m) priceNonVeg = parseInt(m[1].replace(/,/g, ""), 10);
+          } else if (/veg/.test(low)) {
+            const m = l.match(/(?:₹|rs\.?|inr)\s*([\d,]+)/i);
+            if (m) priceVeg = parseInt(m[1].replace(/,/g, ""), 10);
+          }
+        }
+      }
+
+      // Rooms count: line like "50 Rooms" or "Rooms: 50".
+      let rooms = 0;
+      const roomLine = lines.find((l) => /\brooms?\b/i.test(l) && /\d/.test(l) && l.length < 80);
+      if (roomLine) {
+        const m = roomLine.match(/\d+/);
+        if (m) rooms = parseInt(m[0], 10);
+      }
+
+      // Capacity.
+      let capacityMin = 0;
+      let capacityMax = 0;
+      const capLine = lines.find((l) => /pax|guests|capacity/i.test(l) && /\d/.test(l));
+      if (capLine) {
+        const nums = capLine.match(/\d+/g);
+        if (nums && nums.length >= 2) {
+          capacityMin = parseInt(nums[0], 10);
+          capacityMax = parseInt(nums[1], 10);
+        } else if (nums && nums.length === 1) {
+          capacityMax = parseInt(nums[0], 10);
+        }
+      }
+
+      // Venue type hint from the page (e.g. "Banquet Hall", "Resort").
+      let typeHint = "";
+      const typeLine = lines.find((l) =>
+        /\b(resort|farmhouse|farm house|banquet|hotel|club|hall|villa|heritage)\b/i.test(l) &&
+        l.length < 60
+      );
+      if (typeLine) typeHint = typeLine;
+
+      return {
+        name,
+        address,
+        description,
+        photos: uniquePhotos,
+        coverPhoto,
+        phone,
+        priceVeg,
+        priceNonVeg,
+        rooms,
+        capacityMin,
+        capacityMax,
+        typeHint,
+      };
+    });
+  } finally {
+    await page.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Upsert into MongoDB
+// ---------------------------------------------------------------------------
+
+async function upsertVenue(scraped) {
+  const name = scraped.name?.trim();
+  if (!name) return { skipped: true };
+
+  // Case-insensitive exact match on name.
+  const existing = await Venue.findOne({
+    name: { $regex: new RegExp(`^${escapeRegex(name)}$`, "i") },
+  });
+
+  const venueType = classifyVenueType(name, scraped.description || scraped.typeHint || "");
+
+  const doc = {
+    name,
+    venueType,
+    city: "Bangalore",
+    address: scraped.address || existing?.address || "",
+    description: scraped.description || existing?.description || "",
+    coverPhoto: scraped.coverPhoto || existing?.coverPhoto || "",
+    phone: scraped.phone || existing?.phone || "",
+  };
+
+  // Photos — merge with existing.
+  if (Array.isArray(scraped.photos) && scraped.photos.length) {
+    doc.photos = {
+      venue: Array.from(new Set([...(scraped.photos || []), ...(existing?.photos?.venue || [])])),
+      decor: existing?.photos?.decor || [],
+      rooms: existing?.photos?.rooms || [],
+      spaces: existing?.photos?.spaces || [],
+    };
+  }
+
+  // Per-plate pricing.
+  if (scraped.priceVeg || scraped.priceNonVeg) {
+    doc.pricing = {
+      ...(existing?.pricing || {}),
+      perPlate: {
+        veg: scraped.priceVeg || existing?.pricing?.perPlate?.veg || 0,
+        nonVeg: scraped.priceNonVeg || existing?.pricing?.perPlate?.nonVeg || 0,
+      },
+    };
+  }
+
+  // Rooms → accommodation.
+  if (scraped.rooms) {
+    doc.accommodation = {
+      available: true,
+      totalCapacity: existing?.accommodation?.totalCapacity || 0,
+      roomTypes: (existing?.accommodation?.roomTypes?.length)
+        ? existing.accommodation.roomTypes
+        : [{
+            name: "Standard",
+            count: scraped.rooms,
+            occupancyPerRoom: 2,
+            maxPeoplePerRoom: 2,
+            pricePerNight: 0,
+            isAC: true,
+            description: "",
+            photos: [],
+          }],
+    };
+  }
+
+  // Capacity → spaces[0].
+  if (scraped.capacityMax && (!existing?.spaces || existing.spaces.length === 0)) {
+    doc.spaces = [{
+      name: "Main Hall",
+      type: "indoor",
+      capacitySeated: scraped.capacityMax,
+      capacityStanding: 0,
+      bestFor: [],
+      description: "",
+      photos: [],
+    }];
+  }
+
+  // scrapedFrom: add "wedmegood" without duplicates.
+  doc.scrapedFrom = Array.from(new Set([...(existing?.scrapedFrom || []), "wedmegood"]));
+
+  if (existing) {
+    await Venue.updateOne({ _id: existing._id }, { $set: doc });
+    return { updated: true, name };
+  }
+
+  // New venue — pick a slug.
+  let slug = generateSlug(name) || `venue-${Date.now()}`;
+  let n = 1;
+  while (await Venue.exists({ slug })) {
+    slug = `${generateSlug(name)}-${n++}`;
+    if (n > 50) { slug = `${generateSlug(name)}-${Date.now()}`; break; }
+  }
+
+  // Auto-publish rule.
+  const canPublish = doc.name && doc.address && doc.coverPhoto;
+  doc.slug = slug;
+  doc.status = canPublish ? "published" : "draft";
+
+  await Venue.create(doc);
+  return { created: true, published: canPublish, name };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+(async () => {
+  console.log("Connecting to MongoDB…");
+  await mongoose.connect(MONGO_URI);
+
+  console.log("Launching Puppeteer…");
+  const browser = await puppeteer.launch({ headless: true, args: ["--no-sandbox"] });
+
+  let scraped = 0;
+  let created = 0;
+  let updated = 0;
+  let published = 0;
+  let skippedComplete = 0;
+
+  try {
+    // 1) Walk every location-based listing and merge their cards. Dedupe on
+    //    normalized name so a venue appearing in both e.g. "yelahanka" and
+    //    "north-bangalore" is only visited once.
+    const cardsByKey = new Map();
+    for (const listingUrl of LISTING_URLS) {
+      try {
+        const cards = await scrapeListing(browser, listingUrl);
+        for (const c of cards) {
+          const key = normalizeName(c.name);
+          if (!key || cardsByKey.has(key)) continue;
+          cardsByKey.set(key, c);
+        }
+      } catch (err) {
+        console.warn(`[listing] ${listingUrl} failed: ${err.message}`);
+      }
+    }
+    const allCards = Array.from(cardsByKey.values());
+    console.log(`\n[overall] ${allCards.length} unique cards across ${LISTING_URLS.length} listings`);
+
+    const detailJobs = [
+      ...allCards.map((c) => ({ url: c.detailUrl, hint: c })),
+      ...DIRECT_DETAIL_URLS.map((u) => ({ url: u, hint: null })),
+    ];
+
+    console.log(`\nVisiting ${detailJobs.length} detail page(s)…`);
+
+    let i = 0;
+    for (const job of detailJobs) {
+      i++;
+      try {
+        // Skip if we already have a complete WMG-sourced record for this venue.
+        // Saves a Puppeteer load per skip — the main thing keeping us under
+        // Cloudflare's rate limit on big runs.
+        const candidateName = job.hint?.name || nameFromDetailUrl(job.url);
+        if (candidateName) {
+          const existing = await Venue.findOne({
+            name: { $regex: new RegExp(`^${escapeRegex(candidateName)}$`, "i") },
+          }).select("scrapedFrom description coverPhoto").lean();
+          // Relaxed for this run: skip anything already touched by WMG that has
+          // a cover photo, regardless of description state. Lets us blow past
+          // the ~110 already-processed venues and resume at the error-streak
+          // ones that never got written.
+          if (
+            existing &&
+            Array.isArray(existing.scrapedFrom) &&
+            existing.scrapedFrom.includes("wedmegood") &&
+            existing.coverPhoto && existing.coverPhoto.trim()
+          ) {
+            skippedComplete++;
+            console.log(`  [${i}/${detailJobs.length}] · skip (already complete): ${candidateName}`);
+            continue;
+          }
+        }
+
+        const detail = await scrapeDetail(browser, job.url);
+
+        // Cloudflare or other block: skip without writing anything.
+        if (detail && detail.__blocked) {
+          console.warn(`  [${i}/${detailJobs.length}] BLOCKED by Cloudflare (status ${detail.status}) on ${job.url} — not writing`);
+          // Back off harder before continuing.
+          await sleep(5000);
+          continue;
+        }
+
+        // Name priority: listing card > URL slug > detail page heading.
+        // The detail-page heading is unreliable because the first h1/h2 on WMG is
+        // a sidebar category label ("Bridal Wear") rather than the venue name.
+        let resolvedName = job.hint?.name || nameFromDetailUrl(job.url) || detail.name || "";
+
+        // Refuse to upsert anything that still looks like a nav/category label.
+        if (!resolvedName || isSectionOrCategoryName(resolvedName)) {
+          console.warn(`  [${i}/${detailJobs.length}] rejected non-venue name "${resolvedName}" for ${job.url} — skipping`);
+          continue;
+        }
+
+        const merged = {
+          name: resolvedName,
+          address: detail.address || job.hint?.address || "",
+          coverPhoto: detail.coverPhoto || job.hint?.coverPhoto || "",
+          description: detail.description || "",
+          photos: detail.photos || [],
+          phone: detail.phone || "",
+          priceVeg: detail.priceVeg || 0,
+          priceNonVeg: detail.priceNonVeg || 0,
+          rooms: detail.rooms || 0,
+          capacityMin: detail.capacityMin || job.hint?.capacityMin || 0,
+          capacityMax: detail.capacityMax || job.hint?.capacityMax || 0,
+          typeHint: detail.typeHint || "",
+        };
+
+        scraped++;
+        const res = await upsertVenue(merged);
+        if (res.created) {
+          created++;
+          if (res.published) published++;
+          console.log(`  [${i}/${detailJobs.length}] + created${res.published ? " (published)" : " (draft)"}: ${res.name}`);
+        } else if (res.updated) {
+          updated++;
+          console.log(`  [${i}/${detailJobs.length}] ~ updated: ${res.name}`);
+        } else {
+          console.log(`  [${i}/${detailJobs.length}] · skipped: ${job.url}`);
+        }
+      } catch (err) {
+        console.warn(`  [${i}/${detailJobs.length}] error on ${job.url}: ${err.message}`);
+      }
+      await sleep(9000);
+    }
+  } finally {
+    await browser.close();
+    await mongoose.disconnect();
+  }
+
+  console.log("\n=== Summary ===");
+  console.log(`Total scraped:     ${scraped}`);
+  console.log(`New added:         ${created}`);
+  console.log(`Updated:           ${updated}`);
+  console.log(`Published:         ${published}`);
+  console.log(`Skipped (complete): ${skippedComplete}`);
+})().catch((err) => {
+  console.error("Failed:", err);
+  process.exit(1);
+});

--- a/scripts/seed-stages.js
+++ b/scripts/seed-stages.js
@@ -14,6 +14,7 @@ const SEED = [
   { name: "New", slug: "new", order: 0, color: "#4B1528", category: "open", isSystem: true },
   { name: "Contacted", slug: "contacted", order: 1, color: "#8B5A00", category: "open", isSystem: false },
   { name: "Meeting Scheduled", slug: "meeting_scheduled", order: 2, color: "#2D5F3F", category: "open", isSystem: false },
+  { name: "Lost", slug: "lost", order: 99, color: "#8B0000", category: "lost", isSystem: true },
 ];
 (async () => {
   await mongoose.connect(dbUrl);

--- a/scripts/verify-disqualify.js
+++ b/scripts/verify-disqualify.js
@@ -1,0 +1,258 @@
+/**
+ * Verify the Stage 3a disqualify + approval flow at the SERVICE layer (LOCAL DEV ONLY).
+ * Exercises requestDisqualification / decideDisqualification (approve + reject), the
+ * approver-eligibility gate (via the canApprove flag), and the updateStage interception
+ * that turns a move into a "lost"-category stage into a disqualification REQUEST.
+ *
+ * Creates its own throwaway test leads (does NOT mutate real leads) and deletes them on
+ * exit. Aborts if DATABASE_URL is not localhost.
+ *
+ * Run: node scripts/verify-disqualify.js
+ */
+
+require("dotenv").config();
+const mongoose = require("mongoose");
+const Enquiry = require("../models/Enquiry");
+const Admin = require("../models/Admin");
+const Stage = require("../models/Stage");
+const ActivityLog = require("../models/ActivityLog");
+const EnquiryService = require("../services/EnquiryService");
+
+const dbUrl = process.env.DATABASE_URL || "";
+if (!dbUrl.startsWith("mongodb://localhost")) {
+  console.error("ABORT: DATABASE_URL is not localhost.");
+  console.error(`DATABASE_URL = ${dbUrl || "(empty)"}`);
+  process.exit(1);
+}
+
+let pass = 0;
+let fail = 0;
+const check = (label, cond) => {
+  console.log(`${cond ? "PASS" : "FAIL"}  ${label}`);
+  cond ? pass++ : fail++;
+};
+const expectThrow = async (label, status, fn) => {
+  try {
+    await fn();
+    check(`${label} (expected ${status} throw)`, false);
+  } catch (e) {
+    check(`${label} -> ${e.status || "?"} ${e.message}`, e.status === status);
+  }
+};
+
+const PHONE_1 = "9990000001";
+const PHONE_2 = "9990000002";
+const PHONE_3 = "9990000003";
+
+const reopenedLogCount = async (entityId) =>
+  ActivityLog.countDocuments({
+    entityType: "lead",
+    action: "lead.reopened",
+    entityId: String(entityId),
+  });
+const latestReopenedLog = async (entityId) =>
+  ActivityLog.findOne({
+    entityType: "lead",
+    action: "lead.reopened",
+    entityId: String(entityId),
+  })
+    .sort({ createdAt: -1 })
+    .lean();
+
+const mkLead = async (phone, name, assignedTo) =>
+  Enquiry.create({
+    name,
+    phone,
+    verified: true,
+    isInterested: false,
+    isLost: false,
+    source: "VerifyScript",
+    stage: "contacted",
+    assignedTo,
+  });
+
+(async () => {
+  let lead1Id = null;
+  let lead2Id = null;
+  let lead3Id = null;
+  try {
+    await mongoose.connect(dbUrl);
+    console.log(`Connected to ${dbUrl}\n`);
+
+    // ---------- Step 1: ensure "lost" stage exists (idempotent upsert) ----------
+    console.log("=== Step 1: ensure 'lost' stage ===");
+    await Stage.updateOne(
+      { slug: "lost" },
+      {
+        $set: {
+          name: "Lost",
+          slug: "lost",
+          order: 99,
+          color: "#8B0000",
+          category: "lost",
+          isSystem: true,
+          deletedAt: null,
+        },
+      },
+      { upsert: true }
+    );
+    const lostStage = await Stage.findOne({ slug: "lost", deletedAt: null }).lean();
+    check("'lost' stage exists with category 'lost'", !!lostStage && lostStage.category === "lost");
+
+    // ---------- Step 2: create test leads ----------
+    console.log("\n=== Step 2: create test leads (stage='contacted') ===");
+    const anAdmin = await Admin.findOne({}).lean();
+    const adminId = anAdmin ? anAdmin._id : new mongoose.Types.ObjectId();
+    const mgrId = new mongoose.Types.ObjectId(); // a stand-in approver id
+    // clean any leftovers from a previous run first
+    await Enquiry.deleteMany({ phone: { $in: [PHONE_1, PHONE_2, PHONE_3] } });
+    const lead1 = await mkLead(PHONE_1, "Verify Lead One", adminId);
+    const lead2 = await mkLead(PHONE_2, "Verify Lead Two", adminId);
+    lead1Id = lead1._id;
+    lead2Id = lead2._id;
+    check("lead1 created (stage='contacted')", lead1.stage === "contacted");
+    check("lead2 created (stage='contacted')", lead2.stage === "contacted");
+
+    // ---------- Step 3: request disqualification ----------
+    console.log("\n=== Step 3: requestDisqualification(reason='budget') ===");
+    let r = await EnquiryService.requestDisqualification(
+      String(lead1Id),
+      { reason: "budget", note: "test" },
+      adminId
+    );
+    check("lostStatus='pending'", r.lostStatus === "pending");
+    check("stageBeforeLost='contacted'", r.stageBeforeLost === "contacted");
+    check("lostReason='budget'", r.lostReason === "budget");
+    check("lostNote='test'", r.lostNote === "test");
+    check("stage unchanged (still 'contacted')", r.stage === "contacted");
+
+    // ---------- Step 4: re-request while pending -> 400 ----------
+    console.log("\n=== Step 4: re-request while pending rejected ===");
+    await expectThrow("re-request rejected", 400, () =>
+      EnquiryService.requestDisqualification(String(lead1Id), { reason: "budget" }, adminId)
+    );
+
+    // ---------- Step 5: reject -> restores stage ----------
+    console.log("\n=== Step 5: decide reject (canApprove=true) ===");
+    r = await EnquiryService.decideDisqualification(
+      String(lead1Id),
+      { decision: "reject", note: "keep it" },
+      mgrId,
+      true
+    );
+    check("lostStatus='rejected'", r.lostStatus === "rejected");
+    check("stage restored to 'contacted'", r.stage === "contacted");
+    check("isLost still false", r.isLost === false);
+
+    // ---------- Step 6: request again (allowed after rejection) ----------
+    console.log("\n=== Step 6: request again after rejection ===");
+    r = await EnquiryService.requestDisqualification(
+      String(lead1Id),
+      { reason: "competitor", note: "second try" },
+      adminId
+    );
+    check("lostStatus='pending' again", r.lostStatus === "pending");
+    check("stageBeforeLost='contacted'", r.stageBeforeLost === "contacted");
+
+    // ---------- Step 7: decide with canApprove=false -> 403 ----------
+    console.log("\n=== Step 7: decide approve with canApprove=false rejected ===");
+    await expectThrow("ineligible approver rejected", 403, () =>
+      EnquiryService.decideDisqualification(
+        String(lead1Id),
+        { decision: "approve" },
+        mgrId,
+        false
+      )
+    );
+
+    // ---------- Step 8: approve -> lost ----------
+    console.log("\n=== Step 8: decide approve (canApprove=true) ===");
+    r = await EnquiryService.decideDisqualification(
+      String(lead1Id),
+      { decision: "approve", note: "agreed" },
+      mgrId,
+      true
+    );
+    check("lostStatus='approved'", r.lostStatus === "approved");
+    check("stage='lost'", r.stage === "lost");
+    check("isLost=true", r.isLost === true);
+
+    // ---------- Step 9: updateStage interception (move to 'lost' -> request) ----------
+    console.log("\n=== Step 9: updateStage(lead2,'lost') intercepted into a request ===");
+    r = await EnquiryService.updateStage(String(lead2Id), "lost", adminId);
+    check("interception -> lostStatus='pending'", r.lostStatus === "pending");
+    check("interception did NOT set stage='lost'", r.stage !== "lost");
+    check("interception kept stage='contacted'", r.stage === "contacted");
+    check("interception captured stageBeforeLost='contacted'", r.stageBeforeLost === "contacted");
+
+    // ---------- Step 10: REOPEN from approved (approved-lost -> open stage) ----------
+    console.log("\n=== Step 10: updateStage(lead1,'contacted') reopens an approved-lost lead ===");
+    // lead1 is approved/lost from Step 8.
+    r = await EnquiryService.updateStage(String(lead1Id), "contacted", adminId);
+    check("reopen -> stage='contacted'", r.stage === "contacted");
+    check("reopen -> lostStatus='none'", r.lostStatus === "none");
+    check("reopen -> isLost=false", r.isLost === false);
+    check("reopen -> stageBeforeLost cleared ('')", r.stageBeforeLost === "");
+    check("reopen KEEPS historical lostReason ('competitor')", r.lostReason === "competitor");
+    check("reopen KEEPS historical lostDecidedBy", !!r.lostDecidedBy);
+    const reopenLog1 = await latestReopenedLog(lead1Id);
+    check("reopen logged 'lead.reopened' for lead1", !!reopenLog1);
+    check(
+      "reopen log meta.fromLostStatus='approved'",
+      !!reopenLog1 && reopenLog1.meta && reopenLog1.meta.fromLostStatus === "approved"
+    );
+    check(
+      "reopen log meta.toStage='contacted'",
+      !!reopenLog1 && reopenLog1.meta && reopenLog1.meta.toStage === "contacted"
+    );
+
+    // ---------- Step 11: REOPEN from pending (pending request cancelled by move-out) ----------
+    console.log("\n=== Step 11: updateStage(lead2,'new') reopens a pending lead ===");
+    // lead2 is pending from the Step 9 interception.
+    r = await EnquiryService.updateStage(String(lead2Id), "new", adminId);
+    check("pending reopen -> stage='new'", r.stage === "new");
+    check("pending reopen -> lostStatus='none'", r.lostStatus === "none");
+    check("pending reopen -> isLost=false", r.isLost === false);
+    check("pending reopen -> stageBeforeLost cleared ('')", r.stageBeforeLost === "");
+    const reopenLog2 = await latestReopenedLog(lead2Id);
+    check("pending reopen logged 'lead.reopened' for lead2", !!reopenLog2);
+    check(
+      "pending reopen log meta.fromLostStatus='pending'",
+      !!reopenLog2 && reopenLog2.meta && reopenLog2.meta.fromLostStatus === "pending"
+    );
+
+    // ---------- Step 12: SANITY — normal move on a never-lost lead (no reopen, no lost writes) ----------
+    console.log("\n=== Step 12: normal updateStage on a never-lost lead is unaffected ===");
+    const lead3 = await mkLead(PHONE_3, "Verify Lead Three", adminId);
+    lead3Id = lead3._id;
+    const reopenedBefore = await reopenedLogCount(lead3Id);
+    r = await EnquiryService.updateStage(String(lead3Id), "meeting_scheduled", adminId);
+    check("normal move -> stage='meeting_scheduled'", r.stage === "meeting_scheduled");
+    check("normal move -> lostStatus stays 'none'", r.lostStatus === "none");
+    check("normal move -> isLost stays false", r.isLost === false);
+    const reopenedAfter = await reopenedLogCount(lead3Id);
+    check("normal move logged NO 'lead.reopened'", reopenedAfter === reopenedBefore);
+
+    console.log(`\nResult: ${pass} passed, ${fail} failed.`);
+    if (fail > 0) process.exitCode = 1;
+  } catch (error) {
+    console.error("Verification error:", error);
+    process.exitCode = 1;
+  } finally {
+    // ---------- Cleanup: delete throwaway test leads + their activity logs ----------
+    const testLeadIds = [lead1Id, lead2Id, lead3Id].filter(Boolean).map(String);
+    if (lead1Id) await Enquiry.deleteOne({ _id: lead1Id }).catch(() => {});
+    if (lead2Id) await Enquiry.deleteOne({ _id: lead2Id }).catch(() => {});
+    if (lead3Id) await Enquiry.deleteOne({ _id: lead3Id }).catch(() => {});
+    await Enquiry.deleteMany({ phone: { $in: [PHONE_1, PHONE_2, PHONE_3] } }).catch(() => {});
+    if (testLeadIds.length) {
+      await ActivityLog.deleteMany({
+        entityType: "lead",
+        entityId: { $in: testLeadIds },
+      }).catch(() => {});
+    }
+    console.log("Cleaned up test leads + activity logs.");
+    await mongoose.disconnect();
+    console.log("Disconnected.");
+  }
+})();

--- a/services/EnquiryService.js
+++ b/services/EnquiryService.js
@@ -2,36 +2,192 @@ const mongoose = require("mongoose");
 const EnquiryRepository = require("../repositories/EnquiryRepository");
 const AdminRepository = require("../repositories/AdminRepository");
 const StageRepository = require("../repositories/StageRepository");
+const ActivityLogService = require("./ActivityLogService");
+
+// Fixed set of disqualification reasons. Kept as a plain constant (no enum on the field).
+const LOST_REASONS = ["budget", "competitor", "not_responsive", "not_a_fit", "other"];
+
+const httpError = (status, message) => {
+  const err = new Error(message);
+  err.status = status;
+  return err;
+};
 
 // Update an enquiry's pipeline stage.
 // Throws { status, message } shaped errors for the controller to map to HTTP responses.
 const updateStage = async (enquiryId, stage, updatedBy) => {
   if (typeof stage !== "string" || stage.length === 0) {
-    const err = new Error("Stage is required");
-    err.status = 400;
-    throw err;
+    throw httpError(400, "Stage is required");
   }
   const validStage = await StageRepository.findBySlug(stage);
   if (!validStage) {
-    const err = new Error(`Invalid stage: ${stage}`);
-    err.status = 400;
-    throw err;
+    throw httpError(400, `Invalid stage: ${stage}`);
   }
   if (!mongoose.Types.ObjectId.isValid(enquiryId)) {
-    const err = new Error("Invalid enquiry id");
-    err.status = 400;
-    throw err;
+    throw httpError(400, "Invalid enquiry id");
   }
+  // Interception: moving a lead into a "lost"-category stage (e.g. dragging it into the
+  // Lost column) does NOT change the stage directly — it opens a disqualification REQUEST
+  // that must be approved. lostStatus guards (pending/approved) propagate from there.
+  if (validStage.category === "lost") {
+    return await requestDisqualification(
+      enquiryId,
+      { reason: "other", note: "Requested via stage change" },
+      updatedBy
+    );
+  }
+
+  // Non-lost target. Load the lead so we can detect a REOPEN: an approved- or pending-lost
+  // lead moved back to an open stage must clear its active lost state (otherwise lostStatus/
+  // isLost would go stale and contradict the new stage).
+  const enquiry = await EnquiryRepository.findById(enquiryId);
+  if (!enquiry) {
+    throw httpError(404, "Enquiry not found");
+  }
+
+  if (enquiry.lostStatus === "approved" || enquiry.lostStatus === "pending") {
+    const previousLostStatus = enquiry.lostStatus;
+    // Reset the ACTIVE lost state but KEEP the historical audit fields (lostReason,
+    // lostRequestedBy/At, lostDecidedBy/At, lostDecisionNote) so we retain what happened.
+    const reopened = await EnquiryRepository.updateFieldsById(enquiryId, {
+      stage,
+      updatedBy,
+      lostStatus: "none",
+      isLost: false,
+      stageBeforeLost: "",
+    });
+    await ActivityLogService.record({
+      actorId: updatedBy,
+      action: "lead.reopened",
+      entityType: "lead",
+      entityId: String(enquiryId),
+      summary: `Lead reopened (moved to ${stage})`,
+      meta: { fromLostStatus: previousLostStatus, toStage: stage },
+    });
+    return reopened;
+  }
+
+  // Not in a lost state ("none"/"rejected") — normal stage move, no lost-field writes.
   const updated = await EnquiryRepository.updateStageById(
     enquiryId,
     stage,
     updatedBy
   );
   if (!updated) {
-    const err = new Error("Enquiry not found");
-    err.status = 404;
-    throw err;
+    throw httpError(404, "Enquiry not found");
   }
+  return updated;
+};
+
+// Request that a lead be disqualified (marked lost). Pending approval afterward.
+const requestDisqualification = async (enquiryId, { reason, note } = {}, actorId) => {
+  if (!mongoose.Types.ObjectId.isValid(enquiryId)) {
+    throw httpError(400, "Invalid enquiry id");
+  }
+  if (!LOST_REASONS.includes(reason)) {
+    throw httpError(400, "Invalid reason");
+  }
+  if (note !== undefined && note !== null && typeof note !== "string") {
+    throw httpError(400, "Invalid note");
+  }
+
+  const enquiry = await EnquiryRepository.findById(enquiryId);
+  if (!enquiry) {
+    throw httpError(404, "Enquiry not found");
+  }
+  if (enquiry.lostStatus === "pending") {
+    throw httpError(400, "Already pending approval");
+  }
+  if (enquiry.lostStatus === "approved") {
+    throw httpError(400, "Lead is already lost");
+  }
+
+  const updated = await EnquiryRepository.updateFieldsById(enquiryId, {
+    lostStatus: "pending",
+    lostReason: reason,
+    lostNote: note || "",
+    lostRequestedBy: actorId || null,
+    lostRequestedAt: new Date(),
+    stageBeforeLost: enquiry.stage,
+  });
+
+  await ActivityLogService.record({
+    actorId,
+    action: "lead.disqualify_requested",
+    entityType: "lead",
+    entityId: String(enquiryId),
+    summary: `Disqualification requested (reason: ${reason})`,
+    meta: { reason, note: note || "" },
+  });
+
+  return updated;
+};
+
+// Decide on a pending disqualification request. `canApprove` is computed by the controller
+// (assigned person's manager OR holder of a leads:approve permission) and passed in.
+const decideDisqualification = async (
+  enquiryId,
+  { decision, note } = {},
+  actorId,
+  canApprove
+) => {
+  if (decision !== "approve" && decision !== "reject") {
+    throw httpError(400, "Invalid decision");
+  }
+  if (!mongoose.Types.ObjectId.isValid(enquiryId)) {
+    throw httpError(400, "Invalid enquiry id");
+  }
+
+  const enquiry = await EnquiryRepository.findById(enquiryId);
+  if (!enquiry) {
+    throw httpError(404, "Enquiry not found");
+  }
+  if (enquiry.lostStatus !== "pending") {
+    throw httpError(400, "No pending disqualification");
+  }
+  if (!canApprove) {
+    throw httpError(403, "Not authorized to approve this disqualification");
+  }
+
+  if (decision === "approve") {
+    const updated = await EnquiryRepository.updateFieldsById(enquiryId, {
+      lostStatus: "approved",
+      lostDecidedBy: actorId || null,
+      lostDecidedAt: new Date(),
+      lostDecisionNote: note || "",
+      isLost: true,
+      stage: "lost",
+    });
+    await ActivityLogService.record({
+      actorId,
+      action: "lead.disqualify_approved",
+      entityType: "lead",
+      entityId: String(enquiryId),
+      summary: "Disqualification approved",
+      meta: { movedToStage: "lost", reason: enquiry.lostReason },
+    });
+    return updated;
+  }
+
+  // decision === "reject": restore the pre-lost stage (if we captured one).
+  const restoreFields = {
+    lostStatus: "rejected",
+    lostDecidedBy: actorId || null,
+    lostDecidedAt: new Date(),
+    lostDecisionNote: note || "",
+  };
+  if (enquiry.stageBeforeLost) {
+    restoreFields.stage = enquiry.stageBeforeLost;
+  }
+  const updated = await EnquiryRepository.updateFieldsById(enquiryId, restoreFields);
+  await ActivityLogService.record({
+    actorId,
+    action: "lead.disqualify_rejected",
+    entityType: "lead",
+    entityId: String(enquiryId),
+    summary: "Disqualification rejected",
+    meta: { restoredStage: enquiry.stageBeforeLost, note: note || "" },
+  });
   return updated;
 };
 
@@ -78,4 +234,7 @@ const updateAssignedTo = async (enquiryId, assignedTo, updatedBy) => {
 module.exports = {
   updateStage,
   updateAssignedTo,
+  requestDisqualification,
+  decideDisqualification,
+  LOST_REASONS,
 };


### PR DESCRIPTION
Lead disqualification with manager approval:
- Enquiry: additive lost* fields (lostStatus none/pending/approved/rejected + reason/note/requestedBy/decidedBy/stageBeforeLost). isLost preserved.
- POST /enquiry/:id/disqualify (request, leads:edit:own) -> pending + ActivityLog
- PUT /enquiry/:id/disqualify-decision -> eligibility = assigned person's manager OR leads:approve; approve -> Lost stage + isLost; reject -> restore previous stage
- updateStage interception: moving a lead into a lost-category stage routes to a disqualify request (no backdoor)
- Reopen: moving an approved/pending lead to a non-lost stage clears active lost flags (keeps history) + logs lead.reopened
- "Lost" stage seeded (category lost, isSystem)
verify 41/41 + live HTTP tested. CRM-owned, no venue files modified.