### PR TITLE
Lead Lifecycle complete (Phase 1): dashboards, intake engine, cadence, projects, recycle, CSV import, password reset

### DIFF
--- a/controllers/admin.js
+++ b/controllers/admin.js
@@ -24,10 +24,13 @@ const legacyRolesForRole = async (role) => {
   return deriveLegacyRoles(dept ? dept.name : "");
 };
 
-// GET /admin
+// GET /admin — scope-aware INSIDE the service (Slice H): full list for
+// users:view:all, department list for users:view:department, otherwise a
+// minimal active-admin projection so assignee dropdowns keep working.
+// The route deliberately stays CheckAdminLogin-only (no 403 for normal pages).
 const GetAll = async (req, res) => {
   try {
-    const admins = await AdminService.listAdmins();
+    const admins = await AdminService.listAdmins(req.auth.user_id);
     res.status(200).json(admins);
   } catch (error) {
     res.status(500).json({ message: "Server error" });
@@ -95,6 +98,22 @@ const CreateAdmin = async (req, res) => {
       status: "active",
     });
 
+    // Invite email (Lifecycle Slice G — ships dark until the template id exists).
+    // Deliberately sends ONLY {name, email, loginUrl}: the password the founder
+    // typed is NEVER emailed; the founder shares it separately.
+    if (process.env.MAILJET_TEMPLATE_INVITE) {
+      const NotificationService = require("../services/NotificationService");
+      const loginUrl = `${process.env.OS_FRONTEND_URL || "https://os.wedsy.in"}/login`;
+      NotificationService.sendEmail(
+        created.email,
+        Number(process.env.MAILJET_TEMPLATE_INVITE),
+        { name: created.name, email: created.email, loginUrl },
+        created.name
+      ).catch((e) => console.error("[admin] invite email failed:", e.message));
+    } else {
+      console.warn("[admin] MAILJET_TEMPLATE_INVITE not set — invite email skipped (dark ship).");
+    }
+
     const safe = created.toObject();
     delete safe.password;
     return res.status(201).json(safe);
@@ -104,8 +123,8 @@ const CreateAdmin = async (req, res) => {
 };
 
 // PUT /admin/:id — founder-gated via users:edit:all.
-// Whitelisted fields only: roleId, departmentId, reportingManagerId, status.
-// Never updates password/email/phone here.
+// Whitelisted fields only: roleId, departmentId, reportingManagerId, status, phone.
+// Never updates password/email here.
 const UpdateAdmin = async (req, res) => {
   try {
     const { id } = req.params;
@@ -119,6 +138,14 @@ const UpdateAdmin = async (req, res) => {
 
     const body = req.body || {};
     const update = {};
+
+    // Lifecycle Slice I: phone is editable (fixes the seeded "PENDING" phones).
+    if (body.phone !== undefined) {
+      if (typeof body.phone !== "string" || !body.phone.trim()) {
+        return res.status(400).json({ message: "phone must be a non-empty string." });
+      }
+      update.phone = body.phone.trim();
+    }
 
     if (body.status !== undefined) {
       if (!STATUS_VALUES.includes(body.status)) {

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -659,6 +659,93 @@ const GetOTP = (req, res) => {
   }
 };
 
+
+// ── Password reset (Lifecycle Slice G) ───────────────────────────────────────
+const crypto = require("crypto");
+const NotificationService = require("../services/NotificationService");
+
+const sha256 = (value) => crypto.createHash("sha256").update(value).digest("hex");
+const RESET_TOKEN_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+// POST /auth/admin/forgot — ALWAYS responds with the same generic 200 so account
+// existence can never be probed. Ships dark until MAILJET_TEMPLATE_RESET is set.
+const ForgotPassword = async (req, res) => {
+  const generic = { message: "If that account exists, a reset link was sent." };
+  try {
+    const { email } = req.body || {};
+    if (!email || typeof email !== "string") {
+      return res.status(200).send(generic);
+    }
+    const admin = await Admin.findOne({ email: email.trim() });
+    if (!admin) {
+      return res.status(200).send(generic);
+    }
+    const token = crypto.randomBytes(32).toString("hex");
+    admin.resetToken = sha256(token);
+    admin.resetTokenExpiresAt = new Date(Date.now() + RESET_TOKEN_TTL_MS);
+    await admin.save();
+
+    const templateId = process.env.MAILJET_TEMPLATE_RESET;
+    if (!templateId) {
+      console.warn(
+        "[auth] MAILJET_TEMPLATE_RESET is not set — reset email NOT sent (dark ship). Token stored; flow testable via DB."
+      );
+      return res.status(200).send(generic);
+    }
+    const base = process.env.OS_FRONTEND_URL || "https://os.wedsy.in";
+    const resetUrl = `${base}/reset-password?token=${token}&email=${encodeURIComponent(
+      admin.email
+    )}`;
+    NotificationService.sendEmail(
+      admin.email,
+      Number(templateId),
+      { name: admin.name, resetUrl, expiresIn: "30 minutes" },
+      admin.name
+    ).catch((e) => console.error("[auth] reset email failed:", e.message));
+    return res.status(200).send(generic);
+  } catch (error) {
+    console.error("[auth] ForgotPassword error:", error.message);
+    // Still generic — never leak state through errors.
+    return res.status(200).send(generic);
+  }
+};
+
+// POST /auth/admin/reset — one generic 400 on ANY failure (no oracle).
+const ResetPassword = async (req, res) => {
+  try {
+    const { email, token, newPassword } = req.body || {};
+    const fail = () =>
+      res.status(400).send({ message: "Invalid or expired reset link" });
+    if (!email || !token || !newPassword || typeof newPassword !== "string") {
+      return fail();
+    }
+    if (newPassword.length < 8) {
+      return res
+        .status(400)
+        .send({ message: "Password must be at least 8 characters" });
+    }
+    const admin = await Admin.findOne({ email: String(email).trim() });
+    if (
+      !admin ||
+      !admin.resetToken ||
+      !admin.resetTokenExpiresAt ||
+      admin.resetTokenExpiresAt < new Date() ||
+      admin.resetToken !== sha256(String(token))
+    ) {
+      return fail();
+    }
+    admin.password = await CreateHash(newPassword);
+    admin.resetToken = null;
+    admin.resetTokenExpiresAt = null;
+    await admin.save();
+    console.log(`[auth] Password reset completed for admin ${admin._id}`);
+    return res.status(200).send({ message: "Password updated. You can log in now." });
+  } catch (error) {
+    console.error("[auth] ResetPassword error:", error.message);
+    return res.status(400).send({ message: "Invalid or expired reset link" });
+  }
+};
+
 module.exports = {
   AdminLogin,
   GetAdmin,
@@ -672,4 +759,6 @@ module.exports = {
   RestoreUserAccount,
   DeleteVendorAccount,
   RestoreVendorAccount,
+  ForgotPassword,
+  ResetPassword,
 };

--- a/controllers/enquiry-cockpit.js
+++ b/controllers/enquiry-cockpit.js
@@ -1,0 +1,85 @@
+const CallCockpitService = require("../services/CallCockpitService");
+
+// POST /enquiry/:_id/call-log
+const LogCall = async (req, res) => {
+  try {
+    const updated = await CallCockpitService.logCall(
+      req.params._id,
+      req.body,
+      req.auth.user_id
+    );
+    res.status(200).json(updated);
+  } catch (error) {
+    const status = error.status || 500;
+    const message = status === 500 ? "Server error" : error.message;
+    res.status(status).json({ message });
+  }
+};
+
+// POST /enquiry/:_id/follow-up
+const AddFollowUp = async (req, res) => {
+  try {
+    const updated = await CallCockpitService.addFollowUp(
+      req.params._id,
+      req.body,
+      req.auth.user_id
+    );
+    res.status(200).json(updated);
+  } catch (error) {
+    const status = error.status || 500;
+    const message = status === 500 ? "Server error" : error.message;
+    res.status(status).json({ message });
+  }
+};
+
+// PUT /enquiry/:_id/qualification
+const UpdateQualification = async (req, res) => {
+  try {
+    const updated = await CallCockpitService.updateQualification(
+      req.params._id,
+      req.body,
+      req.auth.user_id
+    );
+    res.status(200).json(updated);
+  } catch (error) {
+    const status = error.status || 500;
+    const message = status === 500 ? "Server error" : error.message;
+    res.status(status).json({ message });
+  }
+};
+
+// POST /enquiry/:_id/call-complete
+const CompleteCall = async (req, res) => {
+  try {
+    const updated = await CallCockpitService.completeCall(
+      req.params._id,
+      req.body,
+      req.auth.user_id
+    );
+    res.status(200).json(updated);
+  } catch (error) {
+    const status = error.status || 500;
+    const message = status === 500 ? "Server error" : error.message;
+    res.status(status).json({ message });
+  }
+};
+
+// GET /enquiry/:_id/internal-events
+const GetInternalEvents = async (req, res) => {
+  try {
+    const events = await CallCockpitService.listInternalEvents(req.params._id);
+    res.status(200).json(events);
+  } catch (error) {
+    const status = error.status || 500;
+    const message = status === 500 ? "Server error" : error.message;
+    res.status(status).json({ message });
+  }
+};
+
+module.exports = {
+  LogCall,
+  AddFollowUp,
+  UpdateQualification,
+  CompleteCall,
+  GetInternalEvents,
+};

--- a/controllers/enquiry-import.js
+++ b/controllers/enquiry-import.js
@@ -1,0 +1,54 @@
+const LeadImportService = require("../services/LeadImportService");
+
+const fileFromRequest = (req) => {
+  const file = req.files && (req.files.file || Object.values(req.files)[0]);
+  return file && file.data ? file.data : null;
+};
+
+// POST /enquiry/import/preview (multipart: file)
+const Preview = async (req, res) => {
+  try {
+    const buffer = fileFromRequest(req);
+    if (!buffer) {
+      return res.status(400).json({ message: "Attach a CSV file as multipart field 'file'" });
+    }
+    const result = await LeadImportService.preview(buffer);
+    res.status(200).json(result);
+  } catch (error) {
+    const status = error.status || 500;
+    if (status === 500) console.error("[import:preview]", error);
+    res.status(status).json({ message: status === 500 ? "Server error" : error.message });
+  }
+};
+
+// POST /enquiry/import/commit (multipart: file + mapping/stageMapping JSON fields)
+const Commit = async (req, res) => {
+  try {
+    const buffer = fileFromRequest(req);
+    if (!buffer) {
+      return res.status(400).json({ message: "Attach a CSV file as multipart field 'file'" });
+    }
+    const parseJson = (v, fallback) => {
+      if (v === undefined || v === null || v === "") return fallback;
+      try {
+        return typeof v === "string" ? JSON.parse(v) : v;
+      } catch {
+        return fallback;
+      }
+    };
+    const options = {
+      mapping: parseJson(req.body.mapping, {}),
+      stageMapping: parseJson(req.body.stageMapping, {}),
+      skipDuplicates: req.body.skipDuplicates !== "false" && req.body.skipDuplicates !== false,
+      assignOnImport: req.body.assignOnImport === "true" || req.body.assignOnImport === true,
+    };
+    const result = await LeadImportService.commit(buffer, options, req.auth.user_id);
+    res.status(200).json(result);
+  } catch (error) {
+    const status = error.status || 500;
+    if (status === 500) console.error("[import:commit]", error);
+    res.status(status).json({ message: status === 500 ? "Server error" : error.message });
+  }
+};
+
+module.exports = { Preview, Commit };

--- a/controllers/enquiry-lifecycle.js
+++ b/controllers/enquiry-lifecycle.js
@@ -1,0 +1,72 @@
+const DashboardService = require("../services/DashboardService");
+const LeadLifecycleService = require("../services/LeadLifecycleService");
+const ProjectService = require("../services/ProjectService");
+
+const respondError = (res, error) => {
+  const status = error.status || 500;
+  const message = status === 500 ? "Server error" : error.message;
+  if (status === 500) console.error("[lifecycle]", error);
+  res.status(status).json({ message });
+};
+
+// GET /enquiry/dashboard — the role-aware morning briefing. Every query inside is
+// bounded to the caller's effective scope (req.scope/req.scopeFilter from
+// requirePermission("leads:view:own", { ownerField: "assignedTo" })).
+const Dashboard = async (req, res) => {
+  try {
+    const payload = await DashboardService.buildDashboard(
+      req.auth.user_id,
+      req.scope,
+      req.scopeFilter || {}
+    );
+    res.status(200).json(payload);
+  } catch (error) {
+    respondError(res, error);
+  }
+};
+
+// PUT /enquiry/:_id/follow-up/:followUpId/complete — the zero-orphan gate lives
+// in LeadLifecycleService (422 when an open lead would exit into nothing).
+const CompleteFollowUp = async (req, res) => {
+  try {
+    const result = await LeadLifecycleService.completeFollowUp(
+      req.params._id,
+      req.params.followUpId,
+      req.body,
+      req.auth.user_id
+    );
+    res.status(200).json(result);
+  } catch (error) {
+    respondError(res, error);
+  }
+};
+
+// POST /enquiry/:_id/recycle
+const Recycle = async (req, res) => {
+  try {
+    const updated = await LeadLifecycleService.recycleLead(
+      req.params._id,
+      req.body,
+      req.auth.user_id
+    );
+    res.status(200).json(updated);
+  } catch (error) {
+    respondError(res, error);
+  }
+};
+
+// POST /enquiry/:_id/convert — Meeting Scheduled → Project (terminal "won").
+const Convert = async (req, res) => {
+  try {
+    const project = await ProjectService.convertLead(
+      req.params._id,
+      req.body,
+      req.auth.user_id
+    );
+    res.status(201).json(project);
+  } catch (error) {
+    respondError(res, error);
+  }
+};
+
+module.exports = { Dashboard, CompleteFollowUp, Recycle, Convert };

--- a/controllers/enquiry.js
+++ b/controllers/enquiry.js
@@ -11,6 +11,8 @@ const Bidding = require("../models/Bidding");
 const Order = require("../models/Order");
 const { SendUpdate } = require("../utils/update");
 const { GetPaymentTransactions } = require("../utils/payment");
+const { computeLeadHealth } = require("../utils/leadHealth");
+const EnquiryRepository = require("../repositories/EnquiryRepository");
 
 const CreateNew = (req, res) => {
   const { name, phone, verified, source, Otp, ReferenceId, additionalInfo } =
@@ -810,7 +812,12 @@ const Get = (req, res) => {
           User.findOne({ phone: result.phone })
             .then((user) => {
               if (!user) {
-                res.send({ ...finalResultObj, userCreated: false });
+                res.send({
+                  ...finalResultObj,
+                  userCreated: false,
+                  // Derived on read, never stored (no events without a linked user).
+                  leadHealth: computeLeadHealth(finalResultObj, []),
+                });
               } else {
                 Event.find({ user: user._id })
                   .then((events) => {
@@ -882,6 +889,11 @@ const Get = (req, res) => {
                                     userCreated: true,
                                     user,
                                     events,
+                                    // Derived on read, never stored.
+                                    leadHealth: computeLeadHealth(
+                                      finalResultObj,
+                                      events
+                                    ),
                                     payments: updatedPayments,
                                     paymentStats: {
                                       totalAmount,
@@ -1102,6 +1114,28 @@ const UpdateCallSchedule = (req, res) => {
     });
 };
 
+// First-call TAT anchor: stamp firstCalledAt the FIRST time a lead is called.
+// Idempotent + set-once — if it is already set we leave the original timestamp
+// untouched and simply return the current lead document.
+const SetFirstCall = async (req, res) => {
+  const { _id } = req.params;
+  try {
+    // Set-once semantics live in EnquiryRepository.stampFirstCalledAt (shared with
+    // the cockpit's call-log endpoint): only a never-called lead gets stamped.
+    let result = await EnquiryRepository.stampFirstCalledAt(_id);
+    // No match means it was already stamped (or the lead is missing) — re-read it.
+    if (!result) {
+      result = await Enquiry.findById({ _id });
+    }
+    if (!result) {
+      return res.status(404).send();
+    }
+    res.send(result);
+  } catch (error) {
+    res.status(500).send({ message: "error", error });
+  }
+};
+
 module.exports = {
   CreateNew,
   GetAll,
@@ -1115,4 +1149,5 @@ module.exports = {
   UpdateConversation,
   UpdateNotes,
   UpdateCallSchedule,
+  SetFirstCall,
 };

--- a/controllers/enquiry.js
+++ b/controllers/enquiry.js
@@ -13,6 +13,7 @@ const { SendUpdate } = require("../utils/update");
 const { GetPaymentTransactions } = require("../utils/payment");
 const { computeLeadHealth } = require("../utils/leadHealth");
 const EnquiryRepository = require("../repositories/EnquiryRepository");
+const LeadIntakeService = require("../services/LeadIntakeService");
 
 const CreateNew = (req, res) => {
   const { name, phone, verified, source, Otp, ReferenceId, additionalInfo } =
@@ -41,6 +42,11 @@ const CreateNew = (req, res) => {
                   { new: true }
                 )
                   .then(() => {
+                    // Lifecycle intake hook (additive): dedup-merge — same person enquired again.
+                    LeadIntakeService.recordReEnquiry(existingEnquiry._id, {
+                      source,
+                      message: additionalInfo?.message || "",
+                    });
                     User.findOne({ phone })
                       .then((user) => {
                         if (user) {
@@ -105,6 +111,8 @@ const CreateNew = (req, res) => {
                       })
                         .save()
                         .then((result) => {
+                          // Lifecycle intake hook (additive): auto-assign the new lead.
+                          LeadIntakeService.afterCreate(result._id);
                           SendUpdate({
                             channels: ["SMS", "Whatsapp"],
                             message: "New Lead",
@@ -140,6 +148,8 @@ const CreateNew = (req, res) => {
                           })
                             .save()
                             .then((result) => {
+                              // Lifecycle intake hook (additive): auto-assign the new lead.
+                              LeadIntakeService.afterCreate(result._id);
                               SendUpdate({
                                 channels: ["SMS", "Whatsapp"],
                                 message: "New Lead",
@@ -192,28 +202,52 @@ const CreateNew = (req, res) => {
             { new: true }
           )
             .then(() => {
+              // Lifecycle intake hook (additive): dedup-merge — same person enquired again.
+              LeadIntakeService.recordReEnquiry(existingEnquiry._id, {
+                source,
+                message: additionalInfo?.message || "",
+              });
               res.status(200).send({ message: "Enquiry Updated Successfully" });
             })
             .catch((error) => {
               res.status(400).send({ message: "error", error });
             });
         } else {
-          // Create new enquiry
-          new Enquiry({
-            name,
-            phone,
-            verified: false,
-            source,
-            additionalInfo: additionalInfo || {},
-          })
-            .save()
-            .then((result) => {
-              SendUpdate({
-                channels: ["SMS", "Whatsapp"],
-                message: "New Lead",
-                parameters: { name, phone },
-              });
-              res.status(201).send({ message: "Enquiry Added Successfully" });
+          // Lifecycle intake hook (additive): the exact-match check above misses
+          // formatting variants ("+91 98… " vs "98…"). Normalized match → treat as
+          // the same dedup-merge path, preserving the existing response contract.
+          LeadIntakeService.findExistingByNormalizedPhone(phone)
+            .then((normalizedMatch) => {
+              if (normalizedMatch) {
+                LeadIntakeService.recordReEnquiry(normalizedMatch._id, {
+                  source,
+                  message: additionalInfo?.message || "",
+                });
+                res.status(200).send({ message: "Enquiry Updated Successfully" });
+                return;
+              }
+              // Create new enquiry
+              new Enquiry({
+                name,
+                phone,
+                verified: false,
+                source,
+                additionalInfo: additionalInfo || {},
+              })
+                .save()
+                .then((result) => {
+                  // Lifecycle intake hook (additive): auto-assign the new lead.
+                  LeadIntakeService.afterCreate(result._id);
+                  SendUpdate({
+                    channels: ["SMS", "Whatsapp"],
+                    message: "New Lead",
+                    parameters: { name, phone },
+                  });
+                  res.status(201).send({ message: "Enquiry Added Successfully" });
+                })
+                .catch((error) => {
+                  res.status(400).send({ message: "error", error });
+                });
             })
             .catch((error) => {
               res.status(400).send({ message: "error", error });
@@ -286,6 +320,22 @@ const GetAll = async (req, res) => {
         query.assignedTo = null;
       } else {
         query.assignedTo = assignedTo;
+      }
+    }
+    // Lifecycle (Slice I, additive): lead-list view chips. Absent → behavior unchanged.
+    if (req.query.view) {
+      const view = req.query.view;
+      if (view === "active") {
+        query.stage = { $nin: ["won", "lost"] };
+        query["recycled.isRecycled"] = { $ne: true };
+      } else if (view === "won") {
+        query.stage = "won";
+      } else if (view === "lost") {
+        query.stage = "lost";
+      } else if (view === "meeting") {
+        query.stage = "meeting_scheduled";
+      } else if (view === "recycled") {
+        query["recycled.isRecycled"] = true;
       }
     }
     if (date) {

--- a/controllers/event.js
+++ b/controllers/event.js
@@ -12,7 +12,7 @@ const CreateNew = (req, res) => {
   if (req.body.brideName && req.body.groomName && !req.body.name) {
     req.body.name = `${req.body.groomName} x ${req.body.brideName}`;
   }
-  const { name, community, eventDay, date, time, venue, user, brideName, groomName } = req.body;
+  const { name, community, eventDay, date, time, venue, user, brideName, groomName, eventSpace } = req.body;
   if (!name || !community || !eventDay || !date || !time || !venue) {
     res.status(400).send({ message: "Incomplete Data" });
   } else {
@@ -24,7 +24,8 @@ const CreateNew = (req, res) => {
       groomName: groomName || null,
       community,
       eventDate: date, // Add the eventDate field explicitly
-      eventDays: [{ name: eventDay, date, time, venue }],
+      // eventSpace is optional (additive) — existing callers that omit it get the schema default "".
+      eventDays: [{ name: eventDay, date, time, venue, eventSpace: eventSpace || "" }],
     })
       .save()
       .then((result) => {

--- a/controllers/project.js
+++ b/controllers/project.js
@@ -1,0 +1,15 @@
+const ProjectService = require("../services/ProjectService");
+
+// GET /project — scope-filtered by csOwnerId (own) vs department/all per the
+// caller's projects:view permission.
+const GetAll = async (req, res) => {
+  try {
+    const projects = await ProjectService.listProjects(req.scopeFilter || {});
+    res.status(200).json(projects);
+  } catch (error) {
+    const status = error.status || 500;
+    res.status(status).json({ message: status === 500 ? "Server error" : error.message });
+  }
+};
+
+module.exports = { GetAll };

--- a/controllers/webhook.js
+++ b/controllers/webhook.js
@@ -1,31 +1,42 @@
 const Enquiry = require("../models/Enquiry");
 const { SendUpdate } = require("../utils/update");
+const LeadIntakeService = require("../services/LeadIntakeService");
 
-const CreateNewAdsLead = (req, res) => {
-  const { name, phone, email } = req.body;
-  if (!name || !phone) {
-    res.status(400).send({ message: "Incomplete Data" });
-  } else {
-    new Enquiry({
+const CreateNewAdsLead = async (req, res) => {
+  try {
+    const { name, phone, email } = req.body;
+    if (!name || !phone) {
+      return res.status(400).send({ message: "Incomplete Data" });
+    }
+    // Lifecycle intake hook (additive): dedup-merge before insert. A re-enquiry
+    // from ads does NOT create a duplicate — it stamps the existing lead and
+    // appends a re_enquired event. Response contract preserved (201 empty).
+    const existing = await LeadIntakeService.findExistingByNormalizedPhone(phone);
+    if (existing) {
+      await LeadIntakeService.recordReEnquiry(existing._id, {
+        source: "Ads (Landing Screen)",
+        message: "",
+      });
+      return res.status(201).send();
+    }
+    const result = await new Enquiry({
       name,
       phone,
       email,
       verified: false,
       source: "Ads (Landing Screen)",
       additionalInfo: {},
-    })
-      .save()
-      .then((result) => {
-        SendUpdate({
-          channels: ["SMS", "Whatsapp"],
-          message: "New Lead",
-          parameters: { name, phone },
-        });
-        res.status(201).send();
-      })
-      .catch((error) => {
-        res.status(400).send({ message: "error", error });
-      });
+    }).save();
+    // Lifecycle intake hook (additive): auto-assign the new lead.
+    LeadIntakeService.afterCreate(result._id);
+    SendUpdate({
+      channels: ["SMS", "Whatsapp"],
+      message: "New Lead",
+      parameters: { name, phone },
+    });
+    return res.status(201).send();
+  } catch (error) {
+    return res.status(400).send({ message: "error", error });
   }
 };
 

--- a/models/Admin.js
+++ b/models/Admin.js
@@ -14,6 +14,11 @@ const AdminSchema = new mongoose.Schema(
     reportingManagerId: { type: ObjectId, ref: "Admin", default: null },
     status: { type: String, enum: ["active", "inactive", "on_leave"], default: "active" },
     joinedAt: { type: Date, default: null },
+    // Lifecycle (additive): round-robin auto-assignment cursor (least-recently-assigned wins).
+    lastAssignedAt: { type: Date, default: null },
+    // Password reset (additive): sha256 hash of the emailed token + its expiry.
+    resetToken: { type: String, default: null },
+    resetTokenExpiresAt: { type: Date, default: null },
     meta: {
       designation: { type: String, default: "" },
       employeeId: { type: String, default: "" },

--- a/models/Enquiry.js
+++ b/models/Enquiry.js
@@ -102,6 +102,11 @@ const EnquirySchema = new mongoose.Schema(
           promiseNote: { type: String, default: "" },
           createdBy: { type: ObjectId, ref: "Admin", default: null },
           createdAt: { type: Date, default: Date.now },
+          // Lifecycle (additive): completion stamp via PUT /:_id/follow-up/:followUpId/complete
+          completedAt: { type: Date, default: null },
+          completedBy: { type: ObjectId, ref: "Admin", default: null },
+          completedOutcome: { type: String, default: "" }, // connected | busy | no_answer | done
+          completedNotes: { type: String, default: "" },
         },
       ],
       default: [],
@@ -131,6 +136,25 @@ const EnquirySchema = new mongoose.Schema(
       gaps: { type: [String], default: [] },
       completedAt: { type: Date, default: null },
       completedBy: { type: ObjectId, ref: "Admin", default: null },
+    },
+    // ── Lead lifecycle (additive only) ──────────────────────────────────────
+    // Intake engine: stamped when an existing lead enquires again (dedup-merge).
+    reEnquiredAt: { type: Date, default: null },
+    // Attempt cadence: stamped when busy/unknown attempts reach MAX_ATTEMPTS.
+    unresponsiveFlaggedAt: { type: Date, default: null },
+    // CSV import marker: historical imports are excluded from auto-assignment.
+    importedAt: { type: Date, default: null },
+    // Recycle — the third terminal state. Excluded from all active views while
+    // isRecycled; lazily resurfaced (and reassigned) once revisitAt passes.
+    recycled: {
+      isRecycled: { type: Boolean, default: false },
+      reason: { type: String, default: "" }, // wedding_next_year | budget_mismatch_now | venue_not_booked | other
+      reasonNote: { type: String, default: "" },
+      revisitAt: { type: Date, default: null },
+      recycledBy: { type: ObjectId, ref: "Admin", default: null },
+      recycledAt: { type: Date, default: null },
+      originalOwnerId: { type: ObjectId, ref: "Admin", default: null },
+      resurfacedAt: { type: Date, default: null },
     },
   },
   { timestamps: true }

--- a/models/Enquiry.js
+++ b/models/Enquiry.js
@@ -75,6 +75,63 @@ const EnquirySchema = new mongoose.Schema(
     lostDecidedAt: { type: Date, default: null },
     lostDecisionNote: { type: String, default: "" },
     stageBeforeLost: { type: String, default: "" },
+    // First-call TAT anchor: timestamp of the first time this lead was called (set-once).
+    firstCalledAt: { type: Date, default: null },
+    // First-call cockpit (Phase 1A — additive only).
+    // Append-only call history: entries are pushed by POST /enquiry/:_id/call-log and
+    // intentionally have NO edit/delete route.
+    callLog: {
+      type: [
+        {
+          startedAt: { type: Date, required: true },
+          durationSeconds: { type: Number, default: 0 },
+          connected: { type: Boolean, default: false },
+          outcome: { type: String, default: "" }, // qualified | busy | unknown | disqualified | ""
+          notes: { type: String, default: "" },
+          loggedBy: { type: ObjectId, ref: "Admin", default: null },
+          createdAt: { type: Date, default: Date.now },
+        },
+      ],
+      default: [],
+    },
+    followUps: {
+      type: [
+        {
+          type: { type: String, enum: ["meet", "call", "visit"], required: true },
+          scheduledAt: { type: Date, required: true },
+          promiseNote: { type: String, default: "" },
+          createdBy: { type: ObjectId, ref: "Admin", default: null },
+          createdAt: { type: Date, default: Date.now },
+        },
+      ],
+      default: [],
+    },
+    // Set when a call is logged with outcome "qualified". Drives the server-side
+    // complete-call gate (qualified leads must lock a future follow-up).
+    qualified: { type: Boolean, default: false },
+    qualificationData: {
+      groomName: { type: String, default: "" },
+      brideName: { type: String, default: "" },
+      weddingStyle: { type: String, default: "" },
+      venueStatus: { type: String, default: "" }, // "" | booked | looking
+      venueName: { type: String, default: "" },
+      venueTypeWanted: { type: String, default: "" },
+      venueArea: { type: String, default: "" },
+      venueBudget: { type: String, default: "" },
+      venueShortlistNote: { type: String, default: "" },
+      email: { type: String, default: "" },
+      emailNotWilling: { type: Boolean, default: false },
+      whatsappSameNumber: { type: Boolean, default: true },
+      whatsappNumber: { type: String, default: "" },
+    },
+    // Outcome of the cockpit's complete-call action. gaps holds the missing items
+    // acknowledged on an incomplete save (flagged on the lead, per the approved design).
+    callCompletion: {
+      status: { type: String, enum: ["", "complete", "incomplete"], default: "" },
+      gaps: { type: [String], default: [] },
+      completedAt: { type: Date, default: null },
+      completedBy: { type: ObjectId, ref: "Admin", default: null },
+    },
   },
   { timestamps: true }
 );

--- a/models/LeadInternalEvent.js
+++ b/models/LeadInternalEvent.js
@@ -1,0 +1,23 @@
+const mongoose = require("mongoose");
+const ObjectId = mongoose.Schema.Types.ObjectId;
+
+// Append-only internal event stream per lead (Wedsy OS Notion spec).
+// Rows are written by the system when things happen to a lead and are NEVER
+// edited or deleted — there are intentionally no update/delete routes.
+// Spec types: call_logged | stage_changed | commented | lost_requested.
+// (stage_changed / commented / lost_requested equivalents are currently recorded
+// by the PR #25/#26 ActivityLog writes; cockpit endpoints write here directly.)
+const LeadInternalEventSchema = new mongoose.Schema(
+  {
+    leadId: { type: ObjectId, ref: "Enquiry", required: true },
+    type: { type: String, required: true },
+    actorId: { type: ObjectId, ref: "Admin", default: null },
+    payload: { type: Object, default: {} },
+  },
+  { timestamps: { createdAt: true, updatedAt: false } }
+);
+LeadInternalEventSchema.index({ leadId: 1, createdAt: -1 });
+
+module.exports =
+  mongoose.models.LeadInternalEvent ||
+  mongoose.model("LeadInternalEvent", LeadInternalEventSchema);

--- a/models/Project.js
+++ b/models/Project.js
@@ -1,0 +1,26 @@
+const mongoose = require("mongoose");
+const ObjectId = mongoose.Schema.Types.ObjectId;
+
+// A converted lead — the "won" handoff from Sales to Client Servicing.
+// Created exclusively via POST /enquiry/:_id/convert (Lead Lifecycle, Slice D).
+const ProjectSchema = new mongoose.Schema(
+  {
+    leadId: { type: ObjectId, ref: "Enquiry", required: true },
+    coupleNames: { type: String, default: "" },
+    eventIds: { type: [ObjectId], ref: "Event", default: [] },
+    csOwnerId: { type: ObjectId, ref: "Admin", default: null },
+    convertedBy: { type: ObjectId, ref: "Admin", default: null },
+    value: { type: Number, default: 0 },
+    status: {
+      type: String,
+      enum: ["active", "completed", "on_hold"],
+      default: "active",
+    },
+    handoffNote: { type: String, default: "" },
+  },
+  { timestamps: true }
+);
+ProjectSchema.index({ csOwnerId: 1, createdAt: -1 });
+ProjectSchema.index({ leadId: 1 });
+
+module.exports = mongoose.models.Project || mongoose.model("Project", ProjectSchema);

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "node-cron": "^3.0.3",
         "node-mailjet": "^6.0.6",
         "nodemon": "^3.1.10",
+        "papaparse": "^5.5.3",
         "pdfkit": "^0.14.0",
         "puppeteer": "^24.43.1",
         "razorpay": "^2.9.2",
@@ -4716,6 +4717,12 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "license": "(MIT AND Zlib)"
+    },
+    "node_modules/papaparse": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "license": "MIT"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "node-cron": "^3.0.3",
     "node-mailjet": "^6.0.6",
     "nodemon": "^3.1.10",
+    "papaparse": "^5.5.3",
     "pdfkit": "^0.14.0",
     "puppeteer": "^24.43.1",
     "razorpay": "^2.9.2",

--- a/repositories/EnquiryRepository.js
+++ b/repositories/EnquiryRepository.js
@@ -33,9 +33,44 @@ const updateFieldsById = async (_id, fields) => {
   );
 };
 
+// Append a call-log entry (append-only stream — no edit/delete helpers by design).
+// extraSet lets the caller atomically set fields in the same write (e.g. qualified: true).
+const pushCallLogById = async (_id, entry, extraSet = {}) => {
+  const update = { $push: { callLog: entry } };
+  if (Object.keys(extraSet).length) update.$set = extraSet;
+  return await Enquiry.findByIdAndUpdate(_id, update, {
+    new: true,
+    runValidators: true,
+    context: "query",
+  });
+};
+
+// Append a follow-up entry.
+const pushFollowUpById = async (_id, entry) => {
+  return await Enquiry.findByIdAndUpdate(
+    _id,
+    { $push: { followUps: entry } },
+    { new: true, runValidators: true, context: "query" }
+  );
+};
+
+// First-call TAT anchor (set-once, idempotent — same semantics as enquiry.SetFirstCall):
+// `firstCalledAt: null` matches both null and missing, so only a never-called lead
+// gets stamped; an already-stamped lead simply doesn't match and keeps its timestamp.
+const stampFirstCalledAt = async (_id) => {
+  return await Enquiry.findOneAndUpdate(
+    { _id, firstCalledAt: null },
+    { $set: { firstCalledAt: new Date() } },
+    { new: true }
+  );
+};
+
 module.exports = {
   findById,
   updateStageById,
   updateAssignedToById,
   updateFieldsById,
+  pushCallLogById,
+  pushFollowUpById,
+  stampFirstCalledAt,
 };

--- a/repositories/LeadInternalEventRepository.js
+++ b/repositories/LeadInternalEventRepository.js
@@ -1,0 +1,24 @@
+const LeadInternalEvent = require("../models/LeadInternalEvent");
+
+// Append one event row. No update/delete helpers — the stream is append-only by design.
+const create = async ({ leadId, type, actorId, payload }) => {
+  return await LeadInternalEvent.create({
+    leadId,
+    type,
+    actorId: actorId || null,
+    payload: payload || {},
+  });
+};
+
+// Newest-first event stream for one lead.
+const findByLeadId = async (leadId, { limit = 100 } = {}) => {
+  return await LeadInternalEvent.find({ leadId })
+    .sort({ createdAt: -1 })
+    .limit(limit)
+    .lean();
+};
+
+module.exports = {
+  create,
+  findByLeadId,
+};

--- a/repositories/ProjectRepository.js
+++ b/repositories/ProjectRepository.js
@@ -1,0 +1,17 @@
+const Project = require("../models/Project");
+
+const create = async (fields) => {
+  return await Project.create(fields);
+};
+
+const findByLeadId = async (leadId) => {
+  return await Project.findOne({ leadId }).lean();
+};
+
+// Scope-filtered list, newest first. scopeFilter is built by requirePermission
+// with ownerField csOwnerId (own → only the caller's projects).
+const findAll = async (scopeFilter = {}) => {
+  return await Project.find(scopeFilter).sort({ createdAt: -1 }).lean();
+};
+
+module.exports = { create, findByLeadId, findAll };

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const router = express.Router();
+const rateLimit = require("express-rate-limit");
 
 const { CheckLogin } = require("../middlewares/auth");
 const auth = require("../controllers/auth");
@@ -8,6 +9,16 @@ const authInternational = require("../controllers/auth.international");
 // Admin Auth
 router.post("/admin", auth.AdminLogin);
 router.get("/admin", CheckLogin, auth.GetAdmin);
+// Password reset (Lifecycle Slice G). Forgot is rate-limited (5/hour/IP) and
+// always answers generically — no user enumeration.
+const forgotLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+router.post("/admin/forgot", forgotLimiter, auth.ForgotPassword);
+router.post("/admin/reset", auth.ResetPassword);
 
 // Vendor Auth
 router.post("/vendor", auth.VendorLogin);

--- a/routes/enquiry.js
+++ b/routes/enquiry.js
@@ -5,6 +5,9 @@ const enquiry = require("../controllers/enquiry");
 const enquiryPipeline = require("../controllers/enquiry-pipeline");
 const disqualify = require("../controllers/disqualify");
 const cockpit = require("../controllers/enquiry-cockpit");
+const lifecycle = require("../controllers/enquiry-lifecycle");
+const enquiryImport = require("../controllers/enquiry-import");
+const fileUpload = require("express-fileupload");
 const { CheckLogin, CheckAdminLogin } = require("../middlewares/auth");
 const { requirePermission } = require("../middlewares/requirePermission");
 
@@ -12,6 +15,29 @@ router.post("/", enquiry.CreateNew);
 router.get("/", CheckAdminLogin, requirePermission("leads:view:own", { ownerField: "assignedTo" }), enquiry.GetAll);
 router.put("/", CheckAdminLogin, enquiry.Update);
 router.delete("/", CheckAdminLogin, enquiry.Delete);
+// Lifecycle (Slice A): role-aware dashboard. Literal path — MUST stay above /:_id.
+router.get(
+  "/dashboard",
+  CheckAdminLogin,
+  requirePermission("leads:view:own", { ownerField: "assignedTo" }),
+  lifecycle.Dashboard
+);
+// Lifecycle (Slice F): founder CSV import (the Zoho migration tool). Literal
+// paths above /:_id; multipart handled per-route via express-fileupload.
+router.post(
+  "/import/preview",
+  CheckAdminLogin,
+  requirePermission("leads:create:department"),
+  fileUpload(),
+  enquiryImport.Preview
+);
+router.post(
+  "/import/commit",
+  CheckAdminLogin,
+  requirePermission("leads:create:department"),
+  fileUpload(),
+  enquiryImport.Commit
+);
 router.get("/:_id", CheckAdminLogin, requirePermission("leads:view:own", { ownerField: "assignedTo" }), enquiry.Get);
 router.post("/:_id/user", CheckAdminLogin, enquiry.CreateUser);
 router.post("/:_id/conversations", CheckAdminLogin, enquiry.AddConversation);
@@ -65,6 +91,25 @@ router.get(
   CheckAdminLogin,
   requirePermission("leads:edit:own"),
   cockpit.GetInternalEvents
+);
+// Lifecycle: follow-up completion (zero-orphan gate), recycle, convert.
+router.put(
+  "/:_id/follow-up/:followUpId/complete",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own"),
+  lifecycle.CompleteFollowUp
+);
+router.post(
+  "/:_id/recycle",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own"),
+  lifecycle.Recycle
+);
+router.post(
+  "/:_id/convert",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own"),
+  lifecycle.Convert
 );
 router.put("/:_id/stage", CheckAdminLogin, enquiryPipeline.UpdateStage);
 router.put("/:_id/assign", CheckAdminLogin, enquiryPipeline.UpdateAssignedTo);

--- a/routes/enquiry.js
+++ b/routes/enquiry.js
@@ -4,6 +4,7 @@ const router = express.Router();
 const enquiry = require("../controllers/enquiry");
 const enquiryPipeline = require("../controllers/enquiry-pipeline");
 const disqualify = require("../controllers/disqualify");
+const cockpit = require("../controllers/enquiry-cockpit");
 const { CheckLogin, CheckAdminLogin } = require("../middlewares/auth");
 const { requirePermission } = require("../middlewares/requirePermission");
 
@@ -27,6 +28,44 @@ router.delete(
 router.put("/:_id/", CheckAdminLogin, enquiry.UpdateLead);
 router.put("/:_id/notes", CheckAdminLogin, enquiry.UpdateNotes);
 router.put("/:_id/call", CheckAdminLogin, enquiry.UpdateCallSchedule);
+router.put(
+  "/:_id/first-call",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own"),
+  enquiry.SetFirstCall
+);
+// First-call cockpit (Phase 1A). Same gate as the disqualify request below:
+// edit rights on leads (Sales Executive has leads:edit:own).
+router.post(
+  "/:_id/call-log",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own"),
+  cockpit.LogCall
+);
+router.post(
+  "/:_id/follow-up",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own"),
+  cockpit.AddFollowUp
+);
+router.put(
+  "/:_id/qualification",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own"),
+  cockpit.UpdateQualification
+);
+router.post(
+  "/:_id/call-complete",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own"),
+  cockpit.CompleteCall
+);
+router.get(
+  "/:_id/internal-events",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own"),
+  cockpit.GetInternalEvents
+);
 router.put("/:_id/stage", CheckAdminLogin, enquiryPipeline.UpdateStage);
 router.put("/:_id/assign", CheckAdminLogin, enquiryPipeline.UpdateAssignedTo);
 // Requesting a disqualification needs edit rights on the lead (Sales Executive has leads:edit:own).

--- a/routes/project.js
+++ b/routes/project.js
@@ -1,0 +1,17 @@
+const express = require("express");
+const router = express.Router();
+
+const project = require("../controllers/project");
+const { CheckAdminLogin } = require("../middlewares/auth");
+const { requirePermission } = require("../middlewares/requirePermission");
+
+// Scope-filtered by CS owner: CS Exec sees own; Revenue Head / founders see
+// department/all per their projects:view grant.
+router.get(
+  "/",
+  CheckAdminLogin,
+  requirePermission("projects:view:own", { ownerField: "csOwnerId" }),
+  project.GetAll
+);
+
+module.exports = router;

--- a/routes/router.js
+++ b/routes/router.js
@@ -11,6 +11,7 @@ router.get("/", function (req, res) {
 router.use("/auth", require("./auth"));
 router.use("/user", require("./user"));
 router.use("/enquiry", require("./enquiry"));
+router.use("/project", require("./project")); // Lifecycle Slice D
 router.use("/decor", require("./decor"));
 router.use("/decor-package", require("./decor-package"));
 router.use("/search", require("./search"));

--- a/scripts/lifecycle-role-patch.js
+++ b/scripts/lifecycle-role-patch.js
@@ -1,0 +1,76 @@
+/* Lifecycle one-time idempotent patch (LOCAL DEV — also part of the prod deploy
+ * checklist, run once there by a human):
+ *   1. "Won" stage record (slug "won", category "won") — terminal stage for
+ *      converted leads; the pipeline validates stages against this collection.
+ *   2. Client Servicing Executive role gains projects:view:own + projects:edit:own
+ *      (needed to see their own handed-off projects).
+ *   3. "Sales Intern" role (Sales department) exists — the primary auto-assignment
+ *      pool. Created with leads:view:own + leads:edit:own if missing.
+ * Idempotent: every step checks before writing. Run: node scripts/lifecycle-role-patch.js
+ */
+require("dotenv").config();
+const mongoose = require("mongoose");
+const Stage = require("../models/Stage");
+const Role = require("../models/Role");
+const Department = require("../models/Department");
+
+(async () => {
+  await mongoose.connect(process.env.DATABASE_URL);
+  const log = [];
+
+  // 1. Won stage
+  const won = await Stage.findOne({ slug: "won" });
+  if (!won) {
+    const maxOrder = await Stage.findOne({ deletedAt: null }).sort({ order: -1 }).lean();
+    await Stage.create({
+      name: "Won",
+      slug: "won",
+      order: maxOrder ? maxOrder.order + 1 : 99,
+      color: "#0E7A4B",
+      category: "won",
+      isSystem: true,
+    });
+    log.push("created Won stage");
+  } else {
+    log.push("Won stage already present");
+  }
+
+  // 2. CS Executive projects perms
+  const csRole = await Role.findOne({ name: "Client Servicing Executive", deletedAt: null });
+  if (csRole) {
+    const needed = ["projects:view:own", "projects:edit:own"];
+    const missing = needed.filter((p) => !csRole.permissions.includes(p));
+    if (missing.length) {
+      csRole.permissions.push(...missing);
+      await csRole.save();
+      log.push(`added to CS Executive: ${missing.join(", ")}`);
+    } else {
+      log.push("CS Executive already has projects perms");
+    }
+  } else {
+    log.push("WARN: Client Servicing Executive role not found — skipped");
+  }
+
+  // 3. Sales Intern role
+  const intern = await Role.findOne({ name: "Sales Intern", deletedAt: null });
+  if (!intern) {
+    const salesDept = await Department.findOne({ name: "Sales", deletedAt: null });
+    if (salesDept) {
+      await Role.create({
+        name: "Sales Intern",
+        departmentId: salesDept._id,
+        description: "First-call pool — receives auto-assigned new leads",
+        permissions: ["leads:view:own", "leads:edit:own"],
+        isSystem: false,
+      });
+      log.push("created Sales Intern role");
+    } else {
+      log.push("WARN: Sales department not found — Sales Intern role skipped");
+    }
+  } else {
+    log.push("Sales Intern role already present");
+  }
+
+  console.log(log.join("\n"));
+  await mongoose.disconnect();
+})();

--- a/services/AdminService.js
+++ b/services/AdminService.js
@@ -1,8 +1,42 @@
 const AdminRepository = require("../repositories/AdminRepository");
+const RoleRepository = require("../repositories/RoleRepository");
+const Admin = require("../models/Admin");
+const { permissionSatisfies } = require("../middlewares/requirePermission");
 
-// List all admins. Returns an array (possibly empty). Strips password by repository.
-const listAdmins = async () => {
-  return await AdminRepository.findAll();
+// Scope-aware admin list (Lifecycle Slice H — the careful redo of the reverted gate).
+// The route stays CheckAdminLogin-only so legitimate pages never 403; what the
+// caller SEES is decided here:
+//   users:view:all        → full list (minus password)
+//   users:view:department → own department's admins (minus password)
+//   anything else         → ACTIVE admins as a minimal projection
+//                           { _id, name, roleId, departmentId } — enough for
+//                           assignee dropdowns, no emails/phones/status leakage.
+const listAdmins = async (callerId) => {
+  const caller = callerId ? await AdminRepository.findById(callerId) : null;
+  const role = caller && caller.roleId ? await RoleRepository.findById(caller.roleId) : null;
+  const perms = role && Array.isArray(role.permissions) ? role.permissions : [];
+
+  if (permissionSatisfies(perms, "users:view:all").allowed) {
+    return await AdminRepository.findAll();
+  }
+  if (
+    permissionSatisfies(perms, "users:view:department").allowed &&
+    caller &&
+    caller.departmentId
+  ) {
+    return await Admin.find(
+      { departmentId: caller.departmentId },
+      { password: 0 }
+    )
+      .sort({ name: 1 })
+      .lean();
+  }
+  return await Admin.find(
+    { status: "active" },
+    { _id: 1, name: 1, roleId: 1, departmentId: 1 }
+  )
+    .sort({ name: 1 })
+    .lean();
 };
 
 module.exports = {

--- a/services/CallCockpitService.js
+++ b/services/CallCockpitService.js
@@ -1,0 +1,237 @@
+const mongoose = require("mongoose");
+const EnquiryRepository = require("../repositories/EnquiryRepository");
+const LeadInternalEventService = require("./LeadInternalEventService");
+
+const CALL_OUTCOMES = ["", "qualified", "busy", "unknown", "disqualified"];
+const FOLLOW_UP_TYPES = ["meet", "call", "visit"];
+// Whitelisted qualificationData fields a PUT may write (everything else is ignored).
+const QUALIFICATION_STRING_FIELDS = [
+  "groomName",
+  "brideName",
+  "weddingStyle",
+  "venueStatus",
+  "venueName",
+  "venueTypeWanted",
+  "venueArea",
+  "venueBudget",
+  "venueShortlistNote",
+  "email",
+  "whatsappNumber",
+];
+const QUALIFICATION_BOOLEAN_FIELDS = ["emailNotWilling", "whatsappSameNumber"];
+
+const httpError = (status, message) => {
+  const err = new Error(message);
+  err.status = status;
+  return err;
+};
+
+const assertValidId = (id) => {
+  if (!mongoose.Types.ObjectId.isValid(id)) {
+    throw httpError(400, "Invalid enquiry id");
+  }
+};
+
+const parseDate = (value, fieldName) => {
+  const d = new Date(value);
+  if (!value || Number.isNaN(d.getTime())) {
+    throw httpError(400, `Invalid ${fieldName}`);
+  }
+  return d;
+};
+
+// Does the lead have at least one follow-up scheduled in the future?
+const hasFutureFollowUp = (enquiry, now = new Date()) =>
+  (enquiry.followUps || []).some(
+    (f) => f.scheduledAt && new Date(f.scheduledAt) > now
+  );
+
+// POST /enquiry/:_id/call-log — append-only. Stamps firstCalledAt on the first
+// call ever (set-once, via the SetFirstCall logic) and flips `qualified` when the
+// outcome is "qualified".
+const logCall = async (
+  enquiryId,
+  { startedAt, durationSeconds, connected, outcome, notes } = {},
+  actorId
+) => {
+  assertValidId(enquiryId);
+  const startedAtDate = parseDate(startedAt, "startedAt");
+  const duration = Number(durationSeconds);
+  if (!Number.isFinite(duration) || duration < 0) {
+    throw httpError(400, "Invalid durationSeconds");
+  }
+  if (outcome !== undefined && !CALL_OUTCOMES.includes(outcome)) {
+    throw httpError(400, `Invalid outcome (expected one of: ${CALL_OUTCOMES.filter(Boolean).join(", ")})`);
+  }
+  if (notes !== undefined && typeof notes !== "string") {
+    throw httpError(400, "Invalid notes");
+  }
+
+  const enquiry = await EnquiryRepository.findById(enquiryId);
+  if (!enquiry) {
+    throw httpError(404, "Enquiry not found");
+  }
+
+  const entry = {
+    startedAt: startedAtDate,
+    durationSeconds: duration,
+    connected: connected === true,
+    outcome: outcome || "",
+    notes: notes || "",
+    loggedBy: actorId || null,
+  };
+  const extraSet = outcome === "qualified" ? { qualified: true } : {};
+  const updated = await EnquiryRepository.pushCallLogById(enquiryId, entry, extraSet);
+
+  // First call on this lead → stamp the TAT anchor (no-op for later calls).
+  const stamped = await EnquiryRepository.stampFirstCalledAt(enquiryId);
+
+  await LeadInternalEventService.record({
+    leadId: enquiryId,
+    type: "call_logged",
+    actorId,
+    payload: {
+      outcome: entry.outcome,
+      durationSeconds: entry.durationSeconds,
+      connected: entry.connected,
+    },
+  });
+
+  // Prefer the stamped doc (it carries the fresh firstCalledAt) when this was the first call.
+  return stamped || updated;
+};
+
+// POST /enquiry/:_id/follow-up
+const addFollowUp = async (
+  enquiryId,
+  { type, scheduledAt, promiseNote } = {},
+  actorId
+) => {
+  assertValidId(enquiryId);
+  if (!FOLLOW_UP_TYPES.includes(type)) {
+    throw httpError(400, `Invalid type (expected one of: ${FOLLOW_UP_TYPES.join(", ")})`);
+  }
+  const scheduledAtDate = parseDate(scheduledAt, "scheduledAt");
+  if (promiseNote !== undefined && typeof promiseNote !== "string") {
+    throw httpError(400, "Invalid promiseNote");
+  }
+
+  const enquiry = await EnquiryRepository.findById(enquiryId);
+  if (!enquiry) {
+    throw httpError(404, "Enquiry not found");
+  }
+
+  const updated = await EnquiryRepository.pushFollowUpById(enquiryId, {
+    type,
+    scheduledAt: scheduledAtDate,
+    promiseNote: promiseNote || "",
+    createdBy: actorId || null,
+  });
+
+  await LeadInternalEventService.record({
+    leadId: enquiryId,
+    type: "follow_up_scheduled",
+    actorId,
+    payload: { followUpType: type, scheduledAt: scheduledAtDate, promiseNote: promiseNote || "" },
+  });
+
+  return updated;
+};
+
+// PUT /enquiry/:_id/qualification — partial update; only whitelisted fields are
+// written (dot-path $set so omitted fields are never clobbered).
+const updateQualification = async (enquiryId, body = {}, actorId) => {
+  assertValidId(enquiryId);
+
+  const set = {};
+  for (const field of QUALIFICATION_STRING_FIELDS) {
+    if (body[field] !== undefined) {
+      if (typeof body[field] !== "string") {
+        throw httpError(400, `Invalid ${field}`);
+      }
+      set[`qualificationData.${field}`] = body[field];
+    }
+  }
+  for (const field of QUALIFICATION_BOOLEAN_FIELDS) {
+    if (body[field] !== undefined) {
+      if (typeof body[field] !== "boolean") {
+        throw httpError(400, `Invalid ${field}`);
+      }
+      set[`qualificationData.${field}`] = body[field];
+    }
+  }
+  if (Object.keys(set).length === 0) {
+    throw httpError(400, "No valid qualification fields provided");
+  }
+
+  const updated = await EnquiryRepository.updateFieldsById(enquiryId, set);
+  if (!updated) {
+    throw httpError(404, "Enquiry not found");
+  }
+
+  await LeadInternalEventService.record({
+    leadId: enquiryId,
+    type: "qualification_updated",
+    actorId,
+    payload: { fields: Object.keys(set).map((k) => k.replace("qualificationData.", "")) },
+  });
+
+  return updated;
+};
+
+// POST /enquiry/:_id/call-complete — server-side mirror of the UI gate:
+// a qualified lead CANNOT be saved as complete without a future follow-up locked.
+// An explicit incomplete=true bypasses, with the acknowledged gaps recorded on the lead.
+const completeCall = async (enquiryId, { incomplete, gaps } = {}, actorId) => {
+  assertValidId(enquiryId);
+
+  const enquiry = await EnquiryRepository.findById(enquiryId);
+  if (!enquiry) {
+    throw httpError(404, "Enquiry not found");
+  }
+
+  const isIncomplete = incomplete === true;
+  if (isIncomplete) {
+    if (
+      gaps !== undefined &&
+      (!Array.isArray(gaps) || gaps.some((g) => typeof g !== "string"))
+    ) {
+      throw httpError(400, "Invalid gaps (expected an array of strings)");
+    }
+  } else if (enquiry.qualified && !hasFutureFollowUp(enquiry)) {
+    throw httpError(
+      400,
+      "Cannot complete: a qualified call must end with a future follow-up locked. Lock the next step, or save with incomplete=true to record the gap."
+    );
+  }
+
+  const updated = await EnquiryRepository.updateFieldsById(enquiryId, {
+    "callCompletion.status": isIncomplete ? "incomplete" : "complete",
+    "callCompletion.gaps": isIncomplete ? gaps || [] : [],
+    "callCompletion.completedAt": new Date(),
+    "callCompletion.completedBy": actorId || null,
+  });
+
+  await LeadInternalEventService.record({
+    leadId: enquiryId,
+    type: "call_completed",
+    actorId,
+    payload: { incomplete: isIncomplete, gaps: isIncomplete ? gaps || [] : [] },
+  });
+
+  return updated;
+};
+
+const listInternalEvents = async (enquiryId) => {
+  assertValidId(enquiryId);
+  return await LeadInternalEventService.listForLead(enquiryId);
+};
+
+module.exports = {
+  logCall,
+  addFollowUp,
+  updateQualification,
+  completeCall,
+  listInternalEvents,
+  hasFutureFollowUp,
+};

--- a/services/CallCockpitService.js
+++ b/services/CallCockpitService.js
@@ -4,6 +4,11 @@ const LeadInternalEventService = require("./LeadInternalEventService");
 
 const CALL_OUTCOMES = ["", "qualified", "busy", "unknown", "disqualified"];
 const FOLLOW_UP_TYPES = ["meet", "call", "visit"];
+// Attempt cadence (Lifecycle Slice C): day offsets from the FIRST unanswered
+// attempt for attempts #1..#4. Configurable via Settings later.
+const ATTEMPT_OFFSETS_DAYS = [0, 1, 3, 5];
+const MAX_ATTEMPTS = 4;
+const UNANSWERED_OUTCOMES = ["busy", "unknown"];
 // Whitelisted qualificationData fields a PUT may write (everything else is ignored).
 const QUALIFICATION_STRING_FIELDS = [
   "groomName",
@@ -45,6 +50,54 @@ const hasFutureFollowUp = (enquiry, now = new Date()) =>
   (enquiry.followUps || []).some(
     (f) => f.scheduledAt && new Date(f.scheduledAt) > now
   );
+
+// Attempt-cadence state for a lead's call log (Lifecycle Slice C). attempts =
+// unanswered (busy/unknown) calls so far. Below MAX: suggest the next attempt per
+// the 0/1/3/5-day rhythm anchored to the first unanswered attempt (clamped to
+// tomorrow if the rhythm date already passed). At MAX: unresponsive — rep decides.
+const cadenceFor = (callLog, now = new Date()) => {
+  const unanswered = (callLog || []).filter((e) =>
+    UNANSWERED_OUTCOMES.includes(e.outcome)
+  );
+  const attempts = unanswered.length;
+  if (attempts === 0 || attempts >= MAX_ATTEMPTS) {
+    return {
+      attempts,
+      maxAttempts: MAX_ATTEMPTS,
+      suggestedNextAttemptAt: null,
+      unresponsive: attempts >= MAX_ATTEMPTS,
+    };
+  }
+  const first = new Date(unanswered[0].startedAt);
+  let suggested = new Date(
+    first.getTime() + ATTEMPT_OFFSETS_DAYS[attempts] * 24 * 60 * 60 * 1000
+  );
+  if (suggested <= now) {
+    suggested = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+  }
+  return {
+    attempts,
+    maxAttempts: MAX_ATTEMPTS,
+    suggestedNextAttemptAt: suggested,
+    unresponsive: false,
+  };
+};
+
+// Stamp unresponsiveFlaggedAt + event once attempts reach MAX (set-once on the flag).
+const flagUnresponsiveIfNeeded = async (enquiryId, callLog, actorId, alreadyFlaggedAt) => {
+  const cadence = cadenceFor(callLog);
+  if (!cadence.unresponsive || alreadyFlaggedAt) return false;
+  await EnquiryRepository.updateFieldsById(enquiryId, {
+    unresponsiveFlaggedAt: new Date(),
+  });
+  await LeadInternalEventService.record({
+    leadId: enquiryId,
+    type: "unresponsive_flagged",
+    actorId,
+    payload: { attempts: cadence.attempts },
+  });
+  return true;
+};
 
 // POST /enquiry/:_id/call-log — append-only. Stamps firstCalledAt on the first
 // call ever (set-once, via the SetFirstCall logic) and flips `qualified` when the
@@ -97,8 +150,21 @@ const logCall = async (
     },
   });
 
-  // Prefer the stamped doc (it carries the fresh firstCalledAt) when this was the first call.
-  return stamped || updated;
+  // Cadence (Slice C): on an unanswered outcome, surface the suggested next attempt
+  // (the scheduler pre-fills it) or flag the lead unresponsive at MAX attempts.
+  const doc = stamped || updated;
+  const leadObj = doc.toObject ? doc.toObject() : doc;
+  if (UNANSWERED_OUTCOMES.includes(entry.outcome)) {
+    const flaggedNow = await flagUnresponsiveIfNeeded(
+      enquiryId,
+      leadObj.callLog,
+      actorId,
+      leadObj.unresponsiveFlaggedAt
+    );
+    leadObj.cadence = cadenceFor(leadObj.callLog);
+    if (flaggedNow) leadObj.unresponsiveFlaggedAt = new Date();
+  }
+  return leadObj;
 };
 
 // POST /enquiry/:_id/follow-up
@@ -234,4 +300,9 @@ module.exports = {
   completeCall,
   listInternalEvents,
   hasFutureFollowUp,
+  cadenceFor,
+  flagUnresponsiveIfNeeded,
+  ATTEMPT_OFFSETS_DAYS,
+  MAX_ATTEMPTS,
+  UNANSWERED_OUTCOMES,
 };

--- a/services/DashboardService.js
+++ b/services/DashboardService.js
@@ -206,7 +206,17 @@ const buildDashboard = async (adminId, scope, scopeFilter = {}) => {
   const counts = {};
   for (const c of stageCounts) counts[c._id || "unknown"] = c.count;
 
+  // Mission progress: follow-ups completed today in scope ("X of Y done").
+  const completedTodayDocs = await Enquiry.aggregate([
+    { $match: { ...scopeFilter } },
+    { $unwind: "$followUps" },
+    { $match: { "followUps.completedAt": { $gte: todayStart, $lte: todayEnd } } },
+    { $count: "n" },
+  ]);
+  const completedToday = completedTodayDocs.length ? completedTodayDocs[0].n : 0;
+
   const payload = {
+    completedToday,
     generatedAt: now,
     scope,
     todaysMission,

--- a/services/DashboardService.js
+++ b/services/DashboardService.js
@@ -56,6 +56,11 @@ const buildDashboard = async (adminId, scope, scopeFilter = {}) => {
   // Lazy resurface (Slice E): recycled leads past revisitAt come back before we read.
   await LeadLifecycleService.resurfaceDueLeads(scopeFilter);
 
+  // Hardening: admins who can no longer work leads — their open leads are orphans.
+  const inactiveAdminIds = (
+    await Admin.find({ status: { $ne: "active" } }, { _id: 1 }).lean()
+  ).map((a) => a._id);
+
   const [
     missionLeads,
     unresponsiveLeads,
@@ -66,6 +71,8 @@ const buildDashboard = async (adminId, scope, scopeFilter = {}) => {
     resurfacedDocs,
     promiseLeads,
     stageCounts,
+    orphanedLeads,
+    returnedLeadDocs,
   ] = await Promise.all([
     // Open follow-ups due today or overdue.
     Enquiry.find({
@@ -79,13 +86,15 @@ const buildDashboard = async (adminId, scope, scopeFilter = {}) => {
     Enquiry.find({ ...scopeFilter, ...ACTIVE, stage: "new", "callLog.0": { $exists: false } })
       .sort({ createdAt: 1 })
       .lean(),
-    // At-risk A: New, no call, older than the SLA.
+    // At-risk A: New, no call, older than the SLA. Imported historical leads are
+    // excluded — a Zoho migration must never read as an SLA storm.
     Enquiry.find({
       ...scopeFilter,
       ...ACTIVE,
       stage: "new",
       "callLog.0": { $exists: false },
       createdAt: { $lt: dayAgo },
+      importedAt: null,
     }).lean(),
     // At-risk B candidates: Contacted (silence checked against the event stream below).
     Enquiry.find({ ...scopeFilter, ...ACTIVE, stage: "contacted" }).lean(),
@@ -104,6 +113,16 @@ const buildDashboard = async (adminId, scope, scopeFilter = {}) => {
       { $match: { ...scopeFilter, "recycled.isRecycled": { $ne: true } } },
       { $group: { _id: "$stage", count: { $sum: 1 } } },
     ]),
+    // Hardening: open leads owned by a non-active admin — at risk regardless of recency.
+    inactiveAdminIds.length
+      ? Enquiry.find({ ...scopeFilter, ...ACTIVE, assignedTo: { $in: inactiveAdminIds } }).lean()
+      : Promise.resolve([]),
+    // Hardening: lost leads that came back (re-enquired in the last 14 days).
+    Enquiry.find({
+      ...scopeFilter,
+      stage: "lost",
+      reEnquiredAt: { $gte: new Date(now.getTime() - 14 * 24 * 3600 * 1000) },
+    }).lean(),
   ]);
 
   // Today's mission rows: one per due/overdue follow-up, chronological.
@@ -133,7 +152,9 @@ const buildDashboard = async (adminId, scope, scopeFilter = {}) => {
   }));
 
   const newUntouched = newUntouchedLeads.map((lead) => {
-    const gw = goldenWindowFor(lead.createdAt, now);
+    // Imported leads anchor the golden window on the IMPORT time, not the
+    // (historical) createdAt — a 2024 Zoho lead isn't a breached 30-min window.
+    const gw = goldenWindowFor(lead.importedAt || lead.createdAt, now);
     return {
       ...leadRow(lead),
       source: lead.marketingSource || lead.source || "",
@@ -153,26 +174,38 @@ const buildDashboard = async (adminId, scope, scopeFilter = {}) => {
       ])
     : [];
   const lastEventByLead = new Map(lastEvents.map((e) => [String(e._id), e.last]));
+  const orphanIds = new Set(orphanedLeads.map((l) => String(l._id)));
   const atRisk = [
-    ...staleNewLeads.map((lead) => ({
+    // Orphans first: an inactive owner is the most urgent risk, recency irrelevant.
+    ...orphanedLeads.map((lead) => ({
       ...leadRow(lead),
-      reason: "new_no_call",
-      hoursOverSla: Math.floor((now - new Date(lead.createdAt)) / 3600000 - NEW_LEAD_SLA_HOURS),
+      reason: "owner_inactive",
+      hoursOverSla: Math.floor((now - new Date(lead.updatedAt)) / 3600000),
     })),
-    ...contactedLeads
-      .map((lead) => {
-        const last = lastEventByLead.get(String(lead._id)) || lead.updatedAt;
-        const silentHours = (now - new Date(last)) / 3600000;
-        return silentHours > CONTACTED_SILENCE_SLA_HOURS
-          ? {
-              ...leadRow(lead),
-              reason: "contacted_silent",
-              hoursOverSla: Math.floor(silentHours - CONTACTED_SILENCE_SLA_HOURS),
-            }
-          : null;
-      })
-      .filter(Boolean),
-  ].sort((a, b) => b.hoursOverSla - a.hoursOverSla);
+    ...[
+      ...staleNewLeads
+        .filter((lead) => !orphanIds.has(String(lead._id)))
+        .map((lead) => ({
+          ...leadRow(lead),
+          reason: "new_no_call",
+          hoursOverSla: Math.floor((now - new Date(lead.createdAt)) / 3600000 - NEW_LEAD_SLA_HOURS),
+        })),
+      ...contactedLeads
+        .filter((lead) => !orphanIds.has(String(lead._id)))
+        .map((lead) => {
+          const last = lastEventByLead.get(String(lead._id)) || lead.updatedAt;
+          const silentHours = (now - new Date(last)) / 3600000;
+          return silentHours > CONTACTED_SILENCE_SLA_HOURS
+            ? {
+                ...leadRow(lead),
+                reason: "contacted_silent",
+                hoursOverSla: Math.floor(silentHours - CONTACTED_SILENCE_SLA_HOURS),
+              }
+            : null;
+        })
+        .filter(Boolean),
+    ].sort((a, b) => b.hoursOverSla - a.hoursOverSla),
+  ];
 
   const hotLeads = hotLeadDocs.map((lead) => {
     const nextMeeting = (lead.followUps || [])
@@ -215,6 +248,14 @@ const buildDashboard = async (adminId, scope, scopeFilter = {}) => {
   ]);
   const completedToday = completedTodayDocs.length ? completedTodayDocs[0].n : 0;
 
+  // "Returned — they came back": lost leads that re-enquired in the last 14 days.
+  const returnedLeads = returnedLeadDocs.map((lead) => ({
+    ...leadRow(lead),
+    reEnquiredAt: lead.reEnquiredAt,
+    lostReason: lead.lostReason || "",
+    stageBeforeLost: lead.stageBeforeLost || "",
+  }));
+
   const payload = {
     completedToday,
     generatedAt: now,
@@ -225,6 +266,7 @@ const buildDashboard = async (adminId, scope, scopeFilter = {}) => {
     atRisk,
     hotLeads,
     resurfacedToday,
+    returnedLeads,
     promises,
     counts,
   };
@@ -341,9 +383,10 @@ const buildManagerSections = async (adminId, scope, scopeFilter, { now, todaySta
     createdAt: e.createdAt,
   }));
 
-  // Golden-window health this week.
+  // Golden-window health this week. Imported historical leads excluded — the
+  // migration must never read as a wall of breaches.
   const weekLeads = await Enquiry.find(
-    { ...scopeFilter, createdAt: { $gte: weekAgo } },
+    { ...scopeFilter, createdAt: { $gte: weekAgo }, importedAt: null },
     { createdAt: 1, firstCalledAt: 1 }
   ).lean();
   let minutesSum = 0;

--- a/services/DashboardService.js
+++ b/services/DashboardService.js
@@ -1,0 +1,361 @@
+const Enquiry = require("../models/Enquiry");
+const Admin = require("../models/Admin");
+const LeadInternalEvent = require("../models/LeadInternalEvent");
+const LeadLifecycleService = require("./LeadLifecycleService");
+const { computeLeadHealth } = require("../utils/leadHealth");
+const {
+  goldenWindowFor,
+  goldenDeadline,
+  istDayStart,
+  istDayEnd,
+  toIstWallClock,
+} = require("../utils/goldenWindow");
+
+// At-risk SLAs — configurable via Settings later; constants for Phase 1.
+const NEW_LEAD_SLA_HOURS = 24; // stage New with no call in 24h
+const CONTACTED_SILENCE_SLA_HOURS = 24; // stage Contacted with no internal event in 24h
+const RE_ENQUIRED_BADGE_DAYS = 7;
+
+// A lead still in play for active dashboard surfaces.
+const ACTIVE = {
+  stage: { $nin: ["won", "lost"] },
+  "recycled.isRecycled": { $ne: true },
+  lostStatus: { $nin: ["pending", "approved"] },
+};
+
+// first 2 + last 4 of the local number visible, e.g. "+91 98••• •3210".
+const maskPhone = (phone) => {
+  const digits = String(phone || "").replace(/\D/g, "");
+  if (digits.length < 7) return phone || "—";
+  const local = digits.length > 10 ? digits.slice(-10) : digits;
+  const cc = digits.length > 10 ? `+${digits.slice(0, digits.length - 10)} ` : "";
+  return `${cc}${local.slice(0, 2)}••• •${local.slice(-4)}`;
+};
+
+const leadRow = (lead) => ({
+  leadId: lead._id,
+  name: lead.name,
+  maskedPhone: maskPhone(lead.phone),
+  stage: lead.stage,
+  healthLabel: computeLeadHealth(lead, []).label,
+});
+
+// IST day key for sparkline bucketing.
+const istDayKey = (d) => {
+  const ist = toIstWallClock(new Date(d));
+  return ist.toISOString().slice(0, 10);
+};
+
+const buildDashboard = async (adminId, scope, scopeFilter = {}) => {
+  const now = new Date();
+  const todayStart = istDayStart(now);
+  const todayEnd = istDayEnd(now);
+  const dayAgo = new Date(now.getTime() - NEW_LEAD_SLA_HOURS * 3600 * 1000);
+  const weekAgo = new Date(now.getTime() - 7 * 24 * 3600 * 1000);
+
+  // Lazy resurface (Slice E): recycled leads past revisitAt come back before we read.
+  await LeadLifecycleService.resurfaceDueLeads(scopeFilter);
+
+  const [
+    missionLeads,
+    unresponsiveLeads,
+    newUntouchedLeads,
+    staleNewLeads,
+    contactedLeads,
+    hotLeadDocs,
+    resurfacedDocs,
+    promiseLeads,
+    stageCounts,
+  ] = await Promise.all([
+    // Open follow-ups due today or overdue.
+    Enquiry.find({
+      ...scopeFilter,
+      ...ACTIVE,
+      followUps: { $elemMatch: { completedAt: null, scheduledAt: { $lte: todayEnd } } },
+    }).lean(),
+    // Unresponsive — decide rows.
+    Enquiry.find({ ...scopeFilter, ...ACTIVE, unresponsiveFlaggedAt: { $ne: null } }).lean(),
+    // New & untouched (no call yet), oldest first.
+    Enquiry.find({ ...scopeFilter, ...ACTIVE, stage: "new", "callLog.0": { $exists: false } })
+      .sort({ createdAt: 1 })
+      .lean(),
+    // At-risk A: New, no call, older than the SLA.
+    Enquiry.find({
+      ...scopeFilter,
+      ...ACTIVE,
+      stage: "new",
+      "callLog.0": { $exists: false },
+      createdAt: { $lt: dayAgo },
+    }).lean(),
+    // At-risk B candidates: Contacted (silence checked against the event stream below).
+    Enquiry.find({ ...scopeFilter, ...ACTIVE, stage: "contacted" }).lean(),
+    // Hot: meetings on the books.
+    Enquiry.find({ ...scopeFilter, ...ACTIVE, stage: "meeting_scheduled" }).lean(),
+    // Resurfaced today (isRecycled already cleared by the lazy pass).
+    Enquiry.find({ ...scopeFilter, "recycled.resurfacedAt": { $gte: todayStart } }).lean(),
+    // All open promises.
+    Enquiry.find({
+      ...scopeFilter,
+      ...ACTIVE,
+      followUps: { $elemMatch: { completedAt: null, promiseNote: { $nin: [null, ""] } } },
+    }).lean(),
+    // Pipeline weight per stage (recycled excluded; won/lost included for the funnel).
+    Enquiry.aggregate([
+      { $match: { ...scopeFilter, "recycled.isRecycled": { $ne: true } } },
+      { $group: { _id: "$stage", count: { $sum: 1 } } },
+    ]),
+  ]);
+
+  // Today's mission rows: one per due/overdue follow-up, chronological.
+  const todaysMission = missionLeads
+    .flatMap((lead) =>
+      (lead.followUps || [])
+        .filter((f) => !f.completedAt && new Date(f.scheduledAt) <= todayEnd)
+        .map((f) => ({
+          ...leadRow(lead),
+          followUpId: f._id,
+          type: f.type,
+          scheduledAt: f.scheduledAt,
+          promiseNote: f.promiseNote || "",
+          overdue: new Date(f.scheduledAt) < now,
+          meetingToday:
+            ["meet", "visit"].includes(f.type) &&
+            new Date(f.scheduledAt) >= todayStart &&
+            new Date(f.scheduledAt) <= todayEnd,
+        }))
+    )
+    .sort((a, b) => new Date(a.scheduledAt) - new Date(b.scheduledAt));
+
+  const unresponsiveDecide = unresponsiveLeads.map((lead) => ({
+    ...leadRow(lead),
+    flaggedAt: lead.unresponsiveFlaggedAt,
+    attempts: (lead.callLog || []).filter((e) => ["busy", "unknown"].includes(e.outcome)).length,
+  }));
+
+  const newUntouched = newUntouchedLeads.map((lead) => {
+    const gw = goldenWindowFor(lead.createdAt, now);
+    return {
+      ...leadRow(lead),
+      source: lead.marketingSource || lead.source || "",
+      createdAt: lead.createdAt,
+      minutesSinceCreated: Math.floor((now - new Date(lead.createdAt)) / 60000),
+      goldenWindow: gw,
+      reEnquired: !!(lead.reEnquiredAt && new Date(lead.reEnquiredAt) >= weekAgo),
+    };
+  });
+
+  // At-risk B: contacted leads silent (no internal event) past the SLA.
+  const contactedIds = contactedLeads.map((l) => l._id);
+  const lastEvents = contactedIds.length
+    ? await LeadInternalEvent.aggregate([
+        { $match: { leadId: { $in: contactedIds } } },
+        { $group: { _id: "$leadId", last: { $max: "$createdAt" } } },
+      ])
+    : [];
+  const lastEventByLead = new Map(lastEvents.map((e) => [String(e._id), e.last]));
+  const atRisk = [
+    ...staleNewLeads.map((lead) => ({
+      ...leadRow(lead),
+      reason: "new_no_call",
+      hoursOverSla: Math.floor((now - new Date(lead.createdAt)) / 3600000 - NEW_LEAD_SLA_HOURS),
+    })),
+    ...contactedLeads
+      .map((lead) => {
+        const last = lastEventByLead.get(String(lead._id)) || lead.updatedAt;
+        const silentHours = (now - new Date(last)) / 3600000;
+        return silentHours > CONTACTED_SILENCE_SLA_HOURS
+          ? {
+              ...leadRow(lead),
+              reason: "contacted_silent",
+              hoursOverSla: Math.floor(silentHours - CONTACTED_SILENCE_SLA_HOURS),
+            }
+          : null;
+      })
+      .filter(Boolean),
+  ].sort((a, b) => b.hoursOverSla - a.hoursOverSla);
+
+  const hotLeads = hotLeadDocs.map((lead) => {
+    const nextMeeting = (lead.followUps || [])
+      .filter((f) => !f.completedAt && ["meet", "visit"].includes(f.type) && new Date(f.scheduledAt) > now)
+      .sort((a, b) => new Date(a.scheduledAt) - new Date(b.scheduledAt))[0];
+    return { ...leadRow(lead), nextMeetingAt: nextMeeting ? nextMeeting.scheduledAt : null };
+  });
+
+  const resurfacedToday = resurfacedDocs.map((lead) => ({
+    ...leadRow(lead),
+    reason: lead.recycled ? lead.recycled.reason : "",
+    recycledAt: lead.recycled ? lead.recycled.recycledAt : null,
+  }));
+
+  const promises = promiseLeads
+    .flatMap((lead) =>
+      (lead.followUps || [])
+        .filter((f) => !f.completedAt && f.promiseNote)
+        .map((f) => ({
+          leadId: lead._id,
+          name: lead.name,
+          followUpId: f._id,
+          promiseNote: f.promiseNote,
+          scheduledAt: f.scheduledAt,
+          due: new Date(f.scheduledAt) <= todayEnd,
+          overdue: new Date(f.scheduledAt) < now,
+        }))
+    )
+    .sort((a, b) => new Date(a.scheduledAt) - new Date(b.scheduledAt));
+
+  const counts = {};
+  for (const c of stageCounts) counts[c._id || "unknown"] = c.count;
+
+  const payload = {
+    generatedAt: now,
+    scope,
+    todaysMission,
+    unresponsiveDecide,
+    newUntouched,
+    atRisk,
+    hotLeads,
+    resurfacedToday,
+    promises,
+    counts,
+  };
+
+  // Manager sections only for broader-than-own scopes.
+  if (["team", "department", "all"].includes(scope)) {
+    Object.assign(payload, await buildManagerSections(adminId, scope, scopeFilter, { now, todayStart, todayEnd, weekAgo }));
+  }
+  return payload;
+};
+
+const buildManagerSections = async (adminId, scope, scopeFilter, { now, todayStart, todayEnd, weekAgo }) => {
+  const { getSubordinateIds } = require("../middlewares/requirePermission");
+  const caller = await Admin.findById(adminId).lean();
+
+  let pool;
+  if (scope === "team") {
+    const subIds = await getSubordinateIds(adminId);
+    pool = await Admin.find({ _id: { $in: [adminId, ...subIds] } }).lean();
+  } else if (scope === "department" && caller && caller.departmentId) {
+    pool = await Admin.find({ departmentId: caller.departmentId, status: "active" }).lean();
+  } else {
+    pool = await Admin.find({ status: "active" }).lean();
+  }
+  const poolIds = pool.map((a) => a._id);
+
+  // One aggregate for everyone's 7-day activity sparklines.
+  const activity = await LeadInternalEvent.aggregate([
+    { $match: { actorId: { $in: poolIds }, createdAt: { $gte: weekAgo } } },
+    { $group: { _id: { actor: "$actorId", day: { $dateToString: { format: "%Y-%m-%d", date: "$createdAt", timezone: "Asia/Kolkata" } } }, n: { $sum: 1 } } },
+  ]);
+  const activityByActor = new Map();
+  for (const a of activity) {
+    const key = String(a._id.actor);
+    if (!activityByActor.has(key)) activityByActor.set(key, {});
+    activityByActor.get(key)[a._id.day] = a.n;
+  }
+  const last7Days = Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(now.getTime() - (6 - i) * 24 * 3600 * 1000);
+    return istDayKey(d);
+  });
+
+  const teamRollup = await Promise.all(
+    pool.map(async (member) => {
+      const own = { assignedTo: member._id };
+      const [dueToday, overdue, untouched, atRiskCount] = await Promise.all([
+        Enquiry.countDocuments({
+          ...own,
+          ...ACTIVE,
+          followUps: { $elemMatch: { completedAt: null, scheduledAt: { $gte: todayStart, $lte: todayEnd } } },
+        }),
+        Enquiry.countDocuments({
+          ...own,
+          ...ACTIVE,
+          followUps: { $elemMatch: { completedAt: null, scheduledAt: { $lt: todayStart } } },
+        }),
+        Enquiry.countDocuments({ ...own, ...ACTIVE, stage: "new", "callLog.0": { $exists: false } }),
+        Enquiry.countDocuments({
+          ...own,
+          ...ACTIVE,
+          stage: "new",
+          "callLog.0": { $exists: false },
+          createdAt: { $lt: new Date(now.getTime() - NEW_LEAD_SLA_HOURS * 3600 * 1000) },
+        }),
+      ]);
+      const byDay = activityByActor.get(String(member._id)) || {};
+      return {
+        adminId: member._id,
+        name: member.name,
+        dueToday,
+        overdue,
+        untouched,
+        atRisk: atRiskCount,
+        sparkline: last7Days.map((day) => byDay[day] || 0),
+      };
+    })
+  );
+
+  // Approval queue — PR #26 shapes (pending disqualify requests in scope).
+  const approvalDocs = await Enquiry.find({ ...scopeFilter, lostStatus: "pending" }).lean();
+  const requesterIds = approvalDocs.map((l) => l.lostRequestedBy).filter(Boolean);
+  const requesters = requesterIds.length
+    ? await Admin.find({ _id: { $in: requesterIds } }, { name: 1 }).lean()
+    : [];
+  const requesterById = new Map(requesters.map((r) => [String(r._id), r.name]));
+  const approvalQueue = approvalDocs.map((lead) => ({
+    leadId: lead._id,
+    name: lead.name,
+    maskedPhone: maskPhone(lead.phone),
+    stage: lead.stage,
+    lostReason: lead.lostReason,
+    lostNote: lead.lostNote,
+    lostRequestedBy: lead.lostRequestedBy,
+    lostRequestedByName: requesterById.get(String(lead.lostRequestedBy)) || "—",
+    lostRequestedAt: lead.lostRequestedAt,
+  }));
+
+  // Recent team activity feed.
+  const recentEvents = await LeadInternalEvent.find({ actorId: { $in: poolIds } })
+    .sort({ createdAt: -1 })
+    .limit(20)
+    .lean();
+  const eventLeadIds = [...new Set(recentEvents.map((e) => String(e.leadId)))];
+  const eventLeads = await Enquiry.find({ _id: { $in: eventLeadIds } }, { name: 1 }).lean();
+  const leadNameById = new Map(eventLeads.map((l) => [String(l._id), l.name]));
+  const adminNameById = new Map(pool.map((a) => [String(a._id), a.name]));
+  const recentTeamActivity = recentEvents.map((e) => ({
+    _id: e._id,
+    type: e.type,
+    leadId: e.leadId,
+    leadName: leadNameById.get(String(e.leadId)) || "—",
+    actorName: adminNameById.get(String(e.actorId)) || "system",
+    payload: e.payload || {},
+    createdAt: e.createdAt,
+  }));
+
+  // Golden-window health this week.
+  const weekLeads = await Enquiry.find(
+    { ...scopeFilter, createdAt: { $gte: weekAgo } },
+    { createdAt: 1, firstCalledAt: 1 }
+  ).lean();
+  let minutesSum = 0;
+  let calledCount = 0;
+  let breaches = 0;
+  for (const lead of weekLeads) {
+    const deadline = goldenDeadline(lead.createdAt);
+    if (lead.firstCalledAt) {
+      minutesSum += (new Date(lead.firstCalledAt) - new Date(lead.createdAt)) / 60000;
+      calledCount += 1;
+      if (new Date(lead.firstCalledAt) > deadline) breaches += 1;
+    } else if (now > deadline) {
+      breaches += 1;
+    }
+  }
+  const goldenWindowHealth = {
+    weekLeadCount: weekLeads.length,
+    avgFirstCallMinutes: calledCount ? Math.round(minutesSum / calledCount) : null,
+    breaches,
+  };
+
+  return { teamRollup, approvalQueue, recentTeamActivity, goldenWindowHealth };
+};
+
+module.exports = { buildDashboard, maskPhone, ACTIVE };

--- a/services/LeadAssignmentService.js
+++ b/services/LeadAssignmentService.js
@@ -1,0 +1,75 @@
+const Admin = require("../models/Admin");
+const Role = require("../models/Role");
+const Enquiry = require("../models/Enquiry");
+const LeadInternalEventService = require("./LeadInternalEventService");
+const { istDayStart } = require("../utils/goldenWindow");
+
+// Configurable via Settings later — constants for Phase 1.
+const DAILY_ASSIGNMENT_CAP = 15;
+// Primary pool first; overflow to the next pool when everyone is at cap.
+const POOL_ROLE_NAMES = ["Sales Intern", "Sales Executive"];
+
+// Least-recently-assigned ACTIVE admin in the pools with remaining daily capacity.
+// Round-robin state is the additive Admin.lastAssignedAt field (nulls sort first,
+// so brand-new pool members get the next lead).
+const pickAssignee = async () => {
+  const todayStart = istDayStart();
+  for (const roleName of POOL_ROLE_NAMES) {
+    const role = await Role.findOne({ name: roleName, deletedAt: null }).lean();
+    if (!role) continue;
+    const pool = await Admin.find({ roleId: role._id, status: "active" })
+      .sort({ lastAssignedAt: 1 })
+      .lean();
+    for (const admin of pool) {
+      const assignedToday = await Enquiry.countDocuments({
+        assignedTo: admin._id,
+        createdAt: { $gte: todayStart },
+      });
+      if (assignedToday < DAILY_ASSIGNMENT_CAP) return admin;
+    }
+  }
+  return null;
+};
+
+// Auto-assign a freshly-created lead. Nobody available → lead stays unassigned and
+// an "assignment_failed" event makes it scream on the founder dashboard's untouched list.
+// Never throws (intake must not fail because assignment did).
+const doAssignLead = async (enquiryId) => {
+  try {
+    const assignee = await pickAssignee();
+    if (!assignee) {
+      await LeadInternalEventService.record({
+        leadId: enquiryId,
+        type: "assignment_failed",
+        actorId: null,
+        payload: { reason: "No active pool member under the daily cap" },
+      });
+      return null;
+    }
+    await Enquiry.findByIdAndUpdate(enquiryId, { $set: { assignedTo: assignee._id } });
+    await Admin.findByIdAndUpdate(assignee._id, { $set: { lastAssignedAt: new Date() } });
+    await LeadInternalEventService.record({
+      leadId: enquiryId,
+      type: "auto_assigned",
+      actorId: null,
+      payload: { assignedTo: String(assignee._id), assignedToName: assignee.name },
+    });
+    return assignee;
+  } catch (e) {
+    console.error("LeadAssignmentService.assignLead failed:", e.message);
+    return null;
+  }
+};
+
+// Serialize assignments in-process: burst arrivals (webhook spikes) would otherwise
+// race the least-recently-assigned read before lastAssignedAt persists and skew the
+// round-robin. Single node process today; a multi-instance deploy would need an
+// atomic DB claim instead (noted in the lifecycle report).
+let assignmentQueue = Promise.resolve();
+const assignLead = (enquiryId) => {
+  const task = assignmentQueue.then(() => doAssignLead(enquiryId));
+  assignmentQueue = task.catch(() => {});
+  return task;
+};
+
+module.exports = { assignLead, pickAssignee, DAILY_ASSIGNMENT_CAP, POOL_ROLE_NAMES };

--- a/services/LeadImportService.js
+++ b/services/LeadImportService.js
@@ -1,0 +1,203 @@
+const Papa = require("papaparse");
+const Enquiry = require("../models/Enquiry");
+const Stage = require("../models/Stage");
+const LeadIntakeService = require("./LeadIntakeService");
+const LeadAssignmentService = require("./LeadAssignmentService");
+
+const IMPORT_SOURCE = "zoho_import";
+const BATCH_SIZE = 500;
+
+// Our target fields and the header aliases we auto-map from (lowercased).
+const FIELD_ALIASES = {
+  name: ["name", "full name", "lead name", "first name", "contact name", "contact"],
+  phone: ["phone", "mobile", "mobile number", "phone number", "contact number", "phone no"],
+  email: ["email", "e-mail", "email address", "email id"],
+  source: ["source", "lead source", "channel", "lead channel"],
+  stage: ["stage", "status", "lead status", "pipeline stage", "lead stage"],
+  notes: ["notes", "note", "description", "remarks", "comments"],
+  createdAt: ["created", "created time", "created at", "created date", "date", "created_date", "created on"],
+};
+
+const httpError = (status, message) => {
+  const err = new Error(message);
+  err.status = status;
+  return err;
+};
+
+const parseCsv = (buffer) => {
+  const text = buffer.toString("utf8");
+  const parsed = Papa.parse(text, { header: true, skipEmptyLines: true });
+  if (!parsed.data || parsed.data.length === 0) {
+    throw httpError(400, "The CSV appears to be empty or unparseable");
+  }
+  return parsed;
+};
+
+// Header → field auto-mapping by similarity (exact alias, then contains).
+const detectMapping = (headers) => {
+  const mapping = {};
+  const taken = new Set();
+  for (const [field, aliases] of Object.entries(FIELD_ALIASES)) {
+    let match = headers.find(
+      (h) => !taken.has(h) && aliases.includes(String(h).trim().toLowerCase())
+    );
+    if (!match) {
+      match = headers.find((h) => {
+        if (taken.has(h)) return false;
+        const low = String(h).trim().toLowerCase();
+        return aliases.some((a) => low.includes(a) || a.includes(low));
+      });
+    }
+    if (match) {
+      mapping[field] = match;
+      taken.add(match);
+    }
+  }
+  return mapping;
+};
+
+// Set of normalized phones already in the CRM (founder import tool — full scan is fine).
+const existingPhoneMap = async () => {
+  const existing = await Enquiry.find({}, { phone: 1 }).lean();
+  const map = new Map();
+  for (const e of existing) {
+    const normalized = LeadIntakeService.normalizePhone(e.phone);
+    if (normalized.length >= 7) map.set(normalized, e._id);
+  }
+  return map;
+};
+
+const preview = async (buffer) => {
+  const parsed = parseCsv(buffer);
+  const headers = parsed.meta.fields || [];
+  const detectedMapping = detectMapping(headers);
+
+  const phoneHeader = detectedMapping.phone;
+  let duplicates = 0;
+  if (phoneHeader) {
+    const phones = await existingPhoneMap();
+    for (const row of parsed.data) {
+      const normalized = LeadIntakeService.normalizePhone(row[phoneHeader]);
+      if (normalized.length >= 7 && phones.has(normalized)) duplicates += 1;
+    }
+  }
+
+  return {
+    headers,
+    detectedMapping,
+    rowCount: parsed.data.length,
+    sampleRows: parsed.data.slice(0, 10),
+    duplicates,
+  };
+};
+
+const commit = async (buffer, options = {}, actorId) => {
+  const {
+    mapping = {},
+    stageMapping = {},
+    skipDuplicates = true,
+    assignOnImport = false,
+  } = options;
+  if (!mapping.phone || !mapping.name) {
+    throw httpError(400, "Mapping must include at least name and phone columns");
+  }
+
+  const parsed = parseCsv(buffer);
+  const validStages = new Set(
+    (await Stage.find({ deletedAt: null }, { slug: 1 }).lean()).map((s) => s.slug)
+  );
+  const phones = await existingPhoneMap();
+  const seenInFile = new Set();
+  const now = new Date();
+
+  const toCreate = [];
+  const errors = [];
+  let skippedDuplicates = 0;
+
+  parsed.data.forEach((row, index) => {
+    const rowNo = index + 2; // 1-based + header row
+    const name = String(row[mapping.name] || "").trim();
+    const phone = String(row[mapping.phone] || "").trim();
+    const normalized = LeadIntakeService.normalizePhone(phone);
+    if (!name || normalized.length < 7) {
+      errors.push({ row: rowNo, error: "Missing/invalid name or phone" });
+      return;
+    }
+    if (seenInFile.has(normalized)) {
+      skippedDuplicates += 1;
+      return;
+    }
+    seenInFile.add(normalized);
+
+    const existingId = phones.get(normalized);
+    if (existingId) {
+      if (skipDuplicates) {
+        skippedDuplicates += 1;
+        // Re-enquiry event on the existing lead (Slice B dedup semantics).
+        LeadIntakeService.recordReEnquiry(existingId, {
+          source: IMPORT_SOURCE,
+          message: "Matched during CSV import",
+        });
+        return;
+      }
+      // skipDuplicates=false: fall through and try to insert; exact-equal phones
+      // will land in errors[] via the unique index.
+    }
+
+    const zohoStage = mapping.stage ? String(row[mapping.stage] || "").trim() : "";
+    let stage = stageMapping[zohoStage] || "new";
+    if (!validStages.has(stage)) stage = "new";
+
+    let createdAt = now;
+    if (mapping.createdAt && row[mapping.createdAt]) {
+      const d = new Date(row[mapping.createdAt]);
+      if (!Number.isNaN(d.getTime())) createdAt = d;
+    }
+
+    toCreate.push({
+      name,
+      phone,
+      email: mapping.email ? String(row[mapping.email] || "").trim() : "",
+      verified: false,
+      source: IMPORT_SOURCE,
+      stage,
+      additionalInfo: mapping.notes && row[mapping.notes] ? { importNotes: row[mapping.notes] } : {},
+      importedAt: now,
+      createdAt,
+      updatedAt: createdAt,
+      _assign: assignOnImport && stage === "new",
+    });
+  });
+
+  let created = 0;
+  const createdForAssignment = [];
+  for (let i = 0; i < toCreate.length; i += BATCH_SIZE) {
+    const batch = toCreate.slice(i, i + BATCH_SIZE);
+    const docs = batch.map(({ _assign, ...doc }) => doc);
+    try {
+      // timestamps:false → the provided historical createdAt/updatedAt are kept.
+      const inserted = await Enquiry.insertMany(docs, { ordered: false, timestamps: false });
+      created += inserted.length;
+      inserted.forEach((doc, j) => {
+        if (batch[j] && batch[j]._assign) createdForAssignment.push(doc._id);
+      });
+    } catch (e) {
+      // ordered:false → successful docs in the batch were still written.
+      const okCount = e.insertedDocs ? e.insertedDocs.length : 0;
+      created += okCount;
+      (e.writeErrors || []).forEach((we) => {
+        errors.push({ row: "batch", error: we.errmsg || "Insert failed (likely duplicate phone)" });
+      });
+    }
+  }
+
+  // Historical imports stay unassigned by design; only stage-New rows with the
+  // explicit assignOnImport flag go through the round-robin.
+  for (const id of createdForAssignment) {
+    await LeadAssignmentService.assignLead(id);
+  }
+
+  return { created, skippedDuplicates, errors };
+};
+
+module.exports = { preview, commit, detectMapping, FIELD_ALIASES, IMPORT_SOURCE };

--- a/services/LeadIntakeService.js
+++ b/services/LeadIntakeService.js
@@ -1,0 +1,54 @@
+const Enquiry = require("../models/Enquiry");
+const LeadInternalEventService = require("./LeadInternalEventService");
+const LeadAssignmentService = require("./LeadAssignmentService");
+
+const escapeRegExp = (str) => String(str).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+// Normalize to the last 10 digits (Indian local number) for dedup matching —
+// catches "+91 98765 43210" vs "9876543210" style duplicates the exact-match
+// checks in the existing intake paths can't see.
+const normalizePhone = (phone) => {
+  const digits = String(phone || "").replace(/\D/g, "");
+  return digits.length > 10 ? digits.slice(-10) : digits;
+};
+
+// Existing lead whose phone ends with the normalized number (null if too short to trust).
+const findExistingByNormalizedPhone = async (phone) => {
+  const normalized = normalizePhone(phone);
+  if (normalized.length < 7) return null;
+  return await Enquiry.findOne({ phone: { $regex: escapeRegExp(normalized) + "$" } });
+};
+
+// Dedup-merge: an existing lead enquired again. No duplicate is created — we stamp
+// reEnquiredAt (drives the dashboard 🔥 badge for 7 days) and append a re_enquired
+// event carrying where/what they asked. Never throws (intake must not fail on it).
+const recordReEnquiry = async (enquiryId, { source, message } = {}) => {
+  try {
+    await Enquiry.findByIdAndUpdate(enquiryId, { $set: { reEnquiredAt: new Date() } });
+    await LeadInternalEventService.record({
+      leadId: enquiryId,
+      type: "re_enquired",
+      actorId: null,
+      payload: { source: source || "", message: message || "" },
+    });
+  } catch (e) {
+    console.error("LeadIntakeService.recordReEnquiry failed:", e.message);
+  }
+};
+
+// Post-create hook for genuinely-new leads: auto-assignment. Runs AFTER the existing
+// (venue-hardened) validation and insert — additive only, never blocks the response.
+const afterCreate = async (enquiryId) => {
+  try {
+    await LeadAssignmentService.assignLead(enquiryId);
+  } catch (e) {
+    console.error("LeadIntakeService.afterCreate failed:", e.message);
+  }
+};
+
+module.exports = {
+  normalizePhone,
+  findExistingByNormalizedPhone,
+  recordReEnquiry,
+  afterCreate,
+};

--- a/services/LeadIntakeService.js
+++ b/services/LeadIntakeService.js
@@ -22,15 +22,64 @@ const findExistingByNormalizedPhone = async (phone) => {
 // Dedup-merge: an existing lead enquired again. No duplicate is created — we stamp
 // reEnquiredAt (drives the dashboard 🔥 badge for 7 days) and append a re_enquired
 // event carrying where/what they asked. Never throws (intake must not fail on it).
+//
+// Terminal-state handling (lifecycle hardening):
+//   recycled → a re-enquiry IS the revisit: clear the recycle flags, hand the lead
+//              back to its original owner (or the round-robin), event
+//              "resurfaced_by_reenquiry".
+//   lost     → keep the stage; reEnquiredAt feeds the dashboard's
+//              "Returned — they came back" card (last 14 days) with a manager Reopen.
+//   won      → already a client; event only, no badge.
 const recordReEnquiry = async (enquiryId, { source, message } = {}) => {
   try {
-    await Enquiry.findByIdAndUpdate(enquiryId, { $set: { reEnquiredAt: new Date() } });
+    const lead = await Enquiry.findById(enquiryId).lean();
+    if (!lead) return;
+
     await LeadInternalEventService.record({
       leadId: enquiryId,
       type: "re_enquired",
       actorId: null,
       payload: { source: source || "", message: message || "" },
     });
+
+    if (lead.stage === "won") {
+      return; // event only — they're a client, not a lead
+    }
+
+    await Enquiry.findByIdAndUpdate(enquiryId, { $set: { reEnquiredAt: new Date() } });
+
+    if (lead.recycled && lead.recycled.isRecycled) {
+      // The customer beat the revisit date — resurface NOW.
+      const flipped = await Enquiry.findOneAndUpdate(
+        { _id: enquiryId, "recycled.isRecycled": true },
+        { $set: { "recycled.isRecycled": false, "recycled.resurfacedAt": new Date() } },
+        { new: true }
+      );
+      if (flipped) {
+        const Admin = require("../models/Admin");
+        let reassignedTo = null;
+        const originalOwner = lead.recycled.originalOwnerId
+          ? await Admin.findById(lead.recycled.originalOwnerId).lean()
+          : null;
+        if (originalOwner && originalOwner.status === "active") {
+          await Enquiry.findByIdAndUpdate(enquiryId, { $set: { assignedTo: originalOwner._id } });
+          reassignedTo = originalOwner._id;
+        } else {
+          const assignee = await LeadAssignmentService.assignLead(enquiryId);
+          reassignedTo = assignee ? assignee._id : null;
+        }
+        await LeadInternalEventService.record({
+          leadId: enquiryId,
+          type: "resurfaced_by_reenquiry",
+          actorId: null,
+          payload: {
+            source: source || "",
+            originalOwnerId: lead.recycled.originalOwnerId ? String(lead.recycled.originalOwnerId) : null,
+            reassignedTo: reassignedTo ? String(reassignedTo) : null,
+          },
+        });
+      }
+    }
   } catch (e) {
     console.error("LeadIntakeService.recordReEnquiry failed:", e.message);
   }

--- a/services/LeadInternalEventService.js
+++ b/services/LeadInternalEventService.js
@@ -1,0 +1,17 @@
+const LeadInternalEventRepository = require("../repositories/LeadInternalEventRepository");
+
+// Fire-and-safe (same contract as ActivityLogService): recording an internal
+// event must NEVER break the primary action.
+const record = async ({ leadId, type, actorId, payload }) => {
+  try {
+    return await LeadInternalEventRepository.create({ leadId, type, actorId, payload });
+  } catch (e) {
+    console.error("LeadInternalEvent.record failed:", e.message);
+    return null;
+  }
+};
+
+const listForLead = async (leadId, opts) =>
+  LeadInternalEventRepository.findByLeadId(leadId, opts);
+
+module.exports = { record, listForLead };

--- a/services/LeadLifecycleService.js
+++ b/services/LeadLifecycleService.js
@@ -164,15 +164,25 @@ const completeFollowUp = async (enquiryId, followUpId, body = {}, actorId) => {
   const willFlagUnresponsive =
     CallCockpitService.cadenceFor(prospectiveLog).unresponsive && !lead.unresponsiveFlaggedAt;
 
+  // stageAdvance is a COMPOSITE action: advancing to Meeting Scheduled must be
+  // accompanied by a nextFollowUp of type meet/visit with a valid FUTURE
+  // scheduledAt in the same payload — a meeting stage without a booked meeting
+  // time is invalid (reviewed rule).
+  const stageAdvancePresent = stageAdvance !== undefined && stageAdvance !== null && stageAdvance !== false;
   const nextActions = [
     ["nextFollowUp", nextFollowUp],
     ["stageAdvance", stageAdvance],
     ["requestDisqualify", requestDisqualify],
     ["recycle", recycle],
   ].filter(([, v]) => v !== undefined && v !== null && v !== false);
+  // The stageAdvance+nextFollowUp pair counts as ONE next step.
+  const effectiveActionCount =
+    stageAdvancePresent && nextActions.some(([n]) => n === "nextFollowUp")
+      ? nextActions.length - 1
+      : nextActions.length;
 
   if (open) {
-    if (nextActions.length !== 1 && !(nextActions.length === 0 && willFlagUnresponsive)) {
+    if (effectiveActionCount !== 1 && !(effectiveActionCount === 0 && willFlagUnresponsive)) {
       throw httpError(
         422,
         "Every completed follow-up on an open lead must carry exactly one next step: nextFollowUp, stageAdvance, requestDisqualify, or recycle. A lead can never be left without a scheduled next action."
@@ -184,16 +194,27 @@ const completeFollowUp = async (enquiryId, followUpId, body = {}, actorId) => {
 
   // PRE-validate the chosen action BEFORE any write: a bad payload must fail the
   // whole request, never leave the follow-up marked completed with no next step.
-  if (nextActions.length === 1) {
+  if (stageAdvancePresent) {
+    if (stageAdvance !== "meeting_scheduled") {
+      throw httpError(400, "stageAdvance only supports meeting_scheduled");
+    }
+    const nf = nextFollowUp;
+    const d = new Date(nf && nf.scheduledAt);
+    if (
+      !nf ||
+      !["meet", "visit"].includes(nf.type) ||
+      !nf.scheduledAt ||
+      Number.isNaN(d.getTime()) ||
+      d <= new Date()
+    ) {
+      throw httpError(422, "Advancing to Meeting Scheduled requires booking the meeting time");
+    }
+  } else if (nextActions.length === 1) {
     const [name, value] = nextActions[0];
     if (name === "nextFollowUp") {
       const d = new Date(value && value.scheduledAt);
       if (!value || !["meet", "call", "visit"].includes(value.type) || !value.scheduledAt || Number.isNaN(d.getTime())) {
         throw httpError(400, "nextFollowUp needs a valid type (meet/call/visit) and scheduledAt");
-      }
-    } else if (name === "stageAdvance") {
-      if (value !== "meeting_scheduled") {
-        throw httpError(400, "stageAdvance only supports meeting_scheduled");
       }
     } else if (name === "requestDisqualify") {
       if (!value || !EnquiryService.LOST_REASONS.includes(value.reason)) {
@@ -244,18 +265,18 @@ const completeFollowUp = async (enquiryId, followUpId, body = {}, actorId) => {
     cadence = logged.cadence || null;
   }
 
-  // 3. Apply the single chosen next action through the existing flows.
+  // 3. Apply the chosen next action through the existing flows.
   let appliedAction = willFlagUnresponsive && nextActions.length === 0 ? "unresponsive_flagged" : null;
-  if (nextActions.length === 1) {
+  if (stageAdvancePresent) {
+    // Composite: book the meeting first, then advance the stage.
+    appliedAction = "stageAdvance";
+    await CallCockpitService.addFollowUp(enquiryId, nextFollowUp, actorId);
+    await EnquiryService.updateStage(enquiryId, "meeting_scheduled", actorId);
+  } else if (nextActions.length === 1) {
     const [name, value] = nextActions[0];
     appliedAction = name;
     if (name === "nextFollowUp") {
       await CallCockpitService.addFollowUp(enquiryId, value, actorId);
-    } else if (name === "stageAdvance") {
-      if (value !== "meeting_scheduled") {
-        throw httpError(400, "stageAdvance only supports meeting_scheduled");
-      }
-      await EnquiryService.updateStage(enquiryId, "meeting_scheduled", actorId);
     } else if (name === "requestDisqualify") {
       await EnquiryService.requestDisqualification(
         enquiryId,

--- a/services/LeadLifecycleService.js
+++ b/services/LeadLifecycleService.js
@@ -1,0 +1,260 @@
+const mongoose = require("mongoose");
+const Enquiry = require("../models/Enquiry");
+const Admin = require("../models/Admin");
+const EnquiryRepository = require("../repositories/EnquiryRepository");
+const EnquiryService = require("./EnquiryService");
+const CallCockpitService = require("./CallCockpitService");
+const LeadAssignmentService = require("./LeadAssignmentService");
+const LeadInternalEventService = require("./LeadInternalEventService");
+
+const RECYCLE_REASONS = [
+  "wedding_next_year",
+  "budget_mismatch_now",
+  "venue_not_booked",
+  "other",
+];
+const COMPLETION_OUTCOMES = ["connected", "busy", "no_answer", "done"];
+
+const httpError = (status, message) => {
+  const err = new Error(message);
+  err.status = status;
+  return err;
+};
+
+const assertValidId = (id, label = "enquiry id") => {
+  if (!mongoose.Types.ObjectId.isValid(id)) {
+    throw httpError(400, `Invalid ${label}`);
+  }
+};
+
+// A lead still in play: not won/lost, not recycled, no pending/approved disqualify.
+const isOpenLead = (lead) =>
+  !["won", "lost"].includes(lead.stage) &&
+  !(lead.recycled && lead.recycled.isRecycled) &&
+  !["pending", "approved"].includes(lead.lostStatus);
+
+// ── Recycle: the third terminal state ──────────────────────────────────────
+const recycleLead = async (enquiryId, { reason, reasonNote, revisitAt } = {}, actorId) => {
+  assertValidId(enquiryId);
+  if (!RECYCLE_REASONS.includes(reason)) {
+    throw httpError(400, `Invalid reason (expected one of: ${RECYCLE_REASONS.join(", ")})`);
+  }
+  if (reasonNote !== undefined && typeof reasonNote !== "string") {
+    throw httpError(400, "Invalid reasonNote");
+  }
+  const revisitDate = new Date(revisitAt);
+  if (!revisitAt || Number.isNaN(revisitDate.getTime()) || revisitDate <= new Date()) {
+    throw httpError(422, "revisitAt is required and must be in the future");
+  }
+
+  const lead = await EnquiryRepository.findById(enquiryId);
+  if (!lead) throw httpError(404, "Enquiry not found");
+  if (lead.recycled && lead.recycled.isRecycled) {
+    throw httpError(400, "Lead is already recycled");
+  }
+  if (["won", "lost"].includes(lead.stage)) {
+    throw httpError(400, "Cannot recycle a closed lead");
+  }
+
+  const updated = await EnquiryRepository.updateFieldsById(enquiryId, {
+    "recycled.isRecycled": true,
+    "recycled.reason": reason,
+    "recycled.reasonNote": reasonNote || "",
+    "recycled.revisitAt": revisitDate,
+    "recycled.recycledBy": actorId || null,
+    "recycled.recycledAt": new Date(),
+    "recycled.originalOwnerId": lead.assignedTo || null,
+    "recycled.resurfacedAt": null,
+  });
+
+  await LeadInternalEventService.record({
+    leadId: enquiryId,
+    type: "recycled",
+    actorId,
+    payload: { reason, reasonNote: reasonNote || "", revisitAt: revisitDate },
+  });
+
+  return updated;
+};
+
+// ── Lazy resurface (read-time, no cron) ─────────────────────────────────────
+// Recycled leads whose revisitAt has passed come back to life: clear isRecycled,
+// stamp resurfacedAt, reassign to the original owner (if still active) or through
+// the assignment service. Idempotent — the atomic guard on isRecycled means
+// concurrent dashboard loads can't double-resurface.
+const resurfaceDueLeads = async (scopeFilter = {}) => {
+  const now = new Date();
+  const due = await Enquiry.find({
+    ...scopeFilter,
+    "recycled.isRecycled": true,
+    "recycled.revisitAt": { $lte: now },
+  }).lean();
+
+  const resurfaced = [];
+  for (const lead of due) {
+    const flipped = await Enquiry.findOneAndUpdate(
+      { _id: lead._id, "recycled.isRecycled": true },
+      { $set: { "recycled.isRecycled": false, "recycled.resurfacedAt": now } },
+      { new: true }
+    );
+    if (!flipped) continue; // someone else resurfaced it concurrently
+
+    let reassignedTo = null;
+    const originalOwner = lead.recycled.originalOwnerId
+      ? await Admin.findById(lead.recycled.originalOwnerId).lean()
+      : null;
+    if (originalOwner && originalOwner.status === "active") {
+      await Enquiry.findByIdAndUpdate(lead._id, {
+        $set: { assignedTo: originalOwner._id },
+      });
+      reassignedTo = originalOwner._id;
+    } else {
+      const assignee = await LeadAssignmentService.assignLead(lead._id);
+      reassignedTo = assignee ? assignee._id : null;
+    }
+
+    await LeadInternalEventService.record({
+      leadId: lead._id,
+      type: "resurfaced",
+      actorId: null,
+      payload: {
+        originalOwnerId: lead.recycled.originalOwnerId
+          ? String(lead.recycled.originalOwnerId)
+          : null,
+        reassignedTo: reassignedTo ? String(reassignedTo) : null,
+      },
+    });
+    resurfaced.push(lead._id);
+  }
+  return resurfaced;
+};
+
+// ── Follow-up completion with the ZERO-ORPHAN gate ──────────────────────────
+// Completing a follow-up on an OPEN lead must carry exactly one of:
+// nextFollowUp / stageAdvance / requestDisqualify / recycle — otherwise 422.
+// Sole bypass: this completion itself flags the lead unresponsive (MAX attempts),
+// which puts it on the dashboard's "Unresponsive — decide" surface instead.
+const completeFollowUp = async (enquiryId, followUpId, body = {}, actorId) => {
+  assertValidId(enquiryId);
+  assertValidId(followUpId, "follow-up id");
+  const { outcome, notes, durationSeconds, nextFollowUp, stageAdvance, requestDisqualify, recycle } = body;
+
+  if (!COMPLETION_OUTCOMES.includes(outcome)) {
+    throw httpError(400, `Invalid outcome (expected one of: ${COMPLETION_OUTCOMES.join(", ")})`);
+  }
+  if (notes !== undefined && typeof notes !== "string") {
+    throw httpError(400, "Invalid notes");
+  }
+
+  const lead = await EnquiryRepository.findById(enquiryId);
+  if (!lead) throw httpError(404, "Enquiry not found");
+  const followUp = lead.followUps.id(followUpId);
+  if (!followUp) throw httpError(404, "Follow-up not found");
+  if (followUp.completedAt) throw httpError(400, "Follow-up is already completed");
+
+  const open = isOpenLead(lead);
+  const isCallOutcome = followUp.type === "call" || ["busy", "no_answer"].includes(outcome);
+  const callLogOutcome =
+    outcome === "busy" ? "busy" : outcome === "no_answer" ? "unknown" : "";
+
+  // Prospective unresponsive check: would THIS unanswered attempt hit MAX?
+  const prospectiveLog = isCallOutcome && callLogOutcome
+    ? [...lead.callLog.toObject(), { outcome: callLogOutcome, startedAt: new Date() }]
+    : lead.callLog;
+  const willFlagUnresponsive =
+    CallCockpitService.cadenceFor(prospectiveLog).unresponsive && !lead.unresponsiveFlaggedAt;
+
+  const nextActions = [
+    ["nextFollowUp", nextFollowUp],
+    ["stageAdvance", stageAdvance],
+    ["requestDisqualify", requestDisqualify],
+    ["recycle", recycle],
+  ].filter(([, v]) => v !== undefined && v !== null && v !== false);
+
+  if (open) {
+    if (nextActions.length !== 1 && !(nextActions.length === 0 && willFlagUnresponsive)) {
+      throw httpError(
+        422,
+        "Every completed follow-up on an open lead must carry exactly one next step: nextFollowUp, stageAdvance, requestDisqualify, or recycle. A lead can never be left without a scheduled next action."
+      );
+    }
+  } else if (nextActions.length > 0) {
+    throw httpError(400, "This lead is closed — no next action can be scheduled on it");
+  }
+
+  // 1. Mark the follow-up completed (positional update on the subdoc).
+  await Enquiry.updateOne(
+    { _id: enquiryId, "followUps._id": followUpId },
+    {
+      $set: {
+        "followUps.$.completedAt": new Date(),
+        "followUps.$.completedBy": actorId || null,
+        "followUps.$.completedOutcome": outcome,
+        "followUps.$.completedNotes": notes || "",
+      },
+    }
+  );
+
+  // 2. A call-shaped completion appends to the append-only call log (which also
+  //    runs the cadence/unresponsive logic inside logCall).
+  let cadence = null;
+  if (isCallOutcome) {
+    const logged = await CallCockpitService.logCall(
+      enquiryId,
+      {
+        startedAt: new Date().toISOString(),
+        durationSeconds: Number(durationSeconds) || 0,
+        connected: outcome === "connected" || outcome === "done",
+        outcome: callLogOutcome,
+        notes: notes || "",
+      },
+      actorId
+    );
+    cadence = logged.cadence || null;
+  }
+
+  // 3. Apply the single chosen next action through the existing flows.
+  let appliedAction = willFlagUnresponsive && nextActions.length === 0 ? "unresponsive_flagged" : null;
+  if (nextActions.length === 1) {
+    const [name, value] = nextActions[0];
+    appliedAction = name;
+    if (name === "nextFollowUp") {
+      await CallCockpitService.addFollowUp(enquiryId, value, actorId);
+    } else if (name === "stageAdvance") {
+      if (value !== "meeting_scheduled") {
+        throw httpError(400, "stageAdvance only supports meeting_scheduled");
+      }
+      await EnquiryService.updateStage(enquiryId, "meeting_scheduled", actorId);
+    } else if (name === "requestDisqualify") {
+      await EnquiryService.requestDisqualification(
+        enquiryId,
+        { reason: value.reason, note: value.note },
+        actorId
+      );
+    } else if (name === "recycle") {
+      await recycleLead(enquiryId, value, actorId);
+    }
+  }
+
+  await LeadInternalEventService.record({
+    leadId: enquiryId,
+    type: "follow_up_completed",
+    actorId,
+    payload: { followUpId: String(followUpId), outcome, nextAction: appliedAction },
+  });
+
+  const fresh = await EnquiryRepository.findById(enquiryId);
+  const obj = fresh.toObject();
+  if (cadence) obj.cadence = cadence;
+  obj.appliedAction = appliedAction;
+  return obj;
+};
+
+module.exports = {
+  recycleLead,
+  resurfaceDueLeads,
+  completeFollowUp,
+  isOpenLead,
+  RECYCLE_REASONS,
+  COMPLETION_OUTCOMES,
+};

--- a/services/LeadLifecycleService.js
+++ b/services/LeadLifecycleService.js
@@ -182,6 +182,37 @@ const completeFollowUp = async (enquiryId, followUpId, body = {}, actorId) => {
     throw httpError(400, "This lead is closed — no next action can be scheduled on it");
   }
 
+  // PRE-validate the chosen action BEFORE any write: a bad payload must fail the
+  // whole request, never leave the follow-up marked completed with no next step.
+  if (nextActions.length === 1) {
+    const [name, value] = nextActions[0];
+    if (name === "nextFollowUp") {
+      const d = new Date(value && value.scheduledAt);
+      if (!value || !["meet", "call", "visit"].includes(value.type) || !value.scheduledAt || Number.isNaN(d.getTime())) {
+        throw httpError(400, "nextFollowUp needs a valid type (meet/call/visit) and scheduledAt");
+      }
+    } else if (name === "stageAdvance") {
+      if (value !== "meeting_scheduled") {
+        throw httpError(400, "stageAdvance only supports meeting_scheduled");
+      }
+    } else if (name === "requestDisqualify") {
+      if (!value || !EnquiryService.LOST_REASONS.includes(value.reason)) {
+        throw httpError(400, "requestDisqualify needs a valid reason");
+      }
+      if (lead.lostStatus === "pending") {
+        throw httpError(400, "A disqualification is already pending on this lead");
+      }
+    } else if (name === "recycle") {
+      const d = new Date(value && value.revisitAt);
+      if (!value || !RECYCLE_REASONS.includes(value.reason)) {
+        throw httpError(400, `recycle needs a valid reason (${RECYCLE_REASONS.join(", ")})`);
+      }
+      if (!value.revisitAt || Number.isNaN(d.getTime()) || d <= new Date()) {
+        throw httpError(422, "recycle.revisitAt is required and must be in the future");
+      }
+    }
+  }
+
   // 1. Mark the follow-up completed (positional update on the subdoc).
   await Enquiry.updateOne(
     { _id: enquiryId, "followUps._id": followUpId },

--- a/services/ProjectService.js
+++ b/services/ProjectService.js
@@ -1,0 +1,115 @@
+const mongoose = require("mongoose");
+const ProjectRepository = require("../repositories/ProjectRepository");
+const EnquiryRepository = require("../repositories/EnquiryRepository");
+const EnquiryService = require("./EnquiryService");
+const LeadInternalEventService = require("./LeadInternalEventService");
+const Admin = require("../models/Admin");
+const Role = require("../models/Role");
+const User = require("../models/User");
+const Event = require("../models/Event");
+
+const CS_ROLE_NAME = "Client Servicing Executive";
+
+const httpError = (status, message) => {
+  const err = new Error(message);
+  err.status = status;
+  return err;
+};
+
+// Default CS owner: the (first) active Client Servicing Executive.
+const defaultCsOwner = async () => {
+  const role = await Role.findOne({ name: CS_ROLE_NAME, deletedAt: null }).lean();
+  if (!role) return null;
+  return await Admin.findOne({ roleId: role._id, status: "active" }).lean();
+};
+
+// Convert a Meeting-Scheduled lead into a Project (Slice D). The lead moves to the
+// "won" terminal stage and leaves every active dashboard/list view.
+const convertLead = async (enquiryId, { csOwnerId, value, handoffNote } = {}, actorId) => {
+  if (!mongoose.Types.ObjectId.isValid(enquiryId)) {
+    throw httpError(400, "Invalid enquiry id");
+  }
+  const lead = await EnquiryRepository.findById(enquiryId);
+  if (!lead) throw httpError(404, "Enquiry not found");
+  if (lead.stage !== "meeting_scheduled") {
+    throw httpError(422, "Only a Meeting-Scheduled lead can move to Projects — advance the stage first");
+  }
+  if (lead.lostStatus === "pending") {
+    throw httpError(422, "A disqualification decision is pending on this lead");
+  }
+  const existing = await ProjectRepository.findByLeadId(enquiryId);
+  if (existing) throw httpError(400, "This lead is already converted to a project");
+
+  let csOwner = null;
+  if (csOwnerId) {
+    if (!mongoose.Types.ObjectId.isValid(csOwnerId)) {
+      throw httpError(400, "Invalid csOwnerId");
+    }
+    csOwner = await Admin.findById(csOwnerId).lean();
+    if (!csOwner) throw httpError(400, "csOwnerId does not match any admin");
+  } else {
+    csOwner = await defaultCsOwner();
+  }
+
+  // Events created for this lead's linked user (when one exists).
+  const user = await User.findOne({ phone: lead.phone }).lean();
+  const events = user ? await Event.find({ user: user._id }, { _id: 1 }).lean() : [];
+
+  const q = lead.qualificationData || {};
+  const coupleNames =
+    q.groomName && q.brideName ? `${q.groomName} x ${q.brideName}` : lead.name;
+
+  const project = await ProjectRepository.create({
+    leadId: lead._id,
+    coupleNames,
+    eventIds: events.map((e) => e._id),
+    csOwnerId: csOwner ? csOwner._id : null,
+    convertedBy: actorId || null,
+    value: Number(value) || 0,
+    handoffNote: handoffNote || "",
+  });
+
+  // Terminal stage move through the existing pipeline (Won stage is seeded by
+  // scripts/lifecycle-role-patch.js — see deploy checklist).
+  await EnquiryService.updateStage(enquiryId, "won", actorId);
+
+  await LeadInternalEventService.record({
+    leadId: enquiryId,
+    type: "converted_to_project",
+    actorId,
+    payload: {
+      projectId: String(project._id),
+      csOwnerId: csOwner ? String(csOwner._id) : null,
+      value: Number(value) || 0,
+    },
+  });
+
+  return project;
+};
+
+// Scope-filtered project list with display names joined in.
+const listProjects = async (scopeFilter = {}) => {
+  const projects = await ProjectRepository.findAll(scopeFilter);
+  const adminIds = [
+    ...new Set(
+      projects.flatMap((p) => [p.csOwnerId, p.convertedBy].filter(Boolean).map(String))
+    ),
+  ];
+  const leadIds = projects.map((p) => p.leadId).filter(Boolean);
+  const [admins, leads] = await Promise.all([
+    adminIds.length ? Admin.find({ _id: { $in: adminIds } }, { name: 1 }).lean() : [],
+    leadIds.length
+      ? require("../models/Enquiry").find({ _id: { $in: leadIds } }, { name: 1, phone: 1, stage: 1 }).lean()
+      : [],
+  ]);
+  const adminName = new Map(admins.map((a) => [String(a._id), a.name]));
+  const leadById = new Map(leads.map((l) => [String(l._id), l]));
+  return projects.map((p) => ({
+    ...p,
+    csOwnerName: adminName.get(String(p.csOwnerId)) || "—",
+    convertedByName: adminName.get(String(p.convertedBy)) || "—",
+    lead: leadById.get(String(p.leadId)) || null,
+  }));
+};
+
+module.exports = { convertLead, listProjects, defaultCsOwner, CS_ROLE_NAME };

--- a/utils/goldenWindow.js
+++ b/utils/goldenWindow.js
@@ -1,0 +1,66 @@
+// Golden window: a New lead created during work hours must get its first call
+// within GOLDEN_WINDOW_MINUTES; out-of-hours leads are due by 10:30 IST the next
+// working morning. Read-time only — no cron, no stored state.
+// Configurable via Settings later — constants for Phase 1.
+const GOLDEN_WINDOW_MINUTES = 30;
+const WORK_START_HOUR = 10; // IST
+const WORK_END_HOUR = 19; // IST
+const OUT_OF_HOURS_DUE_MINUTE = 30; // due 10:30 IST next working morning
+
+// IST is fixed UTC+5:30 (no DST) — shift and read UTC parts as IST wall clock.
+const IST_OFFSET_MS = 330 * 60 * 1000;
+const toIstWallClock = (d) => new Date(d.getTime() + IST_OFFSET_MS);
+const fromIstParts = (y, mo, day, h, mi) =>
+  new Date(Date.UTC(y, mo, day, h, mi) - IST_OFFSET_MS);
+
+// Start of "today" in IST as a real Date (UTC instant).
+const istDayStart = (now = new Date()) => {
+  const ist = toIstWallClock(now);
+  return fromIstParts(ist.getUTCFullYear(), ist.getUTCMonth(), ist.getUTCDate(), 0, 0);
+};
+const istDayEnd = (now = new Date()) =>
+  new Date(istDayStart(now).getTime() + 24 * 60 * 60 * 1000 - 1);
+
+// First-call deadline for a lead created at `createdAt`.
+const goldenDeadline = (createdAt) => {
+  const created = new Date(createdAt);
+  const ist = toIstWallClock(created);
+  const hour = ist.getUTCHours();
+  if (hour >= WORK_START_HOUR && hour < WORK_END_HOUR) {
+    return new Date(created.getTime() + GOLDEN_WINDOW_MINUTES * 60 * 1000);
+  }
+  // Out of hours: due 10:30 IST the same morning (created 00:00–09:59)
+  // or the next morning (created 19:00–23:59).
+  const dayShift = hour < WORK_START_HOUR ? 0 : 1;
+  return fromIstParts(
+    ist.getUTCFullYear(),
+    ist.getUTCMonth(),
+    ist.getUTCDate() + dayShift,
+    WORK_START_HOUR,
+    OUT_OF_HOURS_DUE_MINUTE
+  );
+};
+
+// { deadline, inWindow, minutesLeft, minutesOver } for an uncalled lead.
+const goldenWindowFor = (createdAt, now = new Date()) => {
+  const deadline = goldenDeadline(createdAt);
+  const msLeft = deadline.getTime() - now.getTime();
+  return {
+    deadline,
+    inWindow: msLeft > 0,
+    minutesLeft: msLeft > 0 ? Math.ceil(msLeft / 60000) : 0,
+    minutesOver: msLeft >= 0 ? 0 : Math.ceil(-msLeft / 60000),
+  };
+};
+
+module.exports = {
+  GOLDEN_WINDOW_MINUTES,
+  WORK_START_HOUR,
+  WORK_END_HOUR,
+  goldenDeadline,
+  goldenWindowFor,
+  istDayStart,
+  istDayEnd,
+  toIstWallClock,
+  fromIstParts,
+};

--- a/utils/leadHealth.js
+++ b/utils/leadHealth.js
@@ -1,0 +1,61 @@
+// Lead Health: derived Cold/Warm/Hot 0-100 — computed on read, NEVER stored.
+// Weights mirror the approved cockpit design's score():
+//   qualified base 20, event captured +25, venue status +15, email (or explicit
+//   not-willing) +20, future follow-up locked +20. Unqualified leads sit at 15/Cold.
+const computeLeadHealth = (enquiry, events = []) => {
+  const q = (enquiry && enquiry.qualificationData) || {};
+
+  if (!enquiry || !enquiry.qualified) {
+    return {
+      score: 15,
+      label: "Cold",
+      have: [],
+      missing: ["qualified call"],
+    };
+  }
+
+  let score = 20;
+  const have = [];
+  const missing = [];
+
+  const hasEvent = (events || []).some(
+    (e) => Array.isArray(e.eventDays) && e.eventDays.length > 0
+  );
+  if (hasEvent) {
+    score += 25;
+    have.push("event");
+  } else {
+    missing.push("event details");
+  }
+
+  if (q.venueStatus) {
+    score += 15;
+    have.push("venue");
+  } else {
+    missing.push("venue");
+  }
+
+  if (q.email || q.emailNotWilling) {
+    score += 20;
+    if (q.email) have.push("email");
+  } else {
+    missing.push("email");
+  }
+
+  const now = new Date();
+  const hasFutureFollowUp = (enquiry.followUps || []).some(
+    (f) => f.scheduledAt && new Date(f.scheduledAt) > now
+  );
+  if (hasFutureFollowUp) {
+    score += 20;
+    have.push("next step");
+  } else {
+    missing.push("a booked next step");
+  }
+
+  if (score > 100) score = 100;
+  const label = score >= 75 ? "Hot" : score >= 45 ? "Warm" : "Cold";
+  return { score, label, have, missing };
+};
+
+module.exports = { computeLeadHealth };


### PR DESCRIPTION
## Summary

The complete lead lifecycle per the Lead Lifecycle Master Design — replaces Bigin. Includes the first-call cockpit backend (merged from `claude/crm-call-cockpit`).

### Slices
- **A — Role-aware dashboard + follow-up completion**: `GET /enquiry/dashboard` (every query scope-bounded via requirePermission/buildScopeFilter): today's mission, new & untouched with golden-window state, at-risk SLAs, hot leads, resurfaced, promises, pipeline counts; manager sections (team rollup + activity sparklines, approval queue, recent activity, golden-window health) for team/department/all scopes. `PUT /enquiry/:_id/follow-up/:followUpId/complete` enforces the **zero-orphan invariant** server-side: an open lead must exit into exactly one of nextFollowUp / stageAdvance / requestDisqualify / recycle (422 otherwise); action payloads pre-validated before any write.
- **B — Intake engine**: dedup-merge on normalized phone (public form + ads webhook, response contracts preserved) with `re_enquired` events; round-robin auto-assignment (Sales Intern pool, 15/day cap, Sales Executive overflow, serialized against burst races); golden-window helper (30 min in-hours / 10:30 IST next morning), read-time only.
- **C — Attempt cadence**: 0/1/3/5-day rhythm with suggested next attempt in call-log responses; 4th unanswered attempt flags `unresponsiveFlaggedAt` + dashboard "Unresponsive — decide" surface.
- **D — Projects**: `models/Project.js`, scope-filtered `GET /project` (csOwnerId ownership), `POST /enquiry/:_id/convert` (meeting_scheduled only, default CS owner, event linkage, terminal **Won** stage).
- **E — Recycle**: third terminal state with reason + future revisitAt (422 gate); excluded from every active view; lazy resurface on dashboard read with original-owner restoration.
- **F — CSV import (Zoho migration)**: founder-gated multipart preview/commit with header auto-mapping, duplicate detection (normalized phones, in-file too), stage mapping, historical createdAt preserved, no auto-assignment of historical rows.
- **G — Password reset + invite email (dark ship)**: `POST /auth/admin/forgot` (generic 200 always, sha256 token hash, 30-min TTL, 5/hour/IP rate limit) + `/reset` (generic 400, single-use); invite email on admin create (never includes the password). Both skip sending until Mailjet template env vars exist.
- **H — Scope-aware `GET /admin`**: full list for users:view:all, department for users:view:department, otherwise minimal active projection — assignee dropdowns work with zero Forbidden errors (regression-tested per role).
- **I — Small closures**: lead-list lifecycle view param (active default excludes won+recycled), `PUT /admin/:id` phone whitelist.

### Hardening fixes
- **Terminal re-enquiry surfacing**: recycled lead re-enquires → instant resurface + owner restoration (`resurfaced_by_reenquiry`); lost lead → `returnedLeads` dashboard card with manager Reopen (restores stageBeforeLost); won → event only.
- **Inactive-owner flagging**: open leads owned by a non-active admin appear in atRisk as `owner_inactive` (sorted first), regardless of recency.
- **Import SLA immunity**: imported leads anchor the golden window on `importedAt` and are excluded from new-lead at-risk and golden-window breach math — a migration never reads as an SLA storm.
- **stageAdvance gate**: advancing to Meeting Scheduled requires a meet/visit follow-up with a future time in the same payload (422 otherwise).

### Dependency
- **papaparse** (CSV parsing) — **prod must run `npm install`**.

### Prerequisites
- Run `node scripts/lifecycle-role-patch.js` **once on prod** (idempotent): seeds the Won stage, grants CS Executive projects perms, creates the Sales Intern role.
- Mailjet env vars are **optional** (dark ship): `MAILJET_TEMPLATE_RESET`, `MAILJET_TEMPLATE_INVITE`, `OS_FRONTEND_URL` — emails are skipped with a console warning until set.

### Verification
Backend suite 73/73, hardening suite 25/25, Puppeteer e2e 22/22, cockpit regression intact (41/42 known suite quirk + UI 25/25). Frontend counterpart: `claude/crm-lifecycle-complete-ui` on wedsy-os.

🤖 Generated with [Claude Code](https://claude.com/claude-code)