### PR TITLE
[Venue] Integration: Phases 2–3 complete + analytics + team + hardening

### DIFF
--- a/controllers/venue.js
+++ b/controllers/venue.js
@@ -22,7 +22,10 @@ const getVenues = async (req, res) => {
       maxPrice: trimmed(maxPrice),
       sort: trimmed(sort),
     });
-    return res.status(200).json(result);
+    // Stable per-venue isVerified on the browse list (same derivation + API name
+    // as the detail response) so cards are future-proof for the OS boolean.
+    const venues = (result.venues || []).map((v) => ({ ...v, isVerified: v.status === "verified" }));
+    return res.status(200).json({ ...result, venues });
   } catch (err) {
     return res.status(500).json({ message: err.message });
   }

--- a/controllers/venue.js
+++ b/controllers/venue.js
@@ -31,10 +31,31 @@ const getVenues = async (req, res) => {
   }
 };
 
+// Backward-compatible structured policies. If policyDoc has no content yet,
+// migrate the legacy `policies` object into it on read (never lost):
+//   otherRestrictions -> policyDoc.policies, cancellation+refund -> policyDoc.refund.
+function withPolicyDoc(venue) {
+  if (!venue) return venue;
+  const pd = venue.policyDoc || {};
+  const has = (a) => Array.isArray(a) && a.length > 0;
+  if (has(pd.policies) || has(pd.terms) || has(pd.refund)) {
+    venue.policyDoc = { policies: pd.policies || [], terms: pd.terms || [], refund: pd.refund || [] };
+    return venue;
+  }
+  const legacy = venue.policies || {};
+  const clean = (...vals) => vals.map((s) => (s == null ? "" : String(s).trim())).filter(Boolean);
+  venue.policyDoc = {
+    policies: clean(legacy.otherRestrictions),
+    terms: [],
+    refund: clean(legacy.cancellation, legacy.refund),
+  };
+  return venue;
+}
+
 const getVenueBySlug = async (req, res) => {
   try {
     const { slug } = req.params;
-    const venue = await VenueService.getVenueBySlug(slug);
+    const venue = withPolicyDoc(await VenueService.getVenueBySlug(slug));
     // Stable public verification flag. Derived from status today (same as the
     // dashboard); when Wedsy OS ships a real orthogonal boolean, only this
     // derivation changes — the `isVerified` API name stays, so the couple-side

--- a/controllers/venue.js
+++ b/controllers/venue.js
@@ -2,17 +2,25 @@ const VenueService = require("../services/VenueService");
 
 const getVenues = async (req, res) => {
   try {
-    const { status, limit = 100, skip = 0, zone, area, search } = req.query;
+    const { status, limit = 100, skip = 0, zone, area, search, venueType, amenities, veg, nonVeg, minCapacity, minPrice, maxPrice, sort } = req.query;
     // Admin: use the status query as-is (undefined = all statuses, no filter).
     // Non-admin (public/couples): keep the current default-to-published behavior.
     const effectiveStatus = req.admin ? status : status || "published";
+    const trimmed = (v) => (typeof v === "string" && v.trim() ? v.trim() : undefined);
     const result = await VenueService.getAllVenues({
       status: effectiveStatus,
       limit: parseInt(limit),
       skip: parseInt(skip),
-      zone: typeof zone === "string" && zone.trim() ? zone.trim() : undefined,
-      area: typeof area === "string" && area.trim() ? area.trim() : undefined,
-      search: typeof search === "string" && search.trim() ? search.trim() : undefined,
+      zone: trimmed(zone),
+      area: trimmed(area),
+      search: trimmed(search),
+      venueType: trimmed(venueType),
+      amenities: trimmed(amenities),
+      veg, nonVeg,
+      minCapacity: trimmed(minCapacity),
+      minPrice: trimmed(minPrice),
+      maxPrice: trimmed(maxPrice),
+      sort: trimmed(sort),
     });
     return res.status(200).json(result);
   } catch (err) {
@@ -24,7 +32,12 @@ const getVenueBySlug = async (req, res) => {
   try {
     const { slug } = req.params;
     const venue = await VenueService.getVenueBySlug(slug);
-    return res.status(200).json({ venue });
+    // Stable public verification flag. Derived from status today (same as the
+    // dashboard); when Wedsy OS ships a real orthogonal boolean, only this
+    // derivation changes — the `isVerified` API name stays, so the couple-side
+    // frontend needs zero change.
+    const isVerified = (venue && venue.status === "verified") || false;
+    return res.status(200).json({ venue, isVerified });
   } catch (err) {
     if (err.message === "Venue not found") {
       return res.status(404).json({ message: "Venue not found" });

--- a/controllers/venueAnalytics.js
+++ b/controllers/venueAnalytics.js
@@ -1,0 +1,132 @@
+/**
+ * controllers/venueAnalytics.js — Phase 4.1 analytics.
+ * GET /venues/:slug/analytics?from&to (venueOwnerAuth + ownership).
+ *
+ * Returns enquiry volume (by week/month), funnel + conversion, source
+ * attribution, lost-reason breakdown, and revenue (confirmed vs received by
+ * month). Response-time is intentionally omitted (no timestamped first-response
+ * data is captured yet) — see `responseTime: null`.
+ */
+const Venue = require("../models/Venue");
+const VenueEnquiry = require("../models/VenueEnquiry");
+const VenueBooking = require("../models/VenueBooking");
+const VenueInvoice = require("../models/VenueInvoice");
+
+// Pipeline order — used to compute "reached stage X or beyond".
+const STAGE_ORDER = ["new", "contacted", "site_visit_scheduled", "site_visit_done", "proposal_sent", "negotiating", "booked", "lost"];
+const stageIdx = (s) => STAGE_ORDER.indexOf(s);
+
+async function resolveOwnedVenue(req, res) {
+  const venue = await Venue.findOne({ slug: req.params.slug }).select("_id").lean();
+  if (!venue) { res.status(404).json({ message: "Venue not found" }); return null; }
+  if (String(venue._id) !== String(req.venueOwner.venueId)) { res.status(403).json({ message: "Forbidden" }); return null; }
+  return venue;
+}
+
+const pad = (n) => String(n).padStart(2, "0");
+const monthKey = (d) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}`;
+// ISO-ish week key: year-Www based on the Thursday of that week.
+function weekKey(d) {
+  const date = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
+  const day = date.getUTCDay() || 7;
+  date.setUTCDate(date.getUTCDate() + 4 - day);
+  const yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1));
+  const week = Math.ceil(((date - yearStart) / 86400000 + 1) / 7);
+  return `${date.getUTCFullYear()}-W${pad(week)}`;
+}
+function tally(list) {
+  const map = new Map();
+  for (const k of list) map.set(k, (map.get(k) || 0) + 1);
+  return map;
+}
+function mapToSortedArray(map, keyName) {
+  return [...map.entries()].sort((a, b) => (a[0] < b[0] ? -1 : 1)).map(([k, v]) => ({ [keyName]: k, count: v }));
+}
+
+const getAnalytics = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+
+    const { from, to } = req.query;
+    const fromDate = from ? new Date(from) : null;
+    const toDate = to ? new Date(to) : null;
+    const dateFilter = {};
+    if (fromDate && !isNaN(fromDate)) dateFilter.$gte = fromDate;
+    if (toDate && !isNaN(toDate)) dateFilter.$lte = toDate;
+
+    const enqQuery = { venueId: venue._id };
+    if (Object.keys(dateFilter).length) enqQuery.createdAt = dateFilter;
+    const enquiries = await VenueEnquiry.find(enqQuery).select("stage source lostReason createdAt").lean();
+
+    const total = enquiries.length;
+
+    // Volume by week / month (on createdAt).
+    const byWeek = tally(enquiries.map((e) => weekKey(new Date(e.createdAt))));
+    const byMonth = tally(enquiries.map((e) => monthKey(new Date(e.createdAt))));
+
+    // Funnel: leads that reached each milestone (current stage at-or-beyond it),
+    // with "lost" excluded from the at-or-beyond test (lost is a terminal branch).
+    const reached = (target) => enquiries.filter((e) => e.stage !== "lost" && stageIdx(e.stage) >= stageIdx(target)).length;
+    const newCount = total;
+    const siteVisitDone = reached("site_visit_done");
+    const booked = enquiries.filter((e) => e.stage === "booked").length;
+    const funnel = {
+      new: newCount,
+      site_visit_done: siteVisitDone,
+      booked,
+      conversion: {
+        siteVisitRate: total ? Math.round((siteVisitDone / total) * 1000) / 10 : 0,
+        bookingRate: total ? Math.round((booked / total) * 1000) / 10 : 0,
+      },
+    };
+
+    // Source attribution: count + booked-rate per source.
+    const bySource = {};
+    for (const e of enquiries) {
+      const s = e.source || "other";
+      bySource[s] = bySource[s] || { source: s, count: 0, booked: 0 };
+      bySource[s].count += 1;
+      if (e.stage === "booked") bySource[s].booked += 1;
+    }
+    const sources = Object.values(bySource)
+      .map((r) => ({ ...r, bookedRate: r.count ? Math.round((r.booked / r.count) * 1000) / 10 : 0 }))
+      .sort((a, b) => b.count - a.count);
+
+    // Lost-reason breakdown (only leads that are lost, with a reason set).
+    const lostReasons = mapToSortedArray(
+      tally(enquiries.filter((e) => e.stage === "lost" && e.lostReason).map((e) => e.lostReason)),
+      "reason"
+    );
+
+    // Revenue by month: confirmed (booking.totalValue by booking.createdAt) vs
+    // received (invoice payments by payment date).
+    const bookings = await VenueBooking.find({ venue: venue._id, status: { $ne: "cancelled" } }).select("totalValue createdAt").lean();
+    const invoices = await VenueInvoice.find({ venue: venue._id }).select("payments").lean();
+    const revByMonth = {};
+    const bump = (key, field, amount) => {
+      revByMonth[key] = revByMonth[key] || { month: key, confirmed: 0, received: 0 };
+      revByMonth[key][field] += amount;
+    };
+    for (const b of bookings) bump(monthKey(new Date(b.createdAt)), "confirmed", Number(b.totalValue) || 0);
+    for (const inv of invoices) {
+      for (const p of inv.payments || []) bump(monthKey(new Date(p.date)), "received", Number(p.amount) || 0);
+    }
+    const revenue = { byMonth: Object.values(revByMonth).sort((a, b) => (a.month < b.month ? -1 : 1)) };
+
+    return res.status(200).json({
+      range: { from: fromDate || null, to: toDate || null },
+      total,
+      volume: { byWeek: mapToSortedArray(byWeek, "period"), byMonth: mapToSortedArray(byMonth, "period") },
+      funnel,
+      sources,
+      lostReasons,
+      revenue,
+      responseTime: null, // omitted: no first-response timestamp data is captured yet
+    });
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+};
+
+module.exports = { getAnalytics };

--- a/controllers/venueAnalytics.js
+++ b/controllers/venueAnalytics.js
@@ -11,6 +11,7 @@ const Venue = require("../models/Venue");
 const VenueEnquiry = require("../models/VenueEnquiry");
 const VenueBooking = require("../models/VenueBooking");
 const VenueInvoice = require("../models/VenueInvoice");
+const VenueView = require("../models/VenueView");
 
 // Pipeline order — used to compute "reached stage X or beyond".
 const STAGE_ORDER = ["new", "contacted", "site_visit_scheduled", "site_visit_done", "proposal_sent", "negotiating", "booked", "lost"];
@@ -114,6 +115,17 @@ const getAnalytics = async (req, res) => {
     }
     const revenue = { byMonth: Object.values(revByMonth).sort((a, b) => (a.month < b.month ? -1 : 1)) };
 
+    // Views + view→enquiry conversion (couple-side traffic closing the loop).
+    const viewQuery = { venueId: venue._id };
+    if (Object.keys(dateFilter).length) viewQuery.viewedAt = dateFilter;
+    const viewCount = await VenueView.countDocuments(viewQuery);
+    const traffic = {
+      views: viewCount,
+      enquiries: total,
+      // % of viewers who enquired (capped at 100; 0 when no views).
+      conversionRate: viewCount > 0 ? Math.min(100, Math.round((total / viewCount) * 1000) / 10) : 0,
+    };
+
     return res.status(200).json({
       range: { from: fromDate || null, to: toDate || null },
       total,
@@ -122,6 +134,7 @@ const getAnalytics = async (req, res) => {
       sources,
       lostReasons,
       revenue,
+      traffic,
       responseTime: null, // omitted: no first-response timestamp data is captured yet
     });
   } catch (err) {

--- a/controllers/venueAvailability.js
+++ b/controllers/venueAvailability.js
@@ -36,4 +36,32 @@ const saveAvailability = async (req, res) => {
   }
 };
 
-module.exports = { saveAvailability };
+// GET /venues/:slug/availability-check?date=YYYY-MM-DD — PUBLIC single-date read.
+// Returns { date, status: available | unavailable | unknown }. Never leaks the
+// full calendar: only answers for the one requested date. "unknown" = the venue
+// has not configured availability yet (empty blockedDates).
+const availabilityCheck = async (req, res) => {
+  try {
+    const { slug } = req.params;
+    const date = (req.query.date || "").trim();
+    if (!ISO_DATE_RE.test(date)) {
+      return res.status(400).json({ message: "date must be a YYYY-MM-DD string" });
+    }
+    const d = new Date(`${date}T00:00:00Z`);
+    if (Number.isNaN(d.getTime()) || d.toISOString().slice(0, 10) !== date) {
+      return res.status(400).json({ message: "date is not a valid calendar date" });
+    }
+    const venue = await Venue.findOne({ slug }).select("blockedDates").lean();
+    if (!venue) return res.status(404).json({ message: "Venue not found" });
+    const blocked = Array.isArray(venue.blockedDates) ? venue.blockedDates : [];
+    let status;
+    if (blocked.length === 0) status = "unknown";
+    else if (blocked.includes(date)) status = "unavailable";
+    else status = "available";
+    return res.status(200).json({ date, status });
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+};
+
+module.exports = { saveAvailability, availabilityCheck };

--- a/controllers/venueBooking.js
+++ b/controllers/venueBooking.js
@@ -1,0 +1,106 @@
+/**
+ * controllers/venueBooking.js — Phase 3 (3.1) bookings.
+ * CRUD under /venues/:slug/bookings (venueOwnerAuth + ownership).
+ * Also exports createDraftBookingForEnquiry() for the booked-stage auto-create
+ * hook and the quote→booking flow (idempotent: one booking per enquiry).
+ */
+const Venue = require("../models/Venue");
+const VenueBooking = require("../models/VenueBooking");
+
+async function resolveOwnedVenue(req, res) {
+  const venue = await Venue.findOne({ slug: req.params.slug }).select("_id").lean();
+  if (!venue) { res.status(404).json({ message: "Venue not found" }); return null; }
+  if (String(venue._id) !== String(req.venueOwner.venueId)) { res.status(403).json({ message: "Forbidden" }); return null; }
+  return venue;
+}
+
+/**
+ * Idempotently create a draft booking for an enquiry. Returns the booking doc.
+ * Safe to call repeatedly (one booking per enquiry, enforced by unique index).
+ */
+async function createDraftBookingForEnquiry(venueId, enquiry, ownerId) {
+  const existing = await VenueBooking.findOne({ enquiry: enquiry._id });
+  if (existing) return existing;
+  try {
+    return await VenueBooking.create({
+      venue: venueId,
+      enquiry: enquiry._id,
+      coupleName: enquiry.coupleName || enquiry.name || "",
+      couplePhone: enquiry.couplePhone || enquiry.phone || "",
+      days: enquiry.eventDate ? [{ date: enquiry.eventDate, guestCount: enquiry.guestCount || 0 }] : [],
+      totalValue: enquiry.estimatedValue || 0,
+      status: "confirmed",
+      createdBy: ownerId,
+    });
+  } catch (e) {
+    // Concurrent create lost the race on the unique index — return the winner.
+    if (e.code === 11000) return VenueBooking.findOne({ enquiry: enquiry._id });
+    throw e;
+  }
+}
+
+const listBookings = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const bookings = await VenueBooking.find({ venue: venue._id }).sort({ createdAt: -1 }).lean();
+    return res.status(200).json({ bookings, total: bookings.length });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+const getBooking = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const booking = await VenueBooking.findOne({ _id: req.params.bookingId, venue: venue._id }).lean();
+    if (!booking) return res.status(404).json({ message: "Booking not found" });
+    return res.status(200).json({ booking });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+const createBooking = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const { enquiry, coupleName, couplePhone, days, totalValue, paymentSchedule, specialRequirements, status } = req.body || {};
+    const booking = await VenueBooking.create({
+      venue: venue._id,
+      enquiry: enquiry || undefined,
+      coupleName: coupleName || "",
+      couplePhone: couplePhone || "",
+      days: Array.isArray(days) ? days : [],
+      totalValue: Number(totalValue) || 0,
+      paymentSchedule: Array.isArray(paymentSchedule) ? paymentSchedule : [],
+      specialRequirements: specialRequirements || "",
+      status: status || "confirmed",
+      createdBy: req.venueOwner.venueOwnerId,
+    });
+    return res.status(201).json({ booking });
+  } catch (err) {
+    if (err.code === 11000) return res.status(409).json({ message: "A booking already exists for this enquiry" });
+    return res.status(500).json({ message: err.message });
+  }
+};
+
+const UPDATABLE = ["coupleName", "couplePhone", "days", "totalValue", "paymentSchedule", "specialRequirements", "status"];
+const updateBooking = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const booking = await VenueBooking.findOne({ _id: req.params.bookingId, venue: venue._id });
+    if (!booking) return res.status(404).json({ message: "Booking not found" });
+    for (const k of UPDATABLE) {
+      if (req.body[k] !== undefined) booking[k] = req.body[k];
+    }
+    await booking.save();
+    return res.status(200).json({ booking });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+module.exports = {
+  createDraftBookingForEnquiry,
+  listBookings,
+  getBooking,
+  createBooking,
+  updateBooking,
+};

--- a/controllers/venueBulk.js
+++ b/controllers/venueBulk.js
@@ -1,0 +1,155 @@
+/**
+ * controllers/venueBulk.js
+ *
+ * Bulk operations over a venue's leads (venueOwnerAuth + ownership enforced):
+ *   POST /venues/:slug/enquiries/bulk          { enquiryIds[], action, value }
+ *   POST /venues/:slug/enquiries/bulk-whatsapp { enquiryIds[], templateId | body }
+ *
+ * Per-item errors are collected, never thrown, so a partial batch still applies.
+ */
+const Venue = require("../models/Venue");
+const VenueEnquiry = require("../models/VenueEnquiry");
+const VenueMessageTemplate = require("../models/VenueMessageTemplate");
+const VenueLeadInteraction = require("../models/VenueLeadInteraction");
+const venueWhatsApp = require("../utils/venueWhatsApp");
+
+const STAGE_ENUM = [
+  "new", "contacted", "site_visit_scheduled", "site_visit_done",
+  "proposal_sent", "negotiating", "booked", "lost",
+];
+const BULK_ACTIONS = ["assign", "stage", "note"];
+
+// Resolve the owned venue from slug; returns venue or sends an error response.
+async function resolveOwnedVenue(req, res) {
+  const { slug } = req.params;
+  const venue = await Venue.findOne({ slug }).select("_id name contact").lean();
+  if (!venue) {
+    res.status(404).json({ message: "Venue not found" });
+    return null;
+  }
+  if (String(venue._id) !== String(req.venueOwner.venueId)) {
+    res.status(403).json({ message: "Forbidden" });
+    return null;
+  }
+  return venue;
+}
+
+// POST /venues/:slug/enquiries/bulk
+const bulkAction = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+
+    const { enquiryIds, action, value } = req.body || {};
+    if (!Array.isArray(enquiryIds) || enquiryIds.length === 0) {
+      return res.status(400).json({ message: "enquiryIds[] is required" });
+    }
+    if (!BULK_ACTIONS.includes(action)) {
+      return res.status(400).json({ message: `action must be one of ${BULK_ACTIONS.join(", ")}` });
+    }
+    if (action === "stage" && !STAGE_ENUM.includes(value)) {
+      return res.status(400).json({ message: `value must be a valid stage (${STAGE_ENUM.join(", ")})` });
+    }
+    if (action === "assign" && (typeof value !== "string" || !value.trim())) {
+      return res.status(400).json({ message: "value (assignee) is required for assign" });
+    }
+    if (action === "note" && (typeof value !== "string" || !value.trim())) {
+      return res.status(400).json({ message: "value (note text) is required for note" });
+    }
+
+    let updated = 0;
+    const errors = [];
+    for (const id of enquiryIds) {
+      try {
+        const enquiry = await VenueEnquiry.findOne({ _id: id, venueId: venue._id });
+        if (!enquiry) {
+          errors.push({ enquiryId: id, reason: "not found for this venue" });
+          continue;
+        }
+        if (action === "assign") {
+          enquiry.assignedTo = value.trim();
+          enquiry.activities.push({ type: "assigned", description: `Assigned to ${value.trim()}`, timestamp: new Date() });
+        } else if (action === "stage") {
+          if (value !== enquiry.stage) {
+            enquiry.activities.push({ type: "stage_changed", description: `Stage changed from ${enquiry.stage} to ${value}`, timestamp: new Date() });
+            enquiry.stage = value;
+          }
+        } else if (action === "note") {
+          enquiry.notes.push({ text: value.trim(), addedAt: new Date() });
+          enquiry.activities.push({ type: "note_added", description: "Note added (bulk)", timestamp: new Date() });
+        }
+        await enquiry.save();
+        updated += 1;
+      } catch (e) {
+        errors.push({ enquiryId: id, reason: e.message });
+      }
+    }
+    return res.status(200).json({ updated, errors });
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+};
+
+// POST /venues/:slug/enquiries/bulk-whatsapp
+const bulkWhatsApp = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+
+    if (!venueWhatsApp.isConfigured()) {
+      return res.status(503).json({ configured: false, message: "WhatsApp Cloud API is not configured" });
+    }
+
+    const { enquiryIds, templateId, body } = req.body || {};
+    if (!Array.isArray(enquiryIds) || enquiryIds.length === 0) {
+      return res.status(400).json({ message: "enquiryIds[] is required" });
+    }
+
+    let messageBody = typeof body === "string" ? body.trim() : "";
+    if (templateId) {
+      const template = await VenueMessageTemplate.findOne({ _id: templateId, venue: venue._id }).lean();
+      if (!template) return res.status(404).json({ message: "Template not found" });
+      messageBody = template.body;
+    }
+    if (!messageBody) {
+      return res.status(400).json({ message: "Provide a templateId or a non-empty body" });
+    }
+
+    let sent = 0;
+    const failed = [];
+    for (const id of enquiryIds) {
+      try {
+        const enquiry = await VenueEnquiry.findOne({ _id: id, venueId: venue._id });
+        if (!enquiry) {
+          failed.push({ enquiryId: id, reason: "not found for this venue" });
+          continue;
+        }
+        const phone = enquiry.couplePhone || enquiry.phone;
+        if (!phone) {
+          failed.push({ enquiryId: id, reason: "no phone on lead" });
+          continue;
+        }
+        const result = await venueWhatsApp.sendText(phone, messageBody);
+        if (!result.ok) {
+          failed.push({ enquiryId: id, reason: result.error });
+          continue;
+        }
+        await VenueLeadInteraction.create({
+          enquiry: enquiry._id,
+          venue: venue._id,
+          type: "whatsapp",
+          note: messageBody,
+          createdBy: req.venueOwner.venueOwnerId,
+        });
+        sent += 1;
+      } catch (e) {
+        failed.push({ enquiryId: id, reason: e.message });
+      }
+    }
+    return res.status(200).json({ sent, failed });
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+};
+
+module.exports = { bulkAction, bulkWhatsApp };

--- a/controllers/venueDashboard.js
+++ b/controllers/venueDashboard.js
@@ -1,6 +1,8 @@
 const Venue = require("../models/Venue");
 const VenueOwner = require("../models/VenueOwner");
 const VenueEnquiry = require("../models/VenueEnquiry");
+const VenueBooking = require("../models/VenueBooking");
+const VenueInvoice = require("../models/VenueInvoice");
 
 // Stages that no longer need follow-up.
 const TERMINAL_STAGES = ["booked", "lost"];
@@ -77,10 +79,23 @@ const getDashboardOverview = async (req, res) => {
       }),
     ]);
 
+    // ── Revenue (Phase 3.4): confirmed vs received vs pending ──
+    const [bookings, invoices] = await Promise.all([
+      VenueBooking.find({ venue: venueId, status: { $ne: "cancelled" } }).select("totalValue").lean(),
+      VenueInvoice.find({ venue: venueId }).select("payments").lean(),
+    ]);
+    const confirmedValue = bookings.reduce((s, b) => s + (Number(b.totalValue) || 0), 0);
+    const received = invoices.reduce(
+      (s, inv) => s + (inv.payments || []).reduce((a, p) => a + (Number(p.amount) || 0), 0),
+      0
+    );
+    const revenue = { confirmedValue, received, pending: confirmedValue - received };
+
     return res.status(200).json({
       onboarding: { steps, completed, total, percent },
       isVerified,
       followUps: { dueToday, overdue },
+      revenue,
     });
   } catch (err) {
     return res.status(500).json({ message: err.message });

--- a/controllers/venueEnquiry.js
+++ b/controllers/venueEnquiry.js
@@ -159,7 +159,7 @@ const updateEnquiry = async (req, res) => {
     const enquiry = await VenueEnquiry.findOne({ _id: enquiryId, venueId: venue._id });
     if (!enquiry) return res.status(404).json({ message: "Enquiry not found" });
 
-    const { stage, estimatedValue, lostReason, followUpDate, addNote } = req.body || {};
+    const { stage, estimatedValue, lostReason, followUpDate, addNote, assignedTo } = req.body || {};
 
     if (stage !== undefined && stage !== enquiry.stage) {
       enquiry.activities.push({
@@ -172,6 +172,16 @@ const updateEnquiry = async (req, res) => {
     if (estimatedValue !== undefined) enquiry.estimatedValue = estimatedValue;
     if (lostReason !== undefined) enquiry.lostReason = lostReason;
     if (followUpDate !== undefined) enquiry.followUpDate = followUpDate || null;
+    // assignedTo stays a String holding a VenueTeamMember._id (so OS can read/resolve
+    // it); not converted to an ObjectId ref yet. Empty = unassigned.
+    if (assignedTo !== undefined) {
+      enquiry.assignedTo = assignedTo ? String(assignedTo) : "";
+      enquiry.activities.push({
+        type: "assigned",
+        description: assignedTo ? "Lead assigned" : "Lead unassigned",
+        timestamp: new Date(),
+      });
+    }
     if (typeof addNote === "string" && addNote.trim()) {
       enquiry.notes.push({ text: addNote.trim(), addedAt: new Date() });
       enquiry.activities.push({

--- a/controllers/venueEnquiry.js
+++ b/controllers/venueEnquiry.js
@@ -253,10 +253,72 @@ const createManualLead = async (req, res) => {
   }
 };
 
+// Shared bulk-create core (reused by CSV/Excel import AND Google Sheets sync).
+// Given a venueId and an array of mapped rows, dedups by couplePhone (digits-only)
+// against existing venue leads and within the batch, coerces dates/numbers safely,
+// defaults stage/source, and creates VenueEnquiry docs. Returns { created, skipped,
+// errors:[{row, reason}] }. Bad rows are caught per-row and never abort the run.
+async function importLeadRows(venueId, rows, { activityDescription = "Lead imported" } = {}) {
+  const existing = await VenueEnquiry.find({ venueId }).select("couplePhone").lean();
+  const seenPhones = new Set(existing.map((e) => digitsOnly(e.couplePhone)).filter(Boolean));
+
+  let created = 0;
+  let skipped = 0;
+  const errors = [];
+
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i] || {};
+    try {
+      const coupleName = toStr(row.coupleName);
+      const couplePhone = toStr(row.couplePhone);
+      if (!coupleName || !couplePhone) {
+        errors.push({ row: i, reason: "Missing required coupleName or couplePhone" });
+        continue;
+      }
+
+      const key = digitsOnly(couplePhone);
+      if (key && seenPhones.has(key)) {
+        skipped += 1; // duplicate of an existing lead or an earlier row in this batch
+        continue;
+      }
+
+      const sourceRaw = toStr(row.source).toLowerCase();
+      const stageRaw = toStr(row.stage).toLowerCase();
+      const source = sourceRaw && SOURCE_ENUM.includes(sourceRaw) ? sourceRaw : "other";
+      const stage = stageRaw && STAGE_ENUM.includes(stageRaw) ? stageRaw : "new";
+
+      const notesStr = toStr(row.notes);
+      await VenueEnquiry.create({
+        venueId,
+        name: coupleName,
+        phone: couplePhone,
+        coupleName,
+        couplePhone,
+        email: toStr(row.email),
+        eventDate: toDateOrNull(row.eventDate),
+        guestCount: toNumberOrNull(row.guestCount),
+        source,
+        stage,
+        estimatedValue: toNumberOrNull(row.expectedValue) || 0, // expectedValue → estimatedValue
+        notes: notesStr ? [{ text: notesStr }] : [],
+        followUpDate: toDateOrNull(row.followUpDate),
+        assignedTo: toStr(row.assignedTo),
+        activities: [{ type: "created", description: activityDescription, timestamp: new Date() }],
+        status: "new",
+      });
+
+      if (key) seenPhones.add(key);
+      created += 1;
+    } catch (rowErr) {
+      errors.push({ row: i, reason: rowErr.message });
+    }
+  }
+
+  return { created, skipped, errors };
+}
+
 // Bulk CSV/Excel lead import — venue owners only, ownership-checked.
 // Body: { rows: [mappedRow], fileName } (also tolerates a bare array of rows).
-// Per row: require coupleName + couplePhone; dedup by couplePhone within the venue
-// (and within the batch); coerce dates/numbers safely; default stage/source.
 const importLeads = async (req, res) => {
   try {
     const { slug } = req.params;
@@ -270,61 +332,7 @@ const importLeads = async (req, res) => {
       return res.status(403).json({ message: "Forbidden" });
     }
 
-    // Existing phones for this venue → dedup set (digits-only). Batch dups added as we go.
-    const existing = await VenueEnquiry.find({ venueId: venue._id }).select("couplePhone").lean();
-    const seenPhones = new Set(existing.map((e) => digitsOnly(e.couplePhone)).filter(Boolean));
-
-    let created = 0;
-    let skipped = 0;
-    const errors = [];
-
-    for (let i = 0; i < rows.length; i++) {
-      const row = rows[i] || {};
-      try {
-        const coupleName = toStr(row.coupleName);
-        const couplePhone = toStr(row.couplePhone);
-        if (!coupleName || !couplePhone) {
-          errors.push({ row: i, reason: "Missing required coupleName or couplePhone" });
-          continue;
-        }
-
-        const key = digitsOnly(couplePhone);
-        if (key && seenPhones.has(key)) {
-          skipped += 1; // duplicate of an existing lead or an earlier row in this file
-          continue;
-        }
-
-        const sourceRaw = toStr(row.source).toLowerCase();
-        const stageRaw = toStr(row.stage).toLowerCase();
-        const source = sourceRaw && SOURCE_ENUM.includes(sourceRaw) ? sourceRaw : "other";
-        const stage = stageRaw && STAGE_ENUM.includes(stageRaw) ? stageRaw : "new";
-
-        const notesStr = toStr(row.notes);
-        await VenueEnquiry.create({
-          venueId: venue._id,
-          name: coupleName,
-          phone: couplePhone,
-          coupleName,
-          couplePhone,
-          email: toStr(row.email),
-          eventDate: toDateOrNull(row.eventDate),
-          guestCount: toNumberOrNull(row.guestCount),
-          source,
-          stage,
-          estimatedValue: toNumberOrNull(row.expectedValue) || 0, // expectedValue → estimatedValue
-          notes: notesStr ? [{ text: notesStr }] : [],
-          followUpDate: toDateOrNull(row.followUpDate),
-          assignedTo: toStr(row.assignedTo),
-          activities: [{ type: "created", description: "Lead imported", timestamp: new Date() }],
-          status: "new",
-        });
-
-        if (key) seenPhones.add(key);
-        created += 1;
-      } catch (rowErr) {
-        errors.push({ row: i, reason: rowErr.message });
-      }
-    }
+    const { created, skipped, errors } = await importLeadRows(venue._id, rows);
 
     await VenueLeadImport.create({
       venue: venue._id,
@@ -359,4 +367,4 @@ const getImports = async (req, res) => {
   }
 };
 
-module.exports = { createEnquiry, createManualLead, getVenueEnquiries, updateEnquiry, importLeads, getImports };
+module.exports = { createEnquiry, createManualLead, getVenueEnquiries, updateEnquiry, importLeads, getImports, importLeadRows };

--- a/controllers/venueEnquiry.js
+++ b/controllers/venueEnquiry.js
@@ -3,6 +3,10 @@ const Venue = require("../models/Venue");
 const VenueLeadImport = require("../models/VenueLeadImport");
 const VenueLeadInteraction = require("../models/VenueLeadInteraction");
 const { createOrGetConversation } = require("./venueConversation");
+const { createDraftBookingForEnquiry } = require("./venueBooking");
+
+// Phase 3 lost-reason allowlist (mirrors models/VenueEnquiry.js; "" = none/legacy).
+const LOST_REASON_ENUM = ["", "too_expensive", "date_unavailable", "chose_competitor", "no_response", "other"];
 
 // Valid enum values (kept in sync with models/VenueEnquiry.js) for import coercion.
 const SOURCE_ENUM = ["wedsy", "instagram", "referral", "walk_in", "justdial", "wedmegood", "google", "other"];
@@ -161,12 +165,18 @@ const updateEnquiry = async (req, res) => {
 
     const { stage, estimatedValue, lostReason, followUpDate, addNote } = req.body || {};
 
+    if (lostReason !== undefined && !LOST_REASON_ENUM.includes(lostReason)) {
+      return res.status(400).json({ message: `lostReason must be one of ${LOST_REASON_ENUM.filter(Boolean).join(", ")}` });
+    }
+
+    let movedToBooked = false;
     if (stage !== undefined && stage !== enquiry.stage) {
       enquiry.activities.push({
         type: "stage_changed",
         description: `Stage changed from ${enquiry.stage} to ${stage}`,
         timestamp: new Date(),
       });
+      if (stage === "booked") movedToBooked = true;
       enquiry.stage = stage;
     }
     if (estimatedValue !== undefined) enquiry.estimatedValue = estimatedValue;
@@ -182,7 +192,19 @@ const updateEnquiry = async (req, res) => {
     }
 
     await enquiry.save();
-    return res.status(200).json({ enquiry });
+
+    // Phase 3.1: moving a lead to "booked" auto-creates a draft booking (idempotent,
+    // one per enquiry). Failure here must not fail the stage update.
+    let booking = null;
+    if (movedToBooked) {
+      try {
+        booking = await createDraftBookingForEnquiry(venue._id, enquiry, req.venueOwner.venueOwnerId);
+      } catch (bookingErr) {
+        console.error("Auto-create booking failed for enquiry", String(enquiry._id), bookingErr.message);
+      }
+    }
+
+    return res.status(200).json({ enquiry, booking: booking ? { _id: booking._id } : undefined });
   } catch (err) {
     return res.status(500).json({ message: err.message });
   }

--- a/controllers/venueEnquiry.js
+++ b/controllers/venueEnquiry.js
@@ -159,7 +159,7 @@ const updateEnquiry = async (req, res) => {
     const enquiry = await VenueEnquiry.findOne({ _id: enquiryId, venueId: venue._id });
     if (!enquiry) return res.status(404).json({ message: "Enquiry not found" });
 
-    const { stage, estimatedValue, lostReason, followUpDate, addNote } = req.body || {};
+    const { stage, estimatedValue, lostReason, followUpDate, addNote, assignedTo } = req.body || {};
 
     if (stage !== undefined && stage !== enquiry.stage) {
       enquiry.activities.push({
@@ -172,6 +172,15 @@ const updateEnquiry = async (req, res) => {
     if (estimatedValue !== undefined) enquiry.estimatedValue = estimatedValue;
     if (lostReason !== undefined) enquiry.lostReason = lostReason;
     if (followUpDate !== undefined) enquiry.followUpDate = followUpDate || null;
+    // assignedTo on the single-enquiry PATCH (the harness caught this was dropped).
+    if (assignedTo !== undefined) {
+      enquiry.assignedTo = assignedTo ? String(assignedTo) : "";
+      enquiry.activities.push({
+        type: "assigned",
+        description: assignedTo ? `Lead assigned to ${assignedTo}` : "Lead unassigned",
+        timestamp: new Date(),
+      });
+    }
     if (typeof addNote === "string" && addNote.trim()) {
       enquiry.notes.push({ text: addNote.trim(), addedAt: new Date() });
       enquiry.activities.push({

--- a/controllers/venueEnquiry.js
+++ b/controllers/venueEnquiry.js
@@ -8,6 +8,7 @@ const { writeBackLeadToSheet } = require("../utils/venueSheetWriteBack");
 
 // Phase 3 lost-reason allowlist (mirrors models/VenueEnquiry.js; "" = none/legacy).
 const LOST_REASON_ENUM = ["", "too_expensive", "date_unavailable", "chose_competitor", "no_response", "other"];
+const { reqStr, optStr, optDate, optNumber, optCount, cleanStr, MAXLEN } = require("../utils/venueInput");
 
 // Valid enum values (kept in sync with models/VenueEnquiry.js) for import coercion.
 const SOURCE_ENUM = ["wedsy", "instagram", "referral", "walk_in", "justdial", "wedmegood", "google", "other"];
@@ -54,12 +55,21 @@ const createEnquiry = async (req, res) => {
 
     const userId = bodyUserId || (req.auth && req.auth.user_id) || null;
 
-    const effectiveName = coupleName || name;
-    const effectivePhone = couplePhone || phone;
+    const effectiveName = cleanStr(coupleName || name);
+    const effectivePhone = cleanStr(couplePhone || phone);
 
     if (!effectiveName || !effectivePhone) {
       return res.status(400).json({ message: "Name and phone are required" });
     }
+    // Hostile-input validation on the PUBLIC endpoint (length caps, strict dates, numbers).
+    for (const [v, f, max] of [[effectiveName, "name", MAXLEN.name], [effectivePhone, "phone", MAXLEN.phone], [email, "email", MAXLEN.email], [message, "message", MAXLEN.text], [budget, "budget", MAXLEN.label]]) {
+      const r = optStr(v, f, max);
+      if (!r.ok) return res.status(400).json({ message: r.message });
+    }
+    const edPub = optDate(eventDate, "eventDate"); if (!edPub.ok) return res.status(400).json({ message: edPub.message });
+    const fuPub = optDate(followUpDate, "followUpDate"); if (!fuPub.ok) return res.status(400).json({ message: fuPub.message });
+    const gcPub = optCount(guestCount, "guestCount"); if (!gcPub.ok) return res.status(400).json({ message: gcPub.message });
+    const evPub = optNumber(estimatedValue, "estimatedValue"); if (!evPub.ok) return res.status(400).json({ message: evPub.message });
 
     const venue = await Venue.findOne({ slug }).select("_id name phone status").lean();
     if (!venue) {
@@ -80,19 +90,19 @@ const createEnquiry = async (req, res) => {
       userId: userId || undefined,
       name: effectiveName,
       phone: effectivePhone,
-      coupleName: coupleName || effectiveName,
-      couplePhone: couplePhone || effectivePhone,
-      email: email || "",
-      eventDate: eventDate || null,
-      guestCount: guestCount || null,
-      budget: budget || "",
-      vibe: vibe || [],
-      message: message || "",
+      coupleName: cleanStr(coupleName) || effectiveName,
+      couplePhone: cleanStr(couplePhone) || effectivePhone,
+      email: cleanStr(email),
+      eventDate: edPub.value,
+      guestCount: gcPub.value != null ? gcPub.value : null,
+      budget: cleanStr(budget),
+      vibe: Array.isArray(vibe) ? vibe.slice(0, 50).map((x) => String(x).slice(0, 100)) : [],
+      message: cleanStr(message),
       source: source || "wedsy",
       stage: "new", // forced server-side; client cannot set stage on the public endpoint
-      estimatedValue: estimatedValue || 0,
+      estimatedValue: evPub.value != null ? evPub.value : 0,
       notes: notesArray,
-      followUpDate: followUpDate || null,
+      followUpDate: fuPub.value,
       activities: [{ type: "created", description: "Lead created", timestamp: new Date() }],
       status: "new",
     });
@@ -169,6 +179,11 @@ const updateEnquiry = async (req, res) => {
     if (lostReason !== undefined && !LOST_REASON_ENUM.includes(lostReason)) {
       return res.status(400).json({ message: `lostReason must be one of ${LOST_REASON_ENUM.filter(Boolean).join(", ")}` });
     }
+    if (stage !== undefined && !STAGE_ENUM.includes(stage)) {
+      return res.status(400).json({ message: `stage must be one of ${STAGE_ENUM.join(", ")}` });
+    }
+    const evV = optNumber(estimatedValue, "estimatedValue"); if (!evV.ok) return res.status(400).json({ message: evV.message });
+    const fuV = optDate(followUpDate, "followUpDate"); if (!fuV.ok) return res.status(400).json({ message: fuV.message });
 
     let movedToBooked = false;
     let stageChanged = false;
@@ -182,9 +197,9 @@ const updateEnquiry = async (req, res) => {
       enquiry.stage = stage;
       stageChanged = true;
     }
-    if (estimatedValue !== undefined) enquiry.estimatedValue = estimatedValue;
+    if (evV.value !== undefined) enquiry.estimatedValue = evV.value;
     if (lostReason !== undefined) enquiry.lostReason = lostReason;
-    if (followUpDate !== undefined) enquiry.followUpDate = followUpDate || null;
+    if (followUpDate !== undefined) enquiry.followUpDate = fuV.value;
     // assignedTo: a String holding a VenueTeamMember._id (so OS can read/resolve it);
     // not an ObjectId ref yet. Empty = unassigned. (Harness caught it was dropped.)
     if (assignedTo !== undefined) {
@@ -254,9 +269,20 @@ const createManualLead = async (req, res) => {
       assignedTo,
     } = req.body || {};
 
-    if (!coupleName && !couplePhone) {
+    const nameC = cleanStr(coupleName);
+    const phoneC = cleanStr(couplePhone);
+    if (!nameC && !phoneC) {
       return res.status(400).json({ message: "Couple name or phone is required" });
     }
+    // Hostile-input validation (length caps, strict dates, non-negative numbers).
+    for (const [v, f, max] of [[coupleName, "coupleName", MAXLEN.name], [couplePhone, "couplePhone", MAXLEN.phone], [email, "email", MAXLEN.email], [message, "message", MAXLEN.text]]) {
+      const r = optStr(v, f, max);
+      if (!r.ok) return res.status(400).json({ message: r.message });
+    }
+    const edV = optDate(eventDate, "eventDate"); if (!edV.ok) return res.status(400).json({ message: edV.message });
+    const fuV = optDate(followUpDate, "followUpDate"); if (!fuV.ok) return res.status(400).json({ message: fuV.message });
+    const gcV = optCount(guestCount, "guestCount"); if (!gcV.ok) return res.status(400).json({ message: gcV.message });
+    const evV = optNumber(estimatedValue, "estimatedValue"); if (!evV.ok) return res.status(400).json({ message: evV.message });
 
     const venue = await Venue.findOne({ slug }).select("_id").lean();
     if (!venue) return res.status(404).json({ message: "Venue not found" });
@@ -267,28 +293,29 @@ const createManualLead = async (req, res) => {
     let notesArray = [];
     if (Array.isArray(notes)) {
       notesArray = notes
-        .map((n) => (typeof n === "string" ? { text: n } : n))
-        .filter((n) => n && n.text);
+        .map((n) => (typeof n === "string" ? { text: cleanStr(n) } : n))
+        .filter((n) => n && n.text)
+        .map((n) => ({ text: String(n.text).slice(0, MAXLEN.text) }));
     } else if (typeof notes === "string" && notes.trim()) {
-      notesArray = [{ text: notes.trim() }];
+      notesArray = [{ text: notes.trim().slice(0, MAXLEN.text) }];
     }
 
     const enquiry = await VenueEnquiry.create({
       venueId: venue._id,
-      name: coupleName || "",
-      phone: couplePhone || "",
-      coupleName: coupleName || "",
-      couplePhone: couplePhone || "",
-      email: email || "",
-      eventDate: eventDate || null,
-      guestCount: guestCount || null,
-      message: message || "",
+      name: nameC,
+      phone: phoneC,
+      coupleName: nameC,
+      couplePhone: phoneC,
+      email: cleanStr(email),
+      eventDate: edV.value,
+      guestCount: gcV.value != null ? gcV.value : null,
+      message: cleanStr(message),
       source: source || "other",
       stage: stage || "new",
-      estimatedValue: estimatedValue || 0,
+      estimatedValue: evV.value != null ? evV.value : 0,
       notes: notesArray,
-      followUpDate: followUpDate || null,
-      assignedTo: assignedTo || "",
+      followUpDate: fuV.value,
+      assignedTo: cleanStr(assignedTo),
       activities: [{ type: "created", description: "Lead added manually", timestamp: new Date() }],
       status: "new",
     });

--- a/controllers/venueEnquiry.js
+++ b/controllers/venueEnquiry.js
@@ -3,6 +3,7 @@ const Venue = require("../models/Venue");
 const VenueLeadImport = require("../models/VenueLeadImport");
 const VenueLeadInteraction = require("../models/VenueLeadInteraction");
 const { createOrGetConversation } = require("./venueConversation");
+const { writeBackLeadToSheet } = require("../utils/venueSheetWriteBack");
 
 // Valid enum values (kept in sync with models/VenueEnquiry.js) for import coercion.
 const SOURCE_ENUM = ["wedsy", "instagram", "referral", "walk_in", "justdial", "wedmegood", "google", "other"];
@@ -161,6 +162,7 @@ const updateEnquiry = async (req, res) => {
 
     const { stage, estimatedValue, lostReason, followUpDate, addNote } = req.body || {};
 
+    let stageChanged = false;
     if (stage !== undefined && stage !== enquiry.stage) {
       enquiry.activities.push({
         type: "stage_changed",
@@ -168,6 +170,7 @@ const updateEnquiry = async (req, res) => {
         timestamp: new Date(),
       });
       enquiry.stage = stage;
+      stageChanged = true;
     }
     if (estimatedValue !== undefined) enquiry.estimatedValue = estimatedValue;
     if (lostReason !== undefined) enquiry.lostReason = lostReason;
@@ -182,6 +185,18 @@ const updateEnquiry = async (req, res) => {
     }
 
     await enquiry.save();
+
+    // Fire-and-forget: mirror a stage change back to the source Google Sheet for
+    // sheet-synced leads. Never blocks the PATCH and never surfaces errors here;
+    // no-ops gracefully when there is no integration / creds / row mapping.
+    if (stageChanged) {
+      setImmediate(() => {
+        writeBackLeadToSheet(enquiry).catch((e) =>
+          console.warn(`[writeBackLeadToSheet] enquiry ${enquiry._id}: ${e.message}`)
+        );
+      });
+    }
+
     return res.status(200).json({ enquiry });
   } catch (err) {
     return res.status(500).json({ message: err.message });

--- a/controllers/venueInvoice.js
+++ b/controllers/venueInvoice.js
@@ -6,6 +6,7 @@ const Venue = require("../models/Venue");
 const VenueInvoice = require("../models/VenueInvoice");
 const VenueBooking = require("../models/VenueBooking");
 const VenueQuote = require("../models/VenueQuote");
+const VenueCounter = require("../models/VenueCounter");
 const { computeTotals } = require("../utils/venueMoney");
 const { streamInvoicePdf } = require("../utils/venuePdf");
 
@@ -44,11 +45,17 @@ const createFromBooking = async (req, res) => {
     if (!items) items = [{ label: "Venue booking", category: "venue_hire", qty: 1, unitPrice: bookingDoc.totalValue || 0 }];
     const totals = computeTotals(items, pct, disc);
 
-    // Per-venue sequence (retry once on the unique index, in case of a race).
+    // Atomic per-venue invoice sequence (no read-modify-write race). Lazy-init the
+    // counter to the current max seq so it never collides with pre-existing/seeded
+    // invoices, then allocate via an atomic $inc.
     const prefix = venue.invoicePrefix || "INV-";
+    const counterKey = `${venue._id}:invoice`;
+    const maxDoc = await VenueInvoice.findOne({ venue: venue._id }).sort({ seq: -1 }).select("seq").lean();
+    try {
+      await VenueCounter.updateOne({ key: counterKey }, { $setOnInsert: { seq: maxDoc ? maxDoc.seq : 0 } }, { upsert: true });
+    } catch (e) { if (e.code !== 11000) throw e; } // concurrent first-init race — fine
     for (let attempt = 0; attempt < 3; attempt++) {
-      const latest = await VenueInvoice.findOne({ venue: venue._id }).sort({ seq: -1 }).select("seq").lean();
-      const seq = (latest ? latest.seq : 0) + 1;
+      const seq = await VenueCounter.next(counterKey);
       const invoiceNumber = `${prefix}${String(seq).padStart(4, "0")}`;
       try {
         const invoice = await VenueInvoice.create({
@@ -66,7 +73,7 @@ const createFromBooking = async (req, res) => {
         });
         return res.status(201).json({ invoice });
       } catch (e) {
-        if (e.code === 11000 && attempt < 2) continue; // seq raced — retry
+        if (e.code === 11000 && attempt < 2) continue; // extremely unlikely; allocate next
         throw e;
       }
     }
@@ -105,7 +112,18 @@ const addPayment = async (req, res) => {
     const { amount, mode, note, date } = req.body || {};
     const amt = Number(amount);
     if (!Number.isFinite(amt) || amt <= 0) return res.status(400).json({ message: "amount must be a positive number" });
-    invoice.payments.push({ amount: amt, mode: mode || "bank_transfer", note: note || "", date: date ? new Date(date) : new Date() });
+    if (date != null && date !== "" && Number.isNaN(new Date(date).getTime())) {
+      return res.status(400).json({ message: "date is not valid" });
+    }
+    const ALLOWED_MODES = ["bank_transfer", "cash", "cheque", "upi", "card"];
+    if (mode != null && !ALLOWED_MODES.includes(mode)) return res.status(400).json({ message: "invalid payment mode" });
+    // Reject overpayment: a single payment may not exceed the outstanding balance.
+    const already = invoice.payments.reduce((s, p) => s + (Number(p.amount) || 0), 0);
+    const balanceBefore = invoice.totals.grandTotal - already;
+    if (amt > balanceBefore) {
+      return res.status(400).json({ message: `payment exceeds outstanding balance (${balanceBefore})`, balance: balanceBefore });
+    }
+    invoice.payments.push({ amount: amt, mode: mode || "bank_transfer", note: String(note || "").slice(0, 2000), date: date ? new Date(date) : new Date() });
     const received = invoice.payments.reduce((s, p) => s + (Number(p.amount) || 0), 0);
     invoice.status = paymentStatus(invoice.totals.grandTotal, received);
     await invoice.save();

--- a/controllers/venueInvoice.js
+++ b/controllers/venueInvoice.js
@@ -1,0 +1,128 @@
+/**
+ * controllers/venueInvoice.js — Phase 3 (3.3) GST invoices.
+ * Routes under /venues/:slug/invoices (venueOwnerAuth + ownership).
+ */
+const Venue = require("../models/Venue");
+const VenueInvoice = require("../models/VenueInvoice");
+const VenueBooking = require("../models/VenueBooking");
+const VenueQuote = require("../models/VenueQuote");
+const { computeTotals } = require("../utils/venueMoney");
+const { streamInvoicePdf } = require("../utils/venuePdf");
+
+async function resolveOwnedVenue(req, res, select = "_id") {
+  const venue = await Venue.findOne({ slug: req.params.slug }).select(select).lean();
+  if (!venue) { res.status(404).json({ message: "Venue not found" }); return null; }
+  if (String(venue._id) !== String(req.venueOwner.venueId)) { res.status(403).json({ message: "Forbidden" }); return null; }
+  return venue;
+}
+
+function paymentStatus(grandTotal, received) {
+  if (received <= 0) return "unpaid";
+  if (received >= grandTotal) return "paid";
+  return "partially_paid";
+}
+
+// POST /venues/:slug/invoices — create-from-booking.
+const createFromBooking = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res, "_id invoicePrefix");
+    if (!venue) return;
+    const { booking, kind, lineItems, gstPercent, discount } = req.body || {};
+    if (!booking) return res.status(400).json({ message: "booking is required" });
+    const bookingDoc = await VenueBooking.findOne({ _id: booking, venue: venue._id }).lean();
+    if (!bookingDoc) return res.status(404).json({ message: "Booking not found for this venue" });
+
+    // Line items: explicit body > latest accepted quote for the enquiry > single line from booking total.
+    let items = Array.isArray(lineItems) ? lineItems : null;
+    let pct = gstPercent !== undefined ? Number(gstPercent) : 18;
+    let disc = Number(discount) || 0;
+    if (!items && bookingDoc.enquiry) {
+      const quote = await VenueQuote.findOne({ enquiry: bookingDoc.enquiry, status: "accepted" }).sort({ version: -1 }).lean()
+        || await VenueQuote.findOne({ enquiry: bookingDoc.enquiry }).sort({ version: -1 }).lean();
+      if (quote) { items = quote.lineItems; pct = quote.gstPercent; disc = quote.discount; }
+    }
+    if (!items) items = [{ label: "Venue booking", category: "venue_hire", qty: 1, unitPrice: bookingDoc.totalValue || 0 }];
+    const totals = computeTotals(items, pct, disc);
+
+    // Per-venue sequence (retry once on the unique index, in case of a race).
+    const prefix = venue.invoicePrefix || "INV-";
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const latest = await VenueInvoice.findOne({ venue: venue._id }).sort({ seq: -1 }).select("seq").lean();
+      const seq = (latest ? latest.seq : 0) + 1;
+      const invoiceNumber = `${prefix}${String(seq).padStart(4, "0")}`;
+      try {
+        const invoice = await VenueInvoice.create({
+          venue: venue._id,
+          booking: bookingDoc._id,
+          invoiceNumber,
+          seq,
+          kind: kind === "final" ? "final" : "advance",
+          lineItems: items,
+          gstPercent: pct,
+          discount: disc,
+          totals,
+          status: "unpaid",
+          payments: [],
+        });
+        return res.status(201).json({ invoice });
+      } catch (e) {
+        if (e.code === 11000 && attempt < 2) continue; // seq raced — retry
+        throw e;
+      }
+    }
+    return res.status(409).json({ message: "Could not allocate an invoice number, please retry" });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+const listInvoices = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const filter = { venue: venue._id };
+    if (req.query.booking) filter.booking = req.query.booking;
+    const invoices = await VenueInvoice.find(filter).sort({ createdAt: -1 }).lean();
+    return res.status(200).json({ invoices, total: invoices.length });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+const getInvoice = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const invoice = await VenueInvoice.findOne({ _id: req.params.invoiceId, venue: venue._id }).lean();
+    if (!invoice) return res.status(404).json({ message: "Invoice not found" });
+    return res.status(200).json({ invoice });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+// POST /venues/:slug/invoices/:invoiceId/payments — record a payment.
+const addPayment = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const invoice = await VenueInvoice.findOne({ _id: req.params.invoiceId, venue: venue._id });
+    if (!invoice) return res.status(404).json({ message: "Invoice not found" });
+    const { amount, mode, note, date } = req.body || {};
+    const amt = Number(amount);
+    if (!Number.isFinite(amt) || amt <= 0) return res.status(400).json({ message: "amount must be a positive number" });
+    invoice.payments.push({ amount: amt, mode: mode || "bank_transfer", note: note || "", date: date ? new Date(date) : new Date() });
+    const received = invoice.payments.reduce((s, p) => s + (Number(p.amount) || 0), 0);
+    invoice.status = paymentStatus(invoice.totals.grandTotal, received);
+    await invoice.save();
+    return res.status(200).json({ invoice, received, balance: invoice.totals.grandTotal - received });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+// GET /venues/:slug/invoices/:invoiceId/pdf
+const invoicePdf = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res, "name address formattedAddress contact phone email gstin pan");
+    if (!venue) return;
+    const invoice = await VenueInvoice.findOne({ _id: req.params.invoiceId, venue: venue._id }).lean();
+    if (!invoice) return res.status(404).json({ message: "Invoice not found" });
+    const booking = await VenueBooking.findById(invoice.booking).select("coupleName couplePhone").lean();
+    streamInvoicePdf(res, { venue, booking, invoice });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+module.exports = { createFromBooking, listInvoices, getInvoice, addPayment, invoicePdf };

--- a/controllers/venueOnboarding.js
+++ b/controllers/venueOnboarding.js
@@ -1,0 +1,34 @@
+/**
+ * controllers/venueOnboarding.js — public "list your venue" lead capture.
+ * POST /venues/onboarding-requests (public, rate-limited). Hostile-input validated.
+ */
+const VenueOnboardingRequest = require("../models/VenueOnboardingRequest");
+const { reqStr, optStr, MAXLEN } = require("../utils/venueInput");
+
+const createOnboardingRequest = async (req, res) => {
+  try {
+    const { name, venueName, city, phone } = req.body || {};
+    const nameV = reqStr(name, "name", MAXLEN.name);
+    if (!nameV.ok) return res.status(400).json({ message: nameV.message });
+    const venueV = reqStr(venueName, "venueName", MAXLEN.name);
+    if (!venueV.ok) return res.status(400).json({ message: venueV.message });
+    const cityV = optStr(city, "city", 120);
+    if (!cityV.ok) return res.status(400).json({ message: cityV.message });
+    const phoneDigits = String(phone == null ? "" : phone).replace(/\D/g, "");
+    if (phoneDigits.length < 10 || phoneDigits.length > 15) {
+      return res.status(400).json({ message: "A valid phone number is required" });
+    }
+    const doc = await VenueOnboardingRequest.create({
+      name: nameV.value,
+      venueName: venueV.value,
+      city: cityV.value,
+      phone: String(phone).trim().slice(0, MAXLEN.phone),
+      status: "new",
+    });
+    return res.status(201).json({ success: true, id: doc._id });
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+};
+
+module.exports = { createOnboardingRequest };

--- a/controllers/venueOwner.js
+++ b/controllers/venueOwner.js
@@ -1,6 +1,8 @@
 const jwt = require("jsonwebtoken");
 const axios = require("axios");
 const VenueOwner = require("../models/VenueOwner");
+const VenueTeamMember = require("../models/VenueTeamMember");
+const VenueTeamActivity = require("../models/VenueTeamActivity");
 const Venue = require("../models/Venue");
 const VenueClaimRequest = require("../models/VenueClaimRequest");
 const NotificationFailureLog = require("../models/NotificationFailureLog");
@@ -358,8 +360,12 @@ const sendLoginOTP = async (req, res) => {
   try {
     const { phone } = req.body;
     if (!phone) return res.status(400).json({ message: "Phone is required" });
+    // Owner account OR an active team member with this phone may log in.
     const venueOwner = await VenueOwner.findOne({ phone }).lean();
-    if (!venueOwner) return res.status(404).json({ message: "No venue account found for this phone number" });
+    const member = venueOwner ? null : await VenueTeamMember.findOne({ phone, isActive: true }).lean();
+    if (!venueOwner && !member) {
+      return res.status(404).json({ message: "No venue account found for this phone number" });
+    }
     const { ReferenceId } = await SendOTP(phone);
     return res.status(200).json({ success: true, referenceId: ReferenceId });
   } catch (err) {
@@ -378,7 +384,38 @@ const login = async (req, res) => {
       : await VerifyOTP(phone, referenceId, otp);
     if (!result.Valid) return res.status(400).json({ message: "Invalid or expired OTP" });
     const venueOwner = await VenueOwner.findOne({ phone }).populate("venueId", "name slug status");
-    if (!venueOwner) return res.status(404).json({ message: "No venue account found" });
+
+    // No owner account for this phone → try an active team member (per-member login).
+    if (!venueOwner) {
+      const member = await VenueTeamMember.findOne({ phone, isActive: true }).populate("venueId", "name slug status");
+      if (!member) return res.status(404).json({ message: "No venue account found" });
+      member.lastLoginAt = new Date();
+      await member.save();
+      const memberToken = jwt.sign(
+        {
+          type: "venue_owner", // same type — owner = member with role "owner"
+          venueId: member.venueId._id,
+          memberId: member._id,
+          ownerId: member.ownerId,
+          role: member.role,
+        },
+        process.env.JWT_SECRET,
+        { expiresIn: "30d" }
+      );
+      VenueTeamActivity.create({
+        venueId: member.venueId._id,
+        actorId: String(member._id),
+        actorName: member.name,
+        action: "member_login",
+        targetMemberId: String(member._id),
+      }).catch((e) => console.error("Failed to log member login:", e.message));
+      return res.status(200).json({
+        success: true,
+        token: memberToken,
+        venueOwner: { id: member._id, name: member.name, phone: member.phone, role: member.role, venue: member.venueId, isMember: true },
+      });
+    }
+
     venueOwner.lastLoginAt = new Date();
     await venueOwner.save();
     const token = jwt.sign(

--- a/controllers/venueOwner.js
+++ b/controllers/venueOwner.js
@@ -373,6 +373,69 @@ const sendLoginOTP = async (req, res) => {
   }
 };
 
+// Collect EVERY login identity for a phone: owner accounts + active memberships.
+// Each is independently selectable — this makes multi-identity login deterministic
+// (no implicit owner-first / first-member pick when a phone maps to several).
+async function collectIdentities(phone) {
+  const [owners, members] = await Promise.all([
+    VenueOwner.find({ phone }).populate("venueId", "name slug status"),
+    VenueTeamMember.find({ phone, isActive: true }).populate("venueId", "name slug status"),
+  ]);
+  const identities = [];
+  for (const o of owners) {
+    if (!o.venueId) continue;
+    identities.push({ kind: "owner", id: String(o._id), venueId: String(o.venueId._id), venueName: o.venueId.name, role: o.role, doc: o });
+  }
+  for (const m of members) {
+    if (!m.venueId) continue;
+    identities.push({ kind: "member", id: String(m._id), venueId: String(m.venueId._id), venueName: m.venueId.name, role: m.role, doc: m });
+  }
+  return identities;
+}
+
+function signOwnerToken(venueOwner) {
+  return jwt.sign(
+    { type: "venue_owner", venueOwnerId: venueOwner._id, venueId: venueOwner.venueId._id, role: venueOwner.role },
+    process.env.JWT_SECRET,
+    { expiresIn: "30d" }
+  );
+}
+
+function signMemberToken(member) {
+  return jwt.sign(
+    { type: "venue_owner", venueId: member.venueId._id, memberId: member._id, ownerId: member.ownerId, role: member.role },
+    process.env.JWT_SECRET,
+    { expiresIn: "30d" }
+  );
+}
+
+// Mint the session token for a resolved identity and build the login response.
+async function loginAsIdentity(identity) {
+  if (identity.kind === "owner") {
+    const venueOwner = identity.doc;
+    venueOwner.lastLoginAt = new Date();
+    await venueOwner.save();
+    // Fire-and-forget enrichment; never block the login response.
+    setImmediate(() => {
+      enrichVenue(venueOwner.venueId._id).catch((err) =>
+        console.warn(`[enrichVenue] login enrichment failed for venue ${venueOwner.venueId._id}: ${err.message}`)
+      );
+    });
+    return { token: signOwnerToken(venueOwner), venueOwner: { id: venueOwner._id, name: venueOwner.name, phone: venueOwner.phone, role: venueOwner.role, venue: venueOwner.venueId } };
+  }
+  const member = identity.doc;
+  member.lastLoginAt = new Date();
+  await member.save();
+  VenueTeamActivity.create({
+    venueId: member.venueId._id,
+    actorId: String(member._id),
+    actorName: member.name,
+    action: "member_login",
+    targetMemberId: String(member._id),
+  }).catch((e) => console.error("Failed to log member login:", e.message));
+  return { token: signMemberToken(member), venueOwner: { id: member._id, name: member.name, phone: member.phone, role: member.role, venue: member.venueId, isMember: true } };
+}
+
 // POST /venue-owner/auth — login
 const login = async (req, res) => {
   try {
@@ -383,57 +446,71 @@ const login = async (req, res) => {
       ? { Valid: true }
       : await VerifyOTP(phone, referenceId, otp);
     if (!result.Valid) return res.status(400).json({ message: "Invalid or expired OTP" });
-    const venueOwner = await VenueOwner.findOne({ phone }).populate("venueId", "name slug status");
 
-    // No owner account for this phone → try an active team member (per-member login).
-    if (!venueOwner) {
-      const member = await VenueTeamMember.findOne({ phone, isActive: true }).populate("venueId", "name slug status");
-      if (!member) return res.status(404).json({ message: "No venue account found" });
-      member.lastLoginAt = new Date();
-      await member.save();
-      const memberToken = jwt.sign(
-        {
-          type: "venue_owner", // same type — owner = member with role "owner"
-          venueId: member.venueId._id,
-          memberId: member._id,
-          ownerId: member.ownerId,
-          role: member.role,
-        },
-        process.env.JWT_SECRET,
-        { expiresIn: "30d" }
-      );
-      VenueTeamActivity.create({
-        venueId: member.venueId._id,
-        actorId: String(member._id),
-        actorName: member.name,
-        action: "member_login",
-        targetMemberId: String(member._id),
-      }).catch((e) => console.error("Failed to log member login:", e.message));
-      return res.status(200).json({
-        success: true,
-        token: memberToken,
-        venueOwner: { id: member._id, name: member.name, phone: member.phone, role: member.role, venue: member.venueId, isMember: true },
-      });
+    const identities = await collectIdentities(phone);
+    if (identities.length === 0) return res.status(404).json({ message: "No venue account found" });
+
+    // Exactly one identity → log straight in (unchanged behaviour).
+    if (identities.length === 1) {
+      const out = await loginAsIdentity(identities[0]);
+      return res.status(200).json({ success: true, ...out });
     }
 
-    venueOwner.lastLoginAt = new Date();
-    await venueOwner.save();
-    const token = jwt.sign(
-      { type: "venue_owner", venueOwnerId: venueOwner._id, venueId: venueOwner.venueId._id, role: venueOwner.role },
+    // Multiple identities → the client must choose. The short-lived selection
+    // token binds the choice to this just-verified phone and the exact options
+    // offered, so select-identity can't be used to mint an unoffered identity.
+    const selectionToken = jwt.sign(
+      { type: "venue_identity_select", phone, options: identities.map((i) => ({ kind: i.kind, id: i.id })) },
       process.env.JWT_SECRET,
-      { expiresIn: "30d" }
+      { expiresIn: "10m" }
     );
-    // Fire-and-forget Google enrichment so the owner sees fresh photos/zone
-    // next time they hit the dashboard. Never block the login response on it.
-    setImmediate(() => {
-      enrichVenue(venueOwner.venueId._id).catch((err) => {
-        console.warn(`[enrichVenue] login enrichment failed for venue ${venueOwner.venueId._id}: ${err.message}`);
-      });
+    return res.status(200).json({
+      multiple: true,
+      selectionToken,
+      identities: identities.map((i) => ({ kind: i.kind, id: i.id, venueId: i.venueId, venueName: i.venueName, role: i.role })),
     });
-    return res.status(200).json({ success: true, token, venueOwner: { id: venueOwner._id, name: venueOwner.name, phone: venueOwner.phone, role: venueOwner.role, venue: venueOwner.venueId } });
   } catch (err) {
     return res.status(500).json({ message: err.message });
   }
 };
 
-module.exports = { getClaimInfo, initiateClaim, verifyClaim, verifyDocument, submitManualClaim, sendLoginOTP, login };
+// POST /venue-owner/auth/select-identity — exchange a selection token + chosen
+// identity for the venue_owner session token. Re-resolves the identity from the
+// DB (never trusts a client-supplied role) and verifies it was among the offered
+// options bound to the verified phone.
+const selectIdentity = async (req, res) => {
+  try {
+    const { selectionToken, kind, id } = req.body || {};
+    if (!selectionToken || !kind || !id) {
+      return res.status(400).json({ message: "selectionToken, kind, and id are required" });
+    }
+    let payload;
+    try {
+      payload = jwt.verify(selectionToken, process.env.JWT_SECRET);
+    } catch {
+      return res.status(400).json({ message: "Invalid or expired selection token" });
+    }
+    if (payload.type !== "venue_identity_select" || !Array.isArray(payload.options) || !payload.phone) {
+      return res.status(400).json({ message: "Invalid selection token" });
+    }
+    const offered = payload.options.some((o) => o.kind === kind && String(o.id) === String(id));
+    if (!offered) return res.status(403).json({ message: "Identity not offered for this selection" });
+
+    let identity = null;
+    if (kind === "owner") {
+      const o = await VenueOwner.findOne({ _id: id, phone: payload.phone }).populate("venueId", "name slug status");
+      if (o && o.venueId) identity = { kind: "owner", doc: o };
+    } else if (kind === "member") {
+      const m = await VenueTeamMember.findOne({ _id: id, phone: payload.phone, isActive: true }).populate("venueId", "name slug status");
+      if (m && m.venueId) identity = { kind: "member", doc: m };
+    }
+    if (!identity) return res.status(404).json({ message: "Identity no longer available" });
+
+    const out = await loginAsIdentity(identity);
+    return res.status(200).json({ success: true, ...out });
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+};
+
+module.exports = { getClaimInfo, initiateClaim, verifyClaim, verifyDocument, submitManualClaim, sendLoginOTP, login, selectIdentity };

--- a/controllers/venuePayment.js
+++ b/controllers/venuePayment.js
@@ -1,0 +1,67 @@
+/**
+ * controllers/venuePayment.js — Phase 3 (3.4) payments summary.
+ * GET /venues/:slug/payments/summary (venueOwnerAuth + ownership).
+ */
+const Venue = require("../models/Venue");
+const VenueBooking = require("../models/VenueBooking");
+const VenueInvoice = require("../models/VenueInvoice");
+
+async function resolveOwnedVenue(req, res) {
+  const venue = await Venue.findOne({ slug: req.params.slug }).select("_id").lean();
+  if (!venue) { res.status(404).json({ message: "Venue not found" }); return null; }
+  if (String(venue._id) !== String(req.venueOwner.venueId)) { res.status(403).json({ message: "Forbidden" }); return null; }
+  return venue;
+}
+
+const summary = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+
+    const bookings = await VenueBooking.find({ venue: venue._id, status: { $ne: "cancelled" } }).lean();
+    const invoices = await VenueInvoice.find({ venue: venue._id }).lean();
+
+    // Received per booking = sum of all payments across that booking's invoices.
+    const receivedByBooking = {};
+    for (const inv of invoices) {
+      const key = String(inv.booking);
+      const paid = (inv.payments || []).reduce((s, p) => s + (Number(p.amount) || 0), 0);
+      receivedByBooking[key] = (receivedByBooking[key] || 0) + paid;
+    }
+
+    const now = new Date();
+    const perBooking = [];
+    const overdue = [];
+    let confirmedValue = 0;
+    let received = 0;
+
+    for (const b of bookings) {
+      const totalValue = Number(b.totalValue) || 0;
+      const recv = receivedByBooking[String(b._id)] || 0;
+      const balance = totalValue - recv;
+      confirmedValue += totalValue;
+      received += recv;
+      perBooking.push({ bookingId: b._id, coupleName: b.coupleName, totalValue, received: recv, balance });
+
+      for (const item of b.paymentSchedule || []) {
+        if (item.dueDate && new Date(item.dueDate) < now && balance > 0) {
+          overdue.push({
+            bookingId: b._id,
+            coupleName: b.coupleName,
+            label: item.label,
+            dueDate: item.dueDate,
+            amount: Number(item.amount) || 0,
+          });
+        }
+      }
+    }
+
+    return res.status(200).json({
+      perBooking,
+      totals: { confirmedValue, received, pending: confirmedValue - received },
+      overdue,
+    });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+module.exports = { summary };

--- a/controllers/venueQuote.js
+++ b/controllers/venueQuote.js
@@ -1,0 +1,120 @@
+/**
+ * controllers/venueQuote.js — Phase 3 (3.2) versioned quotes + PDF + quote→booking.
+ * Routes under /venues/:slug/quotes (venueOwnerAuth + ownership).
+ */
+const Venue = require("../models/Venue");
+const VenueQuote = require("../models/VenueQuote");
+const VenueEnquiry = require("../models/VenueEnquiry");
+const { computeTotals } = require("../utils/venueMoney");
+const { streamQuotePdf } = require("../utils/venuePdf");
+const { createDraftBookingForEnquiry } = require("./venueBooking");
+
+async function resolveOwnedVenue(req, res, select = "_id") {
+  const venue = await Venue.findOne({ slug: req.params.slug }).select(select).lean();
+  if (!venue) { res.status(404).json({ message: "Venue not found" }); return null; }
+  if (String(venue._id) !== String(req.venueOwner.venueId)) { res.status(403).json({ message: "Forbidden" }); return null; }
+  return venue;
+}
+
+// POST /venues/:slug/quotes — create a new quote version for an enquiry.
+const createQuote = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const { enquiry, lineItems, gstPercent, discount } = req.body || {};
+    if (!enquiry) return res.status(400).json({ message: "enquiry is required" });
+    const enquiryDoc = await VenueEnquiry.findOne({ _id: enquiry, venueId: venue._id }).select("_id").lean();
+    if (!enquiryDoc) return res.status(404).json({ message: "Enquiry not found for this venue" });
+
+    const pct = gstPercent !== undefined ? Number(gstPercent) : 18;
+    const disc = Number(discount) || 0;
+    const totals = computeTotals(lineItems, pct, disc);
+
+    // Next version + supersede earlier non-final versions.
+    const latest = await VenueQuote.findOne({ enquiry }).sort({ version: -1 }).select("version").lean();
+    const version = (latest ? latest.version : 0) + 1;
+    await VenueQuote.updateMany(
+      { enquiry, status: { $in: ["draft", "sent"] } },
+      { status: "superseded" }
+    );
+
+    const quote = await VenueQuote.create({
+      venue: venue._id,
+      enquiry,
+      version,
+      lineItems: Array.isArray(lineItems) ? lineItems : [],
+      gstPercent: pct,
+      discount: disc,
+      totals,
+      status: "draft",
+    });
+    return res.status(201).json({ quote });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+// GET /venues/:slug/quotes[?enquiry=]
+const listQuotes = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const filter = { venue: venue._id };
+    if (req.query.enquiry) filter.enquiry = req.query.enquiry;
+    const quotes = await VenueQuote.find(filter).sort({ enquiry: 1, version: -1 }).lean();
+    return res.status(200).json({ quotes, total: quotes.length });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+const getQuote = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const quote = await VenueQuote.findOne({ _id: req.params.quoteId, venue: venue._id }).lean();
+    if (!quote) return res.status(404).json({ message: "Quote not found" });
+    return res.status(200).json({ quote });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+// PATCH /venues/:slug/quotes/:quoteId — edit line items/status. Recomputes totals.
+// When status transitions to "accepted", create/update the draft booking.
+const updateQuote = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const quote = await VenueQuote.findOne({ _id: req.params.quoteId, venue: venue._id });
+    if (!quote) return res.status(404).json({ message: "Quote not found" });
+    const { lineItems, gstPercent, discount, status } = req.body || {};
+    if (lineItems !== undefined) quote.lineItems = Array.isArray(lineItems) ? lineItems : [];
+    if (gstPercent !== undefined) quote.gstPercent = Number(gstPercent);
+    if (discount !== undefined) quote.discount = Number(discount) || 0;
+    if (lineItems !== undefined || gstPercent !== undefined || discount !== undefined) {
+      quote.totals = computeTotals(quote.lineItems, quote.gstPercent, quote.discount);
+    }
+    if (status !== undefined) quote.status = status;
+    await quote.save();
+
+    let booking = null;
+    if (status === "accepted") {
+      const enquiry = await VenueEnquiry.findOne({ _id: quote.enquiry, venueId: venue._id });
+      if (enquiry) {
+        booking = await createDraftBookingForEnquiry(venue._id, enquiry, req.venueOwner.venueOwnerId);
+        booking.totalValue = quote.totals.grandTotal;
+        await booking.save();
+      }
+    }
+    return res.status(200).json({ quote, booking });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+// GET /venues/:slug/quotes/:quoteId/pdf
+const quotePdf = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res, "name address formattedAddress contact phone email");
+    if (!venue) return;
+    const quote = await VenueQuote.findOne({ _id: req.params.quoteId, venue: venue._id }).lean();
+    if (!quote) return res.status(404).json({ message: "Quote not found" });
+    const enquiry = await VenueEnquiry.findById(quote.enquiry).select("coupleName name couplePhone").lean();
+    streamQuotePdf(res, { venue, enquiry, quote });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+module.exports = { createQuote, listQuotes, getQuote, updateQuote, quotePdf };

--- a/controllers/venueQuote.js
+++ b/controllers/venueQuote.js
@@ -28,6 +28,8 @@ const createQuote = async (req, res) => {
 
     const pct = gstPercent !== undefined ? Number(gstPercent) : 18;
     const disc = Number(discount) || 0;
+    if (!Number.isFinite(pct) || pct < 0 || pct > 100) return res.status(400).json({ message: "gstPercent must be 0..100" });
+    if (!Number.isFinite(disc) || disc < 0) return res.status(400).json({ message: "discount must be >= 0" });
     const totals = computeTotals(lineItems, pct, disc);
 
     // Next version + supersede earlier non-final versions.
@@ -83,6 +85,21 @@ const updateQuote = async (req, res) => {
     const quote = await VenueQuote.findOne({ _id: req.params.quoteId, venue: venue._id });
     if (!quote) return res.status(404).json({ message: "Quote not found" });
     const { lineItems, gstPercent, discount, status } = req.body || {};
+    const QUOTE_STATUS = ["draft", "sent", "accepted", "superseded"];
+    if (status !== undefined && !QUOTE_STATUS.includes(status)) {
+      return res.status(400).json({ message: `status must be one of ${QUOTE_STATUS.join(", ")}` });
+    }
+    if (gstPercent !== undefined && (!Number.isFinite(Number(gstPercent)) || Number(gstPercent) < 0 || Number(gstPercent) > 100)) {
+      return res.status(400).json({ message: "gstPercent must be 0..100" });
+    }
+    if (discount !== undefined && (!Number.isFinite(Number(discount)) || Number(discount) < 0)) {
+      return res.status(400).json({ message: "discount must be >= 0" });
+    }
+    // A quote with no line items cannot be accepted.
+    const effItems = lineItems !== undefined ? (Array.isArray(lineItems) ? lineItems : []) : quote.lineItems;
+    if (status === "accepted" && (!effItems || effItems.length === 0)) {
+      return res.status(400).json({ message: "cannot accept a quote with no line items" });
+    }
     if (lineItems !== undefined) quote.lineItems = Array.isArray(lineItems) ? lineItems : [];
     if (gstPercent !== undefined) quote.gstPercent = Number(gstPercent);
     if (discount !== undefined) quote.discount = Number(discount) || 0;

--- a/controllers/venueSheetsSync.js
+++ b/controllers/venueSheetsSync.js
@@ -12,6 +12,7 @@ const {
   listTabs,
   readSheetValues,
 } = require("../utils/googleSheets");
+const { buildRowMap, stageColumnLetter } = require("../utils/venueSheetWriteBack");
 
 // Resolve venue from slug and confirm the authenticated owner owns it.
 async function resolveOwnedVenue(req, res) {
@@ -200,9 +201,14 @@ async function syncIntegration(integrationDoc) {
     activityDescription: "Synced from Google Sheet",
   });
 
+  // Capture per-row mapping for stage write-back (keyed by couplePhone digits)
+  // and the A1 column letter of the mapped stage column.
+  const rowMap = buildRowMap(header, rows, columnMap.couplePhone);
+  const stageColumn = stageColumnLetter(header, columnMap);
+
   await VenueSheetIntegration.updateOne(
     { _id: integration._id },
-    { lastSyncAt: new Date(), status: "connected" }
+    { lastSyncAt: new Date(), status: "connected", rowMap, stageColumn }
   );
   return result;
 }

--- a/controllers/venueSheetsSync.js
+++ b/controllers/venueSheetsSync.js
@@ -1,0 +1,262 @@
+const jwt = require("jsonwebtoken");
+const Venue = require("../models/Venue");
+const VenueSheetIntegration = require("../models/VenueSheetIntegration");
+const { importLeadRows } = require("./venueEnquiry");
+const {
+  sheetsConfigured,
+  generateAuthUrl,
+  exchangeCode,
+  encryptToken,
+  decryptToken,
+  listSpreadsheets,
+  listTabs,
+  readSheetValues,
+} = require("../utils/googleSheets");
+
+// Resolve venue from slug and confirm the authenticated owner owns it.
+async function resolveOwnedVenue(req, res) {
+  const { slug } = req.params;
+  const venue = await Venue.findOne({ slug }).select("_id").lean();
+  if (!venue) {
+    res.status(404).json({ message: "Venue not found" });
+    return null;
+  }
+  if (String(venue._id) !== String(req.venueOwner.venueId)) {
+    res.status(403).json({ message: "Forbidden" });
+    return null;
+  }
+  return venue;
+}
+
+// Strip the encrypted token before returning an integration to the client.
+function publicIntegration(doc) {
+  if (!doc) return null;
+  const { refreshToken, ...rest } = doc;
+  return { ...rest, connected: Boolean(refreshToken) };
+}
+
+// GET /venues/:slug/integrations/google-sheets — current integration status.
+const getIntegration = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const integration = await VenueSheetIntegration.findOne({ venue: venue._id }).lean();
+    return res.status(200).json({ integration: publicIntegration(integration), configured: sheetsConfigured() });
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+};
+
+// GET /venues/:slug/integrations/google-sheets/connect — return the consent URL.
+const connect = async (req, res) => {
+  try {
+    if (!sheetsConfigured()) {
+      return res.status(503).json({ message: "Google Sheets integration is not configured" });
+    }
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    // Signed, short-lived state carries the venue identity through Google's redirect.
+    const state = jwt.sign(
+      { venueId: String(venue._id), slug: req.params.slug, t: "sheets_oauth" },
+      process.env.JWT_SECRET,
+      { expiresIn: "15m" }
+    );
+    return res.status(200).json({ authUrl: generateAuthUrl(state) });
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+};
+
+// GET /venues/:slug/integrations/google-sheets/callback — Google redirects here.
+// NOT behind venueOwnerAuth (the browser redirect from Google carries no Bearer token);
+// authorized instead by verifying the signed `state` we issued in /connect.
+const callback = async (req, res) => {
+  try {
+    if (!sheetsConfigured()) {
+      return res.status(503).json({ message: "Google Sheets integration is not configured" });
+    }
+    const { code, state } = req.query;
+    if (!code || !state) return res.status(400).json({ message: "Missing code or state" });
+
+    let payload;
+    try {
+      payload = jwt.verify(state, process.env.JWT_SECRET);
+    } catch {
+      return res.status(400).json({ message: "Invalid or expired state" });
+    }
+    if (payload.t !== "sheets_oauth" || !payload.venueId) {
+      return res.status(400).json({ message: "Invalid state" });
+    }
+
+    const tokens = await exchangeCode(code);
+    if (!tokens.refresh_token) {
+      // Google only returns a refresh token on first consent; prompt=consent should force it.
+      return res.status(400).json({ message: "No refresh token returned; please reconnect." });
+    }
+
+    await VenueSheetIntegration.findOneAndUpdate(
+      { venue: payload.venueId },
+      { venue: payload.venueId, refreshToken: encryptToken(tokens.refresh_token), status: "connected" },
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    );
+
+    const appUrl = process.env.VENUE_OWNER_APP_URL;
+    if (appUrl) return res.redirect(`${appUrl}/dashboard/integrations?sheets=connected`);
+    return res.status(200).send("Google Sheets connected. You can close this window and return to the dashboard.");
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+};
+
+// POST /venues/:slug/integrations/google-sheets/disconnect
+const disconnect = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    await VenueSheetIntegration.findOneAndUpdate(
+      { venue: venue._id },
+      { refreshToken: "", status: "disconnected" }
+    );
+    return res.status(200).json({ success: true });
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+};
+
+// GET /venues/:slug/integrations/google-sheets/sheets[?spreadsheetId=]
+//   no spreadsheetId → list spreadsheets;  with spreadsheetId → list that file's tabs.
+const listSheets = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const integration = await VenueSheetIntegration.findOne({ venue: venue._id }).lean();
+    if (!integration || !integration.refreshToken) {
+      return res.status(400).json({ message: "Google Sheets is not connected" });
+    }
+    const refreshToken = decryptToken(integration.refreshToken);
+    const { spreadsheetId, sheetName } = req.query;
+    if (spreadsheetId && sheetName) {
+      // Header row of the chosen tab — the columns to map against.
+      const { header } = await readSheetValues(refreshToken, spreadsheetId, sheetName);
+      return res.status(200).json({ columns: header });
+    }
+    if (spreadsheetId) {
+      const tabs = await listTabs(refreshToken, spreadsheetId);
+      return res.status(200).json({ tabs });
+    }
+    const spreadsheets = await listSpreadsheets(refreshToken);
+    return res.status(200).json({ spreadsheets });
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+};
+
+// POST /venues/:slug/integrations/google-sheets/mapping
+const saveMapping = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const { spreadsheetId, sheetName, columnMap } = req.body || {};
+    const integration = await VenueSheetIntegration.findOneAndUpdate(
+      { venue: venue._id },
+      {
+        spreadsheetId: spreadsheetId || "",
+        sheetName: sheetName || "",
+        columnMap: columnMap && typeof columnMap === "object" ? columnMap : {},
+      },
+      { new: true }
+    ).lean();
+    if (!integration) return res.status(400).json({ message: "Google Sheets is not connected" });
+    return res.status(200).json({ integration: publicIntegration(integration) });
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+};
+
+// Core one-way sync (sheet → leads). Reused by manual "Sync now" and the scheduler.
+// Reuses importLeadRows (the 2.1 dedup core).
+async function syncIntegration(integrationDoc) {
+  const integration = integrationDoc.toObject ? integrationDoc.toObject() : integrationDoc;
+  if (!integration || !integration.refreshToken) throw new Error("Google Sheets is not connected");
+  if (!integration.spreadsheetId || !integration.sheetName) {
+    throw new Error("Spreadsheet and tab are not configured");
+  }
+
+  const refreshToken = decryptToken(integration.refreshToken);
+  const { header, rows } = await readSheetValues(refreshToken, integration.spreadsheetId, integration.sheetName);
+
+  // Map sheet rows → lead-field rows using the saved columnMap { leadField: columnHeader }.
+  const columnMap = integration.columnMap || {};
+  const mappedRows = rows.map((rowArr) => {
+    const mapped = {};
+    for (const [field, colName] of Object.entries(columnMap)) {
+      const idx = header.indexOf(colName);
+      mapped[field] = idx >= 0 && rowArr[idx] != null ? String(rowArr[idx]) : "";
+    }
+    return mapped;
+  });
+
+  const result = await importLeadRows(integration.venue, mappedRows, {
+    activityDescription: "Synced from Google Sheet",
+  });
+
+  await VenueSheetIntegration.updateOne(
+    { _id: integration._id },
+    { lastSyncAt: new Date(), status: "connected" }
+  );
+  return result;
+}
+
+// POST /venues/:slug/integrations/google-sheets/sync — manual "Sync now".
+const syncNow = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const integration = await VenueSheetIntegration.findOne({ venue: venue._id });
+    if (!integration || !integration.refreshToken) {
+      return res.status(400).json({ message: "Google Sheets is not connected" });
+    }
+    const result = await syncIntegration(integration);
+    return res.status(200).json(result);
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+};
+
+// Scheduled (every 15 min) — sync every connected, configured integration.
+// No-op when creds aren't configured. One failing venue never blocks the others.
+async function runScheduledSheetSync() {
+  try {
+    if (!sheetsConfigured()) return;
+    const integrations = await VenueSheetIntegration.find({
+      refreshToken: { $ne: "" },
+      spreadsheetId: { $ne: "" },
+      sheetName: { $ne: "" },
+    });
+    for (const integration of integrations) {
+      try {
+        await syncIntegration(integration);
+      } catch (err) {
+        console.error("Scheduled Google Sheets sync failed for venue", String(integration.venue), err.message);
+        await VenueSheetIntegration.updateOne({ _id: integration._id }, { status: "error" }).catch(() => {});
+      }
+    }
+  } catch (err) {
+    console.error("runScheduledSheetSync error:", err.message);
+  }
+}
+
+// ── DEFERRED seam: writeBackLeadToSheet(integration, enquiry) — two-way sync
+//    (lead stage → sheet row). Intentionally not implemented in the MVP.
+
+module.exports = {
+  getIntegration,
+  connect,
+  callback,
+  disconnect,
+  listSheets,
+  saveMapping,
+  syncNow,
+  syncIntegration,
+  runScheduledSheetSync,
+};

--- a/controllers/venueTeam.js
+++ b/controllers/venueTeam.js
@@ -1,0 +1,151 @@
+const Venue = require("../models/Venue");
+const VenueTeamMember = require("../models/VenueTeamMember");
+const VenueTeamActivity = require("../models/VenueTeamActivity");
+const { VENUE_ROLES, roleHasCapability } = require("../utils/venueRoles");
+
+async function resolveOwnedVenue(req, res) {
+  const { slug } = req.params;
+  const venue = await Venue.findOne({ slug }).select("_id").lean();
+  if (!venue) {
+    res.status(404).json({ message: "Venue not found" });
+    return null;
+  }
+  if (String(venue._id) !== String(req.venueOwner.venueId)) {
+    res.status(403).json({ message: "Forbidden" });
+    return null;
+  }
+  return venue;
+}
+
+function actorId(req) {
+  return String(req.venueOwner.memberId || req.venueOwner.venueOwnerId || "");
+}
+
+// Best-effort activity logging — never let a logging failure break the action.
+async function logActivity(venueId, { actorId: aId = "", actorName = "", action, targetMemberId = "", detail = "" }) {
+  try {
+    await VenueTeamActivity.create({ venueId, actorId: aId, actorName, action, targetMemberId, detail });
+  } catch (err) {
+    console.error("Failed to log team activity:", err.message);
+  }
+}
+
+// GET /venues/:slug/team — list members (team capability).
+const listMembers = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const members = await VenueTeamMember.find({ venueId: venue._id }).sort({ createdAt: -1 }).lean();
+    return res.status(200).json({ members, total: members.length });
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+};
+
+// POST /venues/:slug/team — invite a member (team capability).
+const inviteMember = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+
+    const { name, phone, email, role } = req.body || {};
+    if (!name || !phone) return res.status(400).json({ message: "Name and phone are required" });
+
+    const finalRole = VENUE_ROLES.includes(role) ? role : "sales";
+    // Only an actor with billing/owner-management (owner) can grant the owner role.
+    if (finalRole === "owner" && !roleHasCapability(req.venueOwner.role, "billing")) {
+      return res.status(403).json({ message: "Only the owner can grant the owner role" });
+    }
+
+    const existing = await VenueTeamMember.findOne({ venueId: venue._id, phone }).lean();
+    if (existing) return res.status(400).json({ message: "A member with this phone already exists" });
+
+    const member = await VenueTeamMember.create({
+      venueId: venue._id,
+      ownerId: req.venueOwner.venueOwnerId || undefined,
+      name,
+      phone,
+      email: email || "",
+      role: finalRole,
+      invitedBy: req.venueOwner.memberId || req.venueOwner.venueOwnerId || undefined,
+    });
+
+    await logActivity(venue._id, {
+      actorId: actorId(req),
+      action: "member_invited",
+      targetMemberId: String(member._id),
+      detail: `Invited ${name} as ${finalRole}`,
+    });
+
+    return res.status(201).json({ member });
+  } catch (err) {
+    if (err.code === 11000) return res.status(400).json({ message: "A member with this phone already exists" });
+    return res.status(500).json({ message: err.message });
+  }
+};
+
+// PATCH /venues/:slug/team/:memberId — update / deactivate (team capability).
+const updateMember = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+
+    const { memberId } = req.params;
+    const member = await VenueTeamMember.findOne({ _id: memberId, venueId: venue._id });
+    if (!member) return res.status(404).json({ message: "Member not found" });
+
+    // Can't deactivate / demote yourself.
+    if (String(member._id) === String(req.venueOwner.memberId)) {
+      return res.status(400).json({ message: "You cannot modify your own membership" });
+    }
+
+    const { name, email, role, isActive } = req.body || {};
+    const changes = [];
+
+    if (role !== undefined) {
+      if (!VENUE_ROLES.includes(role)) return res.status(400).json({ message: "Invalid role" });
+      // Granting or changing the owner role requires billing/owner-management.
+      if ((role === "owner" || member.role === "owner") && !roleHasCapability(req.venueOwner.role, "billing")) {
+        return res.status(403).json({ message: "Only the owner can change the owner role" });
+      }
+      if (role !== member.role) changes.push(`role ${member.role}→${role}`);
+      member.role = role;
+    }
+    if (typeof name === "string" && name.trim()) member.name = name.trim();
+    if (typeof email === "string") member.email = email;
+    if (typeof isActive === "boolean" && isActive !== member.isActive) {
+      member.isActive = isActive;
+      changes.push(isActive ? "reactivated" : "deactivated");
+    }
+
+    await member.save();
+
+    await logActivity(venue._id, {
+      actorId: actorId(req),
+      action: isActive === false ? "member_deactivated" : role !== undefined ? "role_changed" : "member_updated",
+      targetMemberId: String(member._id),
+      detail: changes.join(", ") || "updated",
+    });
+
+    return res.status(200).json({ member });
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+};
+
+// GET /venues/:slug/team/activity — recent team activity (team capability).
+const getActivity = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const activity = await VenueTeamActivity.find({ venueId: venue._id })
+      .sort({ createdAt: -1 })
+      .limit(100)
+      .lean();
+    return res.status(200).json({ activity, total: activity.length });
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+};
+
+module.exports = { listMembers, inviteMember, updateMember, getActivity, logActivity };

--- a/controllers/venueTemplate.js
+++ b/controllers/venueTemplate.js
@@ -1,0 +1,88 @@
+/**
+ * controllers/venueTemplate.js
+ *
+ * CRUD for per-venue WhatsApp message templates (venueOwnerAuth + ownership).
+ *   GET    /venues/:slug/templates
+ *   POST   /venues/:slug/templates
+ *   PATCH  /venues/:slug/templates/:templateId
+ *   DELETE /venues/:slug/templates/:templateId
+ */
+const Venue = require("../models/Venue");
+const VenueMessageTemplate = require("../models/VenueMessageTemplate");
+
+async function resolveOwnedVenue(req, res) {
+  const { slug } = req.params;
+  const venue = await Venue.findOne({ slug }).select("_id").lean();
+  if (!venue) {
+    res.status(404).json({ message: "Venue not found" });
+    return null;
+  }
+  if (String(venue._id) !== String(req.venueOwner.venueId)) {
+    res.status(403).json({ message: "Forbidden" });
+    return null;
+  }
+  return venue;
+}
+
+const listTemplates = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const templates = await VenueMessageTemplate.find({ venue: venue._id }).sort({ createdAt: -1 }).lean();
+    return res.status(200).json({ templates, total: templates.length });
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+};
+
+const createTemplate = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const { name, body } = req.body || {};
+    if (!name || !String(name).trim() || !body || !String(body).trim()) {
+      return res.status(400).json({ message: "name and body are required" });
+    }
+    const template = await VenueMessageTemplate.create({
+      venue: venue._id,
+      name: String(name).trim(),
+      body: String(body).trim(),
+      createdBy: req.venueOwner.venueOwnerId,
+    });
+    return res.status(201).json({ template });
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+};
+
+const updateTemplate = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const { templateId } = req.params;
+    const template = await VenueMessageTemplate.findOne({ _id: templateId, venue: venue._id });
+    if (!template) return res.status(404).json({ message: "Template not found" });
+    const { name, body } = req.body || {};
+    if (name !== undefined && String(name).trim()) template.name = String(name).trim();
+    if (body !== undefined && String(body).trim()) template.body = String(body).trim();
+    await template.save();
+    return res.status(200).json({ template });
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+};
+
+const deleteTemplate = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const { templateId } = req.params;
+    const deleted = await VenueMessageTemplate.findOneAndDelete({ _id: templateId, venue: venue._id });
+    if (!deleted) return res.status(404).json({ message: "Template not found" });
+    return res.status(200).json({ success: true });
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+};
+
+module.exports = { listTemplates, createTemplate, updateTemplate, deleteTemplate };

--- a/controllers/venueView.js
+++ b/controllers/venueView.js
@@ -1,45 +1,56 @@
+const crypto = require("crypto");
 const Venue = require("../models/Venue");
 const VenueView = require("../models/VenueView");
 
-// Fire-and-forget view tracking. Always returns 200 — never blocks the page.
+// Opaque per-session/day fingerprint — sha256(ip+ua+slug+day). No raw PII stored.
+function sessionHashFor(req, slug) {
+  const xff = req.headers["x-forwarded-for"];
+  const ip = (xff && String(xff).split(",")[0].trim()) || req.ip || (req.socket && req.socket.remoteAddress) || "";
+  const ua = req.headers["user-agent"] || "";
+  const day = new Date().toISOString().slice(0, 10);
+  return crypto.createHash("sha256").update(`${ip}|${ua}|${slug}|${day}`).digest("hex");
+}
+
+// Coarse referrer class only (no URLs/paths retained).
+function classifyReferer(ref) {
+  if (!ref) return "direct";
+  try {
+    const h = new URL(ref).hostname.toLowerCase();
+    if (/(google|bing|duckduckgo|yahoo)\./.test(h)) return "search";
+    if (/(instagram|facebook|fb\.|t\.co|twitter|x\.com|pinterest|whatsapp|linkedin)/.test(h)) return "social";
+    if (/wedsy\.in$/.test(h) || h === "wedsy.in") return "internal";
+    return "referral";
+  } catch {
+    return "direct";
+  }
+}
+
+// POST /venues/:slug/view — PUBLIC fire-and-forget view beacon. Always 200,
+// never blocks the page. Deduped per session per day (one counted view).
 const trackView = async (req, res) => {
+  res.status(200).json({ success: true }); // respond immediately — never make the page wait
   try {
     const { slug } = req.params;
-    const userId = req.auth && req.auth.user_id;
-
-    if (!userId || !slug) {
-      return res.status(200).json({ success: true });
-    }
-
-    const venue = await Venue.findOne({ slug }).select("_id");
-    if (!venue) {
-      return res.status(200).json({ success: true });
-    }
-
-    const now = new Date();
-    const thirtyMinutesAgo = new Date(now.getTime() - 30 * 60 * 1000);
-
-    const recent = await VenueView.findOne({
-      userId,
-      venueId: venue._id,
-      viewedAt: { $gte: thirtyMinutesAgo },
-    }).select("_id");
-
-    if (recent) {
-      return res.status(200).json({ success: true });
-    }
-
+    if (!slug) return;
+    const venue = await Venue.findOne({ slug }).select("_id").lean();
+    if (!venue) return;
+    const sessionHash = sessionHashFor(req, slug);
+    const source = classifyReferer(req.headers.referer || req.headers.referrer || (req.body && req.body.ref));
+    const startOfDay = new Date();
+    startOfDay.setHours(0, 0, 0, 0);
+    const dup = await VenueView.findOne({ venueId: venue._id, sessionHash, viewedAt: { $gte: startOfDay } }).select("_id").lean();
+    if (dup) return;
     await VenueView.create({
-      userId,
       venueId: venue._id,
       venueSlug: slug,
-      viewedAt: now,
+      sessionHash,
+      source,
+      userId: (req.auth && req.auth.user_id) || undefined,
+      viewedAt: new Date(),
     });
-
-    return res.status(200).json({ success: true });
-  } catch (err) {
-    return res.status(200).json({ success: true });
+  } catch (_) {
+    /* fire-and-forget — swallow */
   }
 };
 
-module.exports = { trackView };
+module.exports = { trackView, sessionHashFor, classifyReferer };

--- a/middlewares/adminOrVenueOwnerAuth.js
+++ b/middlewares/adminOrVenueOwnerAuth.js
@@ -18,8 +18,10 @@ function adminOrVenueOwnerAuth(req, res, next) {
       req.admin = payload;
       return next();
     }
-    // Keep the venue_owner path identical to venueOwnerAuth (same required claims).
-    if (payload && payload.type === "venue_owner" && payload.venueOwnerId && payload.venueId) {
+    // Venue_owner path mirrors venueOwnerAuth: accept BOTH owner tokens
+    // (venueOwnerId) and team-member tokens (memberId) so members with the
+    // relevant capability pass the downstream requireCapabilityOrAdmin gate.
+    if (payload && payload.type === "venue_owner" && payload.venueId && (payload.venueOwnerId || payload.memberId)) {
       req.venueOwner = payload;
       return next();
     }

--- a/middlewares/adminOrVenueOwnerAuth.js
+++ b/middlewares/adminOrVenueOwnerAuth.js
@@ -1,4 +1,5 @@
 const jwt = require("jsonwebtoken");
+const { memberStillValid } = require("./venueOwnerAuth");
 
 // Accepts EITHER an admin token (payload.isAdmin === true, matching CheckAdminLogin)
 // OR a venue_owner token (type "venue_owner"). Mirrors venueOwnerAuth's style and secret.
@@ -10,7 +11,7 @@ function adminOrVenueOwnerAuth(req, res, next) {
   if (!token || token === "null") {
     return res.status(401).json({ message: "No Auth Token" });
   }
-  jwt.verify(token, process.env.JWT_SECRET, function (err, payload) {
+  jwt.verify(token, process.env.JWT_SECRET, async function (err, payload) {
     if (err) {
       return res.status(401).json({ message: "Invalid token", error: err.message });
     }
@@ -19,9 +20,16 @@ function adminOrVenueOwnerAuth(req, res, next) {
       return next();
     }
     // Venue_owner path mirrors venueOwnerAuth: accept BOTH owner tokens
-    // (venueOwnerId) and team-member tokens (memberId) so members with the
-    // relevant capability pass the downstream requireCapabilityOrAdmin gate.
+    // (venueOwnerId) and team-member tokens (memberId), but reject a deactivated
+    // member's live JWT (per-request isActive check).
     if (payload && payload.type === "venue_owner" && payload.venueId && (payload.venueOwnerId || payload.memberId)) {
+      try {
+        if (!(await memberStillValid(payload))) {
+          return res.status(401).json({ message: "Member account is inactive" });
+        }
+      } catch (e) {
+        return res.status(500).json({ message: e.message });
+      }
       req.venueOwner = payload;
       return next();
     }

--- a/middlewares/venueOwnerAuth.js
+++ b/middlewares/venueOwnerAuth.js
@@ -1,4 +1,15 @@
 const jwt = require("jsonwebtoken");
+let VenueTeamMember;
+try { VenueTeamMember = require("../models/VenueTeamMember"); } catch (_) {}
+
+// Per-request guard: a team-member token is only valid while the member is still
+// active and bound to the same venue. Rejects a deactivated member's live JWT.
+async function memberStillValid(payload) {
+  if (!payload.memberId) return true; // owner token — no membership to check
+  if (!VenueTeamMember) return true; // model absent on pre-team branches
+  const m = await VenueTeamMember.findById(payload.memberId).select("isActive venueId").lean();
+  return Boolean(m && m.isActive && String(m.venueId) === String(payload.venueId));
+}
 
 function venueOwnerAuth(req, res, next) {
   if (!req.headers.authorization) {
@@ -8,7 +19,7 @@ function venueOwnerAuth(req, res, next) {
   if (!token || token === "null") {
     return res.status(401).json({ message: "No Auth Token" });
   }
-  jwt.verify(token, process.env.JWT_SECRET, function (err, payload) {
+  jwt.verify(token, process.env.JWT_SECRET, async function (err, payload) {
     if (err) {
       return res.status(401).json({ message: "Invalid token", error: err.message });
     }
@@ -23,9 +34,16 @@ function venueOwnerAuth(req, res, next) {
     ) {
       return res.status(401).json({ message: "Invalid token" });
     }
+    try {
+      if (!(await memberStillValid(payload))) {
+        return res.status(401).json({ message: "Member account is inactive" });
+      }
+    } catch (e) {
+      return res.status(500).json({ message: e.message });
+    }
     req.venueOwner = payload;
     next();
   });
 }
 
-module.exports = { venueOwnerAuth };
+module.exports = { venueOwnerAuth, memberStillValid };

--- a/middlewares/venueOwnerAuth.js
+++ b/middlewares/venueOwnerAuth.js
@@ -12,7 +12,15 @@ function venueOwnerAuth(req, res, next) {
     if (err) {
       return res.status(401).json({ message: "Invalid token", error: err.message });
     }
-    if (!payload || payload.type !== "venue_owner" || !payload.venueOwnerId || !payload.venueId) {
+    // Gate by venueId, accepting BOTH owner tokens (venueOwnerId) and team-member
+    // tokens (memberId). req.venueOwner surfaces venueId + role + memberId/venueOwnerId
+    // for the downstream role gate. Owner = a member with role "owner".
+    if (
+      !payload ||
+      payload.type !== "venue_owner" ||
+      !payload.venueId ||
+      (!payload.venueOwnerId && !payload.memberId)
+    ) {
       return res.status(401).json({ message: "Invalid token" });
     }
     req.venueOwner = payload;

--- a/middlewares/venueRole.js
+++ b/middlewares/venueRole.js
@@ -1,0 +1,17 @@
+const { roleHasCapability } = require("../utils/venueRoles");
+
+// Route-level role gate, layered AFTER venueOwnerAuth (which sets req.venueOwner with
+// role + memberId/venueOwnerId). Returns 401 if unauthenticated, 403 if the member's
+// role lacks the capability. Owner has every capability.
+function requireCapability(capability) {
+  return (req, res, next) => {
+    if (!req.venueOwner) return res.status(401).json({ message: "Not authenticated" });
+    const role = req.venueOwner.role || "owner";
+    if (!roleHasCapability(role, capability)) {
+      return res.status(403).json({ message: `Your role (${role}) cannot perform this action` });
+    }
+    next();
+  };
+}
+
+module.exports = { requireCapability };

--- a/middlewares/venueRole.js
+++ b/middlewares/venueRole.js
@@ -14,4 +14,20 @@ function requireCapability(capability) {
   };
 }
 
-module.exports = { requireCapability };
+// Admin-aware variant for routes behind adminOrVenueOwnerAuth: a platform admin token
+// (req.admin set by that middleware) BYPASSES the venue-role check entirely; venue
+// tokens are role-checked exactly like requireCapability. Cleanly separable because
+// adminOrVenueOwnerAuth sets req.admin XOR req.venueOwner.
+function requireCapabilityOrAdmin(capability) {
+  return (req, res, next) => {
+    if (req.admin) return next(); // platform admin keeps full access
+    if (!req.venueOwner) return res.status(401).json({ message: "Not authenticated" });
+    const role = req.venueOwner.role || "owner";
+    if (!roleHasCapability(role, capability)) {
+      return res.status(403).json({ message: `Your role (${role}) cannot perform this action` });
+    }
+    next();
+  };
+}
+
+module.exports = { requireCapability, requireCapabilityOrAdmin };

--- a/models/Venue.js
+++ b/models/Venue.js
@@ -124,6 +124,15 @@ const VenueSchema = new mongoose.Schema({
     refund: { type: String, default: "" },
     otherRestrictions: { type: String, default: "" },
   },
+  // Structured policy clauses (Phase: owner-feedback). Three ordered lists of
+  // numbered clause strings. Legacy `policies` (above) is NEVER dropped — it is
+  // migrated into policyDoc on read (see controllers/venue.js withPolicyDoc) so
+  // nothing is lost. New field name (couldn't overload the `policies` object).
+  policyDoc: {
+    policies: [{ type: String }],
+    terms: [{ type: String }],
+    refund: [{ type: String }],
+  },
   contact: {
     primaryName: { type: String, default: "" },
     primaryPhone: { type: String, default: "" },

--- a/models/Venue.js
+++ b/models/Venue.js
@@ -149,6 +149,10 @@ const VenueSchema = new mongoose.Schema({
   featured: { type: Boolean, default: false },
   status: { type: String, enum: ["draft", "published", "pending_outreach", "outreach_sent", "verified", "rejected"], default: "draft" },
   vendorId: { type: mongoose.Schema.Types.ObjectId, ref: "Vendor" },
+  // Phase 3 (3.3) invoicing profile — venue-owned, editable from listing/settings.
+  gstin: { type: String, default: "" },
+  pan: { type: String, default: "" },
+  invoicePrefix: { type: String, default: "" },
   enquiries: [{ type: mongoose.Schema.Types.ObjectId, ref: "VenueEnquiry" }],
   nearbyAccommodation: [{
     placeId: { type: String },

--- a/models/Venue.js
+++ b/models/Venue.js
@@ -108,6 +108,7 @@ const VenueSchema = new mongoose.Schema({
     shuttleService: { type: Boolean, default: false },
     petFriendly: { type: Boolean, default: false },
     smokingAllowed: { type: Boolean, default: false },
+    evCharging: { type: Boolean, default: false },
     outsideAlcohol: { type: String, enum: ["yes", "no", "extra_charge"], default: "no" },
   },
   photos: {

--- a/models/VenueBooking.js
+++ b/models/VenueBooking.js
@@ -1,0 +1,42 @@
+const mongoose = require("mongoose");
+
+// Phase 3 (3.1) — a confirmed booking, created (as a draft) when a lead moves to
+// "booked". One booking per enquiry (idempotent via the unique sparse index).
+const VenueBookingSchema = new mongoose.Schema(
+  {
+    venue: { type: mongoose.Schema.Types.ObjectId, ref: "Venue", required: true },
+    enquiry: { type: mongoose.Schema.Types.ObjectId, ref: "VenueEnquiry" },
+    coupleName: { type: String, default: "" },
+    couplePhone: { type: String, default: "" },
+    days: [
+      {
+        date: { type: Date },
+        eventType: { type: String, default: "" },
+        guestCount: { type: Number, default: 0 },
+        spaces: [{ type: String }],
+      },
+    ],
+    totalValue: { type: Number, default: 0 },
+    paymentSchedule: [
+      {
+        label: { type: String, default: "" },
+        dueDate: { type: Date },
+        amount: { type: Number, default: 0 },
+      },
+    ],
+    specialRequirements: { type: String, default: "" },
+    status: {
+      type: String,
+      enum: ["confirmed", "in_progress", "completed", "cancelled"],
+      default: "confirmed",
+    },
+    createdBy: { type: mongoose.Schema.Types.ObjectId, ref: "VenueOwner" },
+  },
+  { timestamps: true }
+);
+
+VenueBookingSchema.index({ venue: 1, createdAt: -1 });
+// One booking per enquiry (sparse: bookings without an enquiry are allowed).
+VenueBookingSchema.index({ enquiry: 1 }, { unique: true, sparse: true });
+
+module.exports = mongoose.models.VenueBooking || mongoose.model("VenueBooking", VenueBookingSchema);

--- a/models/VenueCounter.js
+++ b/models/VenueCounter.js
@@ -1,0 +1,27 @@
+const mongoose = require("mongoose");
+
+/**
+ * VenueCounter — atomic per-venue sequence counters (e.g. invoice numbers).
+ * Use findOneAndUpdate($inc) with upsert to allocate a sequence value with no
+ * read-modify-write race under concurrency.
+ *   key: `${venueId}:invoice`   seq: monotonically increasing
+ */
+const VenueCounterSchema = new mongoose.Schema(
+  {
+    key: { type: String, required: true, unique: true },
+    seq: { type: Number, default: 0 },
+  },
+  { timestamps: true }
+);
+
+/** Atomically increment and return the next sequence value for a key. */
+VenueCounterSchema.statics.next = async function next(key) {
+  const doc = await this.findOneAndUpdate(
+    { key },
+    { $inc: { seq: 1 } },
+    { new: true, upsert: true, setDefaultsOnInsert: true }
+  );
+  return doc.seq;
+};
+
+module.exports = mongoose.models.VenueCounter || mongoose.model("VenueCounter", VenueCounterSchema);

--- a/models/VenueEnquiry.js
+++ b/models/VenueEnquiry.js
@@ -34,7 +34,13 @@ const VenueEnquirySchema = new mongoose.Schema(
       default: "new",
     },
     estimatedValue: { type: Number, default: 0 },
-    lostReason: { type: String, default: "" },
+    // Phase 3 (3.x): structured lost reason. "" allowed (legacy/none) so the
+    // pre-existing free-text String data never fails validation on save.
+    lostReason: {
+      type: String,
+      enum: ["", "too_expensive", "date_unavailable", "chose_competitor", "no_response", "other"],
+      default: "",
+    },
     followUpDate: { type: Date },
     assignedTo: { type: String, default: "" },
     notes: [{ text: String, addedAt: { type: Date, default: Date.now } }],

--- a/models/VenueInvoice.js
+++ b/models/VenueInvoice.js
@@ -1,0 +1,52 @@
+const mongoose = require("mongoose");
+
+// Phase 3 (3.3) — a GST invoice generated from a booking. invoiceNumber is a
+// per-venue auto-incrementing string (prefix + zero-padded seq) assigned at
+// creation and immutable thereafter.
+const VenueInvoiceSchema = new mongoose.Schema(
+  {
+    venue: { type: mongoose.Schema.Types.ObjectId, ref: "Venue", required: true },
+    booking: { type: mongoose.Schema.Types.ObjectId, ref: "VenueBooking", required: true },
+    invoiceNumber: { type: String, required: true },
+    seq: { type: Number, required: true }, // per-venue sequence backing invoiceNumber
+    kind: { type: String, enum: ["advance", "final"], default: "advance" },
+    lineItems: [
+      {
+        label: { type: String, default: "" },
+        category: { type: String, default: "other" },
+        qty: { type: Number, default: 1 },
+        unitPrice: { type: Number, default: 0 },
+        perDay: { type: Boolean, default: false },
+        day: { type: Number, default: null },
+      },
+    ],
+    gstPercent: { type: Number, default: 18 },
+    discount: { type: Number, default: 0 },
+    totals: {
+      subtotal: { type: Number, default: 0 },
+      gst: { type: Number, default: 0 },
+      grandTotal: { type: Number, default: 0 },
+    },
+    status: {
+      type: String,
+      enum: ["unpaid", "partially_paid", "paid"],
+      default: "unpaid",
+    },
+    payments: [
+      {
+        date: { type: Date, default: Date.now },
+        amount: { type: Number, default: 0 },
+        mode: { type: String, enum: ["bank_transfer", "cash", "cheque", "upi", "card"], default: "bank_transfer" },
+        note: { type: String, default: "" },
+      },
+    ],
+  },
+  { timestamps: true }
+);
+
+VenueInvoiceSchema.index({ venue: 1, createdAt: -1 });
+VenueInvoiceSchema.index({ booking: 1 });
+// Unique invoice number per venue.
+VenueInvoiceSchema.index({ venue: 1, invoiceNumber: 1 }, { unique: true });
+
+module.exports = mongoose.models.VenueInvoice || mongoose.model("VenueInvoice", VenueInvoiceSchema);

--- a/models/VenueMessageTemplate.js
+++ b/models/VenueMessageTemplate.js
@@ -1,0 +1,21 @@
+const mongoose = require("mongoose");
+
+/**
+ * VenueMessageTemplate — reusable message bodies a venue owner can apply when
+ * sending bulk WhatsApp messages to leads. Scoped per venue.
+ */
+const VenueMessageTemplateSchema = new mongoose.Schema(
+  {
+    venue: { type: mongoose.Schema.Types.ObjectId, ref: "Venue", required: true },
+    name: { type: String, required: true, trim: true },
+    body: { type: String, required: true, trim: true },
+    createdBy: { type: mongoose.Schema.Types.ObjectId, ref: "VenueOwner" },
+  },
+  { timestamps: true }
+);
+
+VenueMessageTemplateSchema.index({ venue: 1, createdAt: -1 });
+
+module.exports =
+  mongoose.models.VenueMessageTemplate ||
+  mongoose.model("VenueMessageTemplate", VenueMessageTemplateSchema);

--- a/models/VenueOnboardingRequest.js
+++ b/models/VenueOnboardingRequest.js
@@ -1,0 +1,21 @@
+const mongoose = require("mongoose");
+
+// A "list your venue" lead from the public landing page. Venue-owned, no auth —
+// captured via the public rate-limited endpoint; the team follows up offline.
+const VenueOnboardingRequestSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true, trim: true },
+    venueName: { type: String, required: true, trim: true },
+    city: { type: String, default: "", trim: true },
+    phone: { type: String, required: true, trim: true },
+    status: { type: String, enum: ["new", "contacted", "converted", "dropped"], default: "new" },
+  },
+  { timestamps: true }
+);
+
+VenueOnboardingRequestSchema.index({ status: 1, createdAt: -1 });
+VenueOnboardingRequestSchema.index({ phone: 1 });
+
+module.exports =
+  mongoose.models.VenueOnboardingRequest ||
+  mongoose.model("VenueOnboardingRequest", VenueOnboardingRequestSchema);

--- a/models/VenueOwner.js
+++ b/models/VenueOwner.js
@@ -1,13 +1,16 @@
 const mongoose = require("mongoose");
+const { VENUE_ROLES } = require("../utils/venueRoles");
 
 const VenueOwnerSchema = new mongoose.Schema(
   {
     name: { type: String, required: true, trim: true },
     phone: { type: String, required: true, trim: true },
     email: { type: String, trim: true, default: "" },
+    // Unified venue role vocabulary (shared with VenueTeamMember). Widened additively
+    // from owner|manager|marketing — existing values and the default are unchanged.
     role: {
       type: String,
-      enum: ["owner", "manager", "marketing"],
+      enum: VENUE_ROLES,
       default: "owner",
     },
     venueId: {

--- a/models/VenueQuote.js
+++ b/models/VenueQuote.js
@@ -1,0 +1,43 @@
+const mongoose = require("mongoose");
+
+// Phase 3 (3.2) — a versioned quote for an enquiry. A new version supersedes the
+// prior one (version auto-increments per enquiry).
+const VenueQuoteSchema = new mongoose.Schema(
+  {
+    venue: { type: mongoose.Schema.Types.ObjectId, ref: "Venue", required: true },
+    enquiry: { type: mongoose.Schema.Types.ObjectId, ref: "VenueEnquiry", required: true },
+    version: { type: Number, default: 1 },
+    lineItems: [
+      {
+        label: { type: String, default: "" },
+        category: {
+          type: String,
+          enum: ["venue_hire", "catering", "decoration", "accommodation", "other"],
+          default: "other",
+        },
+        qty: { type: Number, default: 1 },
+        unitPrice: { type: Number, default: 0 },
+        perDay: { type: Boolean, default: false },
+        day: { type: Number, default: null },
+      },
+    ],
+    gstPercent: { type: Number, default: 18 },
+    discount: { type: Number, default: 0 },
+    totals: {
+      subtotal: { type: Number, default: 0 },
+      gst: { type: Number, default: 0 },
+      grandTotal: { type: Number, default: 0 },
+    },
+    status: {
+      type: String,
+      enum: ["draft", "sent", "accepted", "superseded"],
+      default: "draft",
+    },
+  },
+  { timestamps: true }
+);
+
+VenueQuoteSchema.index({ venue: 1, createdAt: -1 });
+VenueQuoteSchema.index({ enquiry: 1, version: -1 });
+
+module.exports = mongoose.models.VenueQuote || mongoose.model("VenueQuote", VenueQuoteSchema);

--- a/models/VenueSheetIntegration.js
+++ b/models/VenueSheetIntegration.js
@@ -1,0 +1,28 @@
+const mongoose = require("mongoose");
+
+// One Google Sheets integration per venue (Venue-Booking-owned). MVP is one-way
+// (sheet → leads). The refreshToken is stored ENCRYPTED (see utils/googleSheets.js).
+const VenueSheetIntegrationSchema = new mongoose.Schema(
+  {
+    venue: { type: mongoose.Schema.Types.ObjectId, ref: "Venue", required: true, unique: true },
+    refreshToken: { type: String, default: "" }, // AES-256-GCM ciphertext, never plaintext
+    spreadsheetId: { type: String, default: "" },
+    sheetName: { type: String, default: "" },
+    // columnMap: { <leadField>: <sheet column header> }
+    columnMap: { type: mongoose.Schema.Types.Mixed, default: {} },
+    lastSyncAt: { type: Date },
+    status: {
+      type: String,
+      enum: ["disconnected", "connected", "error"],
+      default: "disconnected",
+    },
+    // ── DEFERRED seam: two-way write-back (lead stage → sheet row). Not built in MVP.
+    //   When implemented, add e.g. writeBackEnabled:Boolean + a row-id column mapping
+    //   here, and a writeBackLeadToSheet() in controllers/venueSheetsSync.js.
+  },
+  { timestamps: true }
+);
+
+module.exports =
+  mongoose.models.VenueSheetIntegration ||
+  mongoose.model("VenueSheetIntegration", VenueSheetIntegrationSchema);

--- a/models/VenueSheetIntegration.js
+++ b/models/VenueSheetIntegration.js
@@ -16,9 +16,14 @@ const VenueSheetIntegrationSchema = new mongoose.Schema(
       enum: ["disconnected", "connected", "error"],
       default: "disconnected",
     },
-    // ── DEFERRED seam: two-way write-back (lead stage → sheet row). Not built in MVP.
-    //   When implemented, add e.g. writeBackEnabled:Boolean + a row-id column mapping
-    //   here, and a writeBackLeadToSheet() in controllers/venueSheetsSync.js.
+    // ── Two-way write-back support (lead stage → sheet row) ──
+    // Captured at sync time so a later stage change can locate the right cell
+    // WITHOUT mutating the shared VenueEnquiry model (chosen over adding
+    // sheetRowIndex to VenueEnquiry, which is the more invasive option).
+    //   rowMap:      { <couplePhoneDigits>: <1-based sheet row number> }
+    //   stageColumn: A1 column letter of the mapped stage column (e.g. "H")
+    rowMap: { type: mongoose.Schema.Types.Mixed, default: {} },
+    stageColumn: { type: String, default: "" },
   },
   { timestamps: true }
 );

--- a/models/VenueTeamActivity.js
+++ b/models/VenueTeamActivity.js
@@ -1,0 +1,19 @@
+const mongoose = require("mongoose");
+
+// Team activity log (who / what / when) for member management + member logins.
+const VenueTeamActivitySchema = new mongoose.Schema(
+  {
+    venueId: { type: mongoose.Schema.Types.ObjectId, ref: "Venue", required: true },
+    actorId: { type: String, default: "" }, // member or owner id (string, mixed actor types)
+    actorName: { type: String, default: "" },
+    action: { type: String, required: true }, // e.g. member_invited, member_deactivated, role_changed, member_login
+    targetMemberId: { type: String, default: "" },
+    detail: { type: String, default: "" },
+  },
+  { timestamps: true }
+);
+
+VenueTeamActivitySchema.index({ venueId: 1, createdAt: -1 });
+
+module.exports =
+  mongoose.models.VenueTeamActivity || mongoose.model("VenueTeamActivity", VenueTeamActivitySchema);

--- a/models/VenueTeamMember.js
+++ b/models/VenueTeamMember.js
@@ -1,0 +1,29 @@
+const mongoose = require("mongoose");
+const { VENUE_ROLES } = require("../utils/venueRoles");
+
+// A team member under a venue. VenueOwner remains the account anchor (claim/OTP/
+// verification lifecycle); members are additional logins scoped to the same venue.
+// NOTE: provisional shape — a shared contract pending OS sign-off on Owner-tab /
+// impersonation.
+const VenueTeamMemberSchema = new mongoose.Schema(
+  {
+    venueId: { type: mongoose.Schema.Types.ObjectId, ref: "Venue", required: true },
+    ownerId: { type: mongoose.Schema.Types.ObjectId, ref: "VenueOwner" }, // anchor account
+    name: { type: String, required: true, trim: true },
+    phone: { type: String, required: true, trim: true },
+    email: { type: String, trim: true, default: "" },
+    role: { type: String, enum: VENUE_ROLES, default: "sales" },
+    isActive: { type: Boolean, default: true },
+    // Actor (owner or member) id that invited this member; not a strict ref since the
+    // actor may be either type.
+    invitedBy: { type: mongoose.Schema.Types.ObjectId },
+    lastLoginAt: { type: Date },
+  },
+  { timestamps: true }
+);
+
+VenueTeamMemberSchema.index({ venueId: 1, phone: 1 }, { unique: true });
+VenueTeamMemberSchema.index({ phone: 1 });
+
+module.exports =
+  mongoose.models.VenueTeamMember || mongoose.model("VenueTeamMember", VenueTeamMemberSchema);

--- a/models/VenueView.js
+++ b/models/VenueView.js
@@ -1,19 +1,26 @@
 const mongoose = require("mongoose");
 const ObjectId = mongoose.Schema.Types.ObjectId;
 
+// A single venue page view. Public (anonymous) views are deduped per
+// session/day via sessionHash — a server-side hash of IP+UA+slug+day. NO PII is
+// stored (no raw IP/UA). Authenticated views additionally carry userId.
 const VenueViewSchema = new mongoose.Schema(
   {
-    userId: { type: ObjectId, ref: "User", required: true },
+    userId: { type: ObjectId, ref: "User" }, // optional — anonymous views have none
     venueId: { type: ObjectId, ref: "Venue", required: true },
     venueSlug: { type: String },
+    // sha256(ip + ua + slug + YYYY-MM-DD). Opaque, non-reversible, no PII.
+    sessionHash: { type: String },
+    // Coarse referrer class only (e.g. "direct", "search", "social", "internal").
+    source: { type: String, default: "direct" },
     viewedAt: { type: Date, default: Date.now },
   },
   { timestamps: true }
 );
 
 VenueViewSchema.index({ userId: 1 });
-VenueViewSchema.index({ venueId: 1 });
-VenueViewSchema.index({ userId: 1, venueId: 1, viewedAt: 1 });
+VenueViewSchema.index({ venueId: 1, viewedAt: 1 });
+VenueViewSchema.index({ venueId: 1, sessionHash: 1, viewedAt: 1 });
 
 module.exports =
   mongoose.models.VenueView ||

--- a/repositories/VenueRepository.js
+++ b/repositories/VenueRepository.js
@@ -4,28 +4,67 @@ const Venue = require("../models/Venue");
 // abuse) the query — runs server-side on every public browse search.
 const escapeRegex = (s) => String(s).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
-const findAll = async ({ status, limit = 100, skip = 0, zone, area, search } = {}) => {
+// Amenity keys filterable on the public browse page (mirror Venue.amenities booleans).
+const AMENITY_KEYS = new Set([
+  "swimmingPool", "generatorBackup", "parking", "helipad", "garden", "airConditioning",
+  "cctv", "wifi", "elevator", "bridalSuite", "kalyanMandap", "floatingMandap", "groomRoom",
+  "makeupRoom", "changingRooms", "prayerRoom", "fireNOC", "liquorLicense", "dayOfCoordinator",
+  "securityStaff", "housekeeping", "valetParking", "shuttleService", "petFriendly",
+  "smokingAllowed", "evCharging",
+]);
+const SORTS = {
+  newest: { createdAt: -1 },
+  price_low: { "pricing.perPlate.veg": 1 },
+  price_high: { "pricing.perPlate.veg": -1 },
+  capacity: { "accommodation.totalCapacity": -1 },
+  relevance: { dataCompleteness: -1, googleRating: -1 },
+};
+
+const findAll = async ({
+  status, limit = 100, skip = 0, zone, area, search,
+  venueType, amenities, veg, nonVeg, minCapacity, minPrice, maxPrice, sort,
+} = {}) => {
   const query = {};
   if (status) query.status = status;
   if (zone) query.zone = zone;
-  // Area search matches BOTH the structured locality field (set by Google
-  // enrichment) and the raw address — so typing "Yelahanka" finds venues
-  // whether the locality is "Yelahanka" or the word lives in the address.
+  if (venueType) query.venueType = venueType;
   if (area) {
     const re = { $regex: escapeRegex(area), $options: "i" };
     query.$or = [{ locality: re }, { address: re }];
   }
-  // Name search — case-insensitive substring match. Escaped like `area` above
-  // so user input can't inject regex. Absent/empty search → no key added.
   if (search) {
     query.name = { $regex: escapeRegex(search), $options: "i" };
   }
+  // Amenity booleans — every requested amenity must be true. Accepts array or CSV.
+  const amenityList = Array.isArray(amenities) ? amenities : typeof amenities === "string" ? amenities.split(",") : [];
+  for (const a of amenityList) {
+    const key = String(a).trim();
+    if (AMENITY_KEYS.has(key)) query[`amenities.${key}`] = true;
+  }
+  // Dietary (cateringPolicy.dietaryOptions enum strings).
+  if (veg === true || veg === "true") query["cateringPolicy.dietaryOptions"] = "Veg";
+  if (nonVeg === true || nonVeg === "true") {
+    query["cateringPolicy.dietaryOptions"] = query["cateringPolicy.dietaryOptions"]
+      ? { $all: ["Veg", "Non-veg"] } : "Non-veg";
+  }
+  // Capacity — venue has at least one space seating >= minCapacity (uses spaces[]).
+  if (minCapacity && Number(minCapacity) > 0) {
+    query["spaces.capacitySeated"] = { $gte: Number(minCapacity) };
+  }
+  // Price range on per-plate veg (the single queryable price field; tiered pricing
+  // is an array and is NOT range-filterable here — see report flag).
+  const pp = {};
+  if (minPrice && Number(minPrice) > 0) pp.$gte = Number(minPrice);
+  if (maxPrice && Number(maxPrice) > 0) pp.$lte = Number(maxPrice);
+  if (Object.keys(pp).length) query["pricing.perPlate.veg"] = pp;
+
+  const sortSpec = SORTS[sort] || SORTS.relevance;
   const [venues, total] = await Promise.all([
     Venue.find(query)
-      .select("name slug address city venueType capacity accommodation amenities catering pricing photos coverPhoto phone googlePlaceId googleRating googleReviewCount description seoKeywords dataCompleteness status zone locality googlePhotos featured")
-      .sort({ dataCompleteness: -1, googleRating: -1 })
-      .skip(skip)
-      .limit(limit)
+      .select("name slug address city venueType capacity accommodation amenities catering cateringPolicy spaces pricing photos coverPhoto phone googlePlaceId googleRating googleReviewCount description seoKeywords dataCompleteness status zone locality googlePhotos featured createdAt")
+      .sort(sortSpec)
+      .skip(Number(skip) || 0)
+      .limit(Math.min(Number(limit) || 100, 200))
       .lean(),
     Venue.countDocuments(query),
   ]);

--- a/routes/venue.js
+++ b/routes/venue.js
@@ -9,6 +9,7 @@ const { refreshReviews } = require("../controllers/venueReviews");
 const { generateLocationDescription } = require("../controllers/venueLocation");
 const { getDashboardOverview } = require("../controllers/venueDashboard");
 const { addInteraction, getInteractions } = require("../controllers/venueLeadInteraction");
+const sheets = require("../controllers/venueSheetsSync");
 const { venueOwnerAuth } = require("../middlewares/venueOwnerAuth");
 const { adminOrVenueOwnerAuth } = require("../middlewares/adminOrVenueOwnerAuth");
 const { optionalAdminAuth } = require("../middlewares/optionalAdminAuth");
@@ -34,6 +35,16 @@ router.patch("/:slug/enquiries/:enquiryId", venueOwnerAuth, updateEnquiry);
 // Per-lead communication log (4-segment paths — no shadowing of the routes above).
 router.post("/:slug/enquiries/:enquiryId/interactions", venueOwnerAuth, addInteraction);
 router.get("/:slug/enquiries/:enquiryId/interactions", venueOwnerAuth, getInteractions);
+// Google Sheets integration (MVP one-way sheet→leads). callback is public — it is
+// authorized by the signed OAuth state, since Google's redirect carries no Bearer token.
+router.get("/:slug/integrations/google-sheets", venueOwnerAuth, sheets.getIntegration);
+router.get("/:slug/integrations/google-sheets/connect", venueOwnerAuth, sheets.connect);
+router.get("/:slug/integrations/google-sheets/callback", sheets.callback);
+router.post("/:slug/integrations/google-sheets/disconnect", venueOwnerAuth, sheets.disconnect);
+router.get("/:slug/integrations/google-sheets/sheets", venueOwnerAuth, sheets.listSheets);
+router.post("/:slug/integrations/google-sheets/mapping", venueOwnerAuth, sheets.saveMapping);
+router.post("/:slug/integrations/google-sheets/sync", venueOwnerAuth, sheets.syncNow);
+
 router.post("/:slug/availability", venueOwnerAuth, saveAvailability);
 router.post("/:slug/view", CheckLogin, trackView);
 router.post("/:slug/nearby", refreshNearby);

--- a/routes/venue.js
+++ b/routes/venue.js
@@ -13,6 +13,7 @@ const { listBookings, getBooking, createBooking, updateBooking } = require("../c
 const { createQuote, listQuotes, getQuote, updateQuote, quotePdf } = require("../controllers/venueQuote");
 const { createFromBooking, listInvoices, getInvoice, addPayment, invoicePdf } = require("../controllers/venueInvoice");
 const { summary: paymentsSummary } = require("../controllers/venuePayment");
+const { getAnalytics } = require("../controllers/venueAnalytics");
 const { venueOwnerAuth } = require("../middlewares/venueOwnerAuth");
 const { adminOrVenueOwnerAuth } = require("../middlewares/adminOrVenueOwnerAuth");
 const { optionalAdminAuth } = require("../middlewares/optionalAdminAuth");
@@ -61,6 +62,9 @@ router.post("/:slug/invoices/:invoiceId/payments", venueOwnerAuth, addPayment);
 
 // ── Phase 3: payments summary (3.4) ──
 router.get("/:slug/payments/summary", venueOwnerAuth, paymentsSummary);
+
+// ── Phase 4.1: analytics ──
+router.get("/:slug/analytics", venueOwnerAuth, getAnalytics);
 
 router.post("/:slug/availability", venueOwnerAuth, saveAvailability);
 router.post("/:slug/view", CheckLogin, trackView);

--- a/routes/venue.js
+++ b/routes/venue.js
@@ -11,7 +11,7 @@ const { getDashboardOverview } = require("../controllers/venueDashboard");
 const { addInteraction, getInteractions } = require("../controllers/venueLeadInteraction");
 const { listMembers, inviteMember, updateMember, getActivity } = require("../controllers/venueTeam");
 const { venueOwnerAuth } = require("../middlewares/venueOwnerAuth");
-const { requireCapability } = require("../middlewares/venueRole");
+const { requireCapability, requireCapabilityOrAdmin } = require("../middlewares/venueRole");
 const { adminOrVenueOwnerAuth } = require("../middlewares/adminOrVenueOwnerAuth");
 const { optionalAdminAuth } = require("../middlewares/optionalAdminAuth");
 const { CheckLogin, CheckAdminLogin } = require("../middlewares/auth");
@@ -23,7 +23,9 @@ router.post("/", CheckAdminLogin, createVenue);
 // Declared before "/:slug" so the literal path is never shadowed by the slug param.
 router.get("/dashboard/overview", venueOwnerAuth, getDashboardOverview);
 router.get("/:slug", getVenueBySlug);
-router.put("/:slug", adminOrVenueOwnerAuth, updateVenue);
+// Listing edit: admins bypass; venue tokens need the "listing" capability
+// (sales blocked; marketing/listing_manager/manager/owner allowed).
+router.put("/:slug", adminOrVenueOwnerAuth, requireCapabilityOrAdmin("listing"), updateVenue);
 router.post("/:slug/enquiry", createEnquiry);
 router.post("/:slug/enquiries", createEnquiry);
 // Gated manual lead creation (venue owners only) — must precede none, distinct path.

--- a/routes/venue.js
+++ b/routes/venue.js
@@ -9,6 +9,8 @@ const { refreshReviews } = require("../controllers/venueReviews");
 const { generateLocationDescription } = require("../controllers/venueLocation");
 const { getDashboardOverview } = require("../controllers/venueDashboard");
 const { addInteraction, getInteractions } = require("../controllers/venueLeadInteraction");
+const { bulkAction, bulkWhatsApp } = require("../controllers/venueBulk");
+const { listTemplates, createTemplate, updateTemplate, deleteTemplate } = require("../controllers/venueTemplate");
 const { venueOwnerAuth } = require("../middlewares/venueOwnerAuth");
 const { adminOrVenueOwnerAuth } = require("../middlewares/adminOrVenueOwnerAuth");
 const { optionalAdminAuth } = require("../middlewares/optionalAdminAuth");
@@ -29,11 +31,20 @@ router.post("/:slug/enquiries/manual", venueOwnerAuth, createManualLead);
 // CSV/Excel bulk import + import history (venue owners only).
 router.post("/:slug/enquiries/import", venueOwnerAuth, importLeads);
 router.get("/:slug/enquiries/imports", venueOwnerAuth, getImports);
+// Bulk actions over selected leads (literal "bulk" segments — declared before
+// the /:enquiryId param routes so they are never shadowed).
+router.post("/:slug/enquiries/bulk", venueOwnerAuth, bulkAction);
+router.post("/:slug/enquiries/bulk-whatsapp", venueOwnerAuth, bulkWhatsApp);
 router.get("/:slug/enquiries", venueOwnerAuth, getVenueEnquiries);
 router.patch("/:slug/enquiries/:enquiryId", venueOwnerAuth, updateEnquiry);
 // Per-lead communication log (4-segment paths — no shadowing of the routes above).
 router.post("/:slug/enquiries/:enquiryId/interactions", venueOwnerAuth, addInteraction);
 router.get("/:slug/enquiries/:enquiryId/interactions", venueOwnerAuth, getInteractions);
+// Message templates CRUD (venue owners only).
+router.get("/:slug/templates", venueOwnerAuth, listTemplates);
+router.post("/:slug/templates", venueOwnerAuth, createTemplate);
+router.patch("/:slug/templates/:templateId", venueOwnerAuth, updateTemplate);
+router.delete("/:slug/templates/:templateId", venueOwnerAuth, deleteTemplate);
 router.post("/:slug/availability", venueOwnerAuth, saveAvailability);
 router.post("/:slug/view", CheckLogin, trackView);
 router.post("/:slug/nearby", refreshNearby);

--- a/routes/venue.js
+++ b/routes/venue.js
@@ -10,6 +10,7 @@ const { generateLocationDescription } = require("../controllers/venueLocation");
 const { getDashboardOverview } = require("../controllers/venueDashboard");
 const { addInteraction, getInteractions } = require("../controllers/venueLeadInteraction");
 const { venueOwnerAuth } = require("../middlewares/venueOwnerAuth");
+const { enquiryIpLimiter, enquiryPhoneLimiter } = require("../utils/venueEnquiryRateLimit");
 const { adminOrVenueOwnerAuth } = require("../middlewares/adminOrVenueOwnerAuth");
 const { optionalAdminAuth } = require("../middlewares/optionalAdminAuth");
 const { CheckLogin, CheckAdminLogin } = require("../middlewares/auth");
@@ -22,8 +23,10 @@ router.post("/", CheckAdminLogin, createVenue);
 router.get("/dashboard/overview", venueOwnerAuth, getDashboardOverview);
 router.get("/:slug", getVenueBySlug);
 router.put("/:slug", adminOrVenueOwnerAuth, updateVenue);
-router.post("/:slug/enquiry", createEnquiry);
-router.post("/:slug/enquiries", createEnquiry);
+// Public enquiry submission — rate-limited per IP and per phone+venue.
+// (The gated /enquiries/manual route below is intentionally NOT limited.)
+router.post("/:slug/enquiry", enquiryIpLimiter, enquiryPhoneLimiter, createEnquiry);
+router.post("/:slug/enquiries", enquiryIpLimiter, enquiryPhoneLimiter, createEnquiry);
 // Gated manual lead creation (venue owners only) — must precede none, distinct path.
 router.post("/:slug/enquiries/manual", venueOwnerAuth, createManualLead);
 // CSV/Excel bulk import + import history (venue owners only).

--- a/routes/venue.js
+++ b/routes/venue.js
@@ -89,15 +89,16 @@ router.post("/:slug/invoices/:invoiceId/payments", venueOwnerAuth, requireCapabi
 router.get("/:slug/payments/summary", venueOwnerAuth, paymentsSummary);
 router.get("/:slug/analytics", venueOwnerAuth, getAnalytics);
 
-// Google Sheets integration — venueOwnerAuth only (FLAGGED: no capability ruling).
-// callback is public — authorized by the signed OAuth state (no Bearer on Google's redirect).
-router.get("/:slug/integrations/google-sheets", venueOwnerAuth, sheets.getIntegration);
-router.get("/:slug/integrations/google-sheets/connect", venueOwnerAuth, sheets.connect);
+// Google Sheets integration — ALL routes require the "leads" capability (ruling),
+// since the sync brings leads in. callback is public — authorized by the signed
+// OAuth state (Google's redirect carries no Bearer token).
+router.get("/:slug/integrations/google-sheets", venueOwnerAuth, requireCapability("leads"), sheets.getIntegration);
+router.get("/:slug/integrations/google-sheets/connect", venueOwnerAuth, requireCapability("leads"), sheets.connect);
 router.get("/:slug/integrations/google-sheets/callback", sheets.callback);
-router.post("/:slug/integrations/google-sheets/disconnect", venueOwnerAuth, sheets.disconnect);
-router.get("/:slug/integrations/google-sheets/sheets", venueOwnerAuth, sheets.listSheets);
-router.post("/:slug/integrations/google-sheets/mapping", venueOwnerAuth, sheets.saveMapping);
-router.post("/:slug/integrations/google-sheets/sync", venueOwnerAuth, sheets.syncNow);
+router.post("/:slug/integrations/google-sheets/disconnect", venueOwnerAuth, requireCapability("leads"), sheets.disconnect);
+router.get("/:slug/integrations/google-sheets/sheets", venueOwnerAuth, requireCapability("leads"), sheets.listSheets);
+router.post("/:slug/integrations/google-sheets/mapping", venueOwnerAuth, requireCapability("leads"), sheets.saveMapping);
+router.post("/:slug/integrations/google-sheets/sync", venueOwnerAuth, requireCapability("leads"), sheets.syncNow);
 
 // ── Team members — team capability ──
 router.get("/:slug/team", venueOwnerAuth, requireCapability("team"), listMembers);

--- a/routes/venue.js
+++ b/routes/venue.js
@@ -2,7 +2,7 @@ const express = require("express");
 const router = express.Router();
 const { getVenues, getVenueBySlug, updateVenue, createVenue } = require("../controllers/venue");
 const { createEnquiry, createManualLead, getVenueEnquiries, updateEnquiry, importLeads, getImports } = require("../controllers/venueEnquiry");
-const { saveAvailability } = require("../controllers/venueAvailability");
+const { saveAvailability, availabilityCheck } = require("../controllers/venueAvailability");
 const { trackView } = require("../controllers/venueView");
 const { refreshNearby } = require("../controllers/venueNearby");
 const { refreshReviews } = require("../controllers/venueReviews");
@@ -20,7 +20,7 @@ const sheets = require("../controllers/venueSheetsSync");
 const { listMembers, inviteMember, updateMember, getActivity } = require("../controllers/venueTeam");
 const { venueOwnerAuth } = require("../middlewares/venueOwnerAuth");
 const { requireCapability, requireCapabilityOrAdmin } = require("../middlewares/venueRole");
-const { enquiryIpLimiter, enquiryPhoneLimiter } = require("../utils/venueEnquiryRateLimit");
+const { enquiryIpLimiter, enquiryPhoneLimiter, publicReadLimiter } = require("../utils/venueEnquiryRateLimit");
 const { adminOrVenueOwnerAuth } = require("../middlewares/adminOrVenueOwnerAuth");
 const { optionalAdminAuth } = require("../middlewares/optionalAdminAuth");
 const { CheckLogin, CheckAdminLogin } = require("../middlewares/auth");
@@ -108,7 +108,9 @@ router.patch("/:slug/team/:memberId", venueOwnerAuth, requireCapability("team"),
 
 // Availability — availability capability.
 router.post("/:slug/availability", venueOwnerAuth, requireCapability("availability"), saveAvailability);
-router.post("/:slug/view", CheckLogin, trackView);
+// Public view beacon (fire-and-forget, rate-limited, no PII) + single-date availability read.
+router.post("/:slug/view", publicReadLimiter, trackView);
+router.get("/:slug/availability-check", publicReadLimiter, availabilityCheck);
 router.post("/:slug/nearby", refreshNearby);
 router.post("/:slug/reviews", refreshReviews);
 router.post("/:slug/generate-location-description", generateLocationDescription);

--- a/routes/venue.js
+++ b/routes/venue.js
@@ -9,6 +9,10 @@ const { refreshReviews } = require("../controllers/venueReviews");
 const { generateLocationDescription } = require("../controllers/venueLocation");
 const { getDashboardOverview } = require("../controllers/venueDashboard");
 const { addInteraction, getInteractions } = require("../controllers/venueLeadInteraction");
+const { listBookings, getBooking, createBooking, updateBooking } = require("../controllers/venueBooking");
+const { createQuote, listQuotes, getQuote, updateQuote, quotePdf } = require("../controllers/venueQuote");
+const { createFromBooking, listInvoices, getInvoice, addPayment, invoicePdf } = require("../controllers/venueInvoice");
+const { summary: paymentsSummary } = require("../controllers/venuePayment");
 const { venueOwnerAuth } = require("../middlewares/venueOwnerAuth");
 const { adminOrVenueOwnerAuth } = require("../middlewares/adminOrVenueOwnerAuth");
 const { optionalAdminAuth } = require("../middlewares/optionalAdminAuth");
@@ -34,6 +38,30 @@ router.patch("/:slug/enquiries/:enquiryId", venueOwnerAuth, updateEnquiry);
 // Per-lead communication log (4-segment paths — no shadowing of the routes above).
 router.post("/:slug/enquiries/:enquiryId/interactions", venueOwnerAuth, addInteraction);
 router.get("/:slug/enquiries/:enquiryId/interactions", venueOwnerAuth, getInteractions);
+
+// ── Phase 3: bookings (3.1) ──
+router.get("/:slug/bookings", venueOwnerAuth, listBookings);
+router.post("/:slug/bookings", venueOwnerAuth, createBooking);
+router.get("/:slug/bookings/:bookingId", venueOwnerAuth, getBooking);
+router.patch("/:slug/bookings/:bookingId", venueOwnerAuth, updateBooking);
+
+// ── Phase 3: quotes (3.2) — /pdf before /:quoteId is unnecessary (distinct suffix) ──
+router.get("/:slug/quotes", venueOwnerAuth, listQuotes);
+router.post("/:slug/quotes", venueOwnerAuth, createQuote);
+router.get("/:slug/quotes/:quoteId/pdf", venueOwnerAuth, quotePdf);
+router.get("/:slug/quotes/:quoteId", venueOwnerAuth, getQuote);
+router.patch("/:slug/quotes/:quoteId", venueOwnerAuth, updateQuote);
+
+// ── Phase 3: invoices (3.3) ──
+router.get("/:slug/invoices", venueOwnerAuth, listInvoices);
+router.post("/:slug/invoices", venueOwnerAuth, createFromBooking);
+router.get("/:slug/invoices/:invoiceId/pdf", venueOwnerAuth, invoicePdf);
+router.get("/:slug/invoices/:invoiceId", venueOwnerAuth, getInvoice);
+router.post("/:slug/invoices/:invoiceId/payments", venueOwnerAuth, addPayment);
+
+// ── Phase 3: payments summary (3.4) ──
+router.get("/:slug/payments/summary", venueOwnerAuth, paymentsSummary);
+
 router.post("/:slug/availability", venueOwnerAuth, saveAvailability);
 router.post("/:slug/view", CheckLogin, trackView);
 router.post("/:slug/nearby", refreshNearby);

--- a/routes/venue.js
+++ b/routes/venue.js
@@ -18,6 +18,7 @@ const { summary: paymentsSummary } = require("../controllers/venuePayment");
 const { getAnalytics } = require("../controllers/venueAnalytics");
 const sheets = require("../controllers/venueSheetsSync");
 const { listMembers, inviteMember, updateMember, getActivity } = require("../controllers/venueTeam");
+const { createOnboardingRequest } = require("../controllers/venueOnboarding");
 const { venueOwnerAuth } = require("../middlewares/venueOwnerAuth");
 const { requireCapability, requireCapabilityOrAdmin } = require("../middlewares/venueRole");
 const { enquiryIpLimiter, enquiryPhoneLimiter, publicReadLimiter } = require("../utils/venueEnquiryRateLimit");
@@ -38,6 +39,8 @@ const { CheckLogin, CheckAdminLogin } = require("../middlewares/auth");
 router.get("/", optionalAdminAuth, getVenues);
 // Admin-only: create a new venue (venue owners must NOT create venues).
 router.post("/", CheckAdminLogin, createVenue);
+// Public "list your venue" lead from the landing page — rate-limited + validated.
+router.post("/onboarding-requests", publicReadLimiter, createOnboardingRequest);
 // Venue-owner dashboard home widgets (onboarding, verification, follow-ups).
 router.get("/dashboard/overview", venueOwnerAuth, getDashboardOverview);
 router.get("/:slug", getVenueBySlug);

--- a/routes/venue.js
+++ b/routes/venue.js
@@ -94,7 +94,9 @@ router.get("/:slug/analytics", venueOwnerAuth, getAnalytics);
 // OAuth state (Google's redirect carries no Bearer token).
 router.get("/:slug/integrations/google-sheets", venueOwnerAuth, requireCapability("leads"), sheets.getIntegration);
 router.get("/:slug/integrations/google-sheets/connect", venueOwnerAuth, requireCapability("leads"), sheets.connect);
-router.get("/:slug/integrations/google-sheets/callback", sheets.callback);
+// Public OAuth redirect target — authorized by the signed `state` JWT; add a
+// per-IP rate limiter on top so the unauthenticated endpoint can't be flooded.
+router.get("/:slug/integrations/google-sheets/callback", publicReadLimiter, sheets.callback);
 router.post("/:slug/integrations/google-sheets/disconnect", venueOwnerAuth, requireCapability("leads"), sheets.disconnect);
 router.get("/:slug/integrations/google-sheets/sheets", venueOwnerAuth, requireCapability("leads"), sheets.listSheets);
 router.post("/:slug/integrations/google-sheets/mapping", venueOwnerAuth, requireCapability("leads"), sheets.saveMapping);
@@ -111,8 +113,11 @@ router.post("/:slug/availability", venueOwnerAuth, requireCapability("availabili
 // Public view beacon (fire-and-forget, rate-limited, no PII) + single-date availability read.
 router.post("/:slug/view", publicReadLimiter, trackView);
 router.get("/:slug/availability-check", publicReadLimiter, availabilityCheck);
-router.post("/:slug/nearby", refreshNearby);
-router.post("/:slug/reviews", refreshReviews);
-router.post("/:slug/generate-location-description", generateLocationDescription);
+// Pre-existing public enrichment routes — now rate-limited per IP. The last one
+// invokes the Anthropic API unauthenticated (cost-abuse surface), so the limiter
+// matters most there (it also short-circuits to a cached result per venue).
+router.post("/:slug/nearby", publicReadLimiter, refreshNearby);
+router.post("/:slug/reviews", publicReadLimiter, refreshReviews);
+router.post("/:slug/generate-location-description", publicReadLimiter, generateLocationDescription);
 
 module.exports = router;

--- a/routes/venue.js
+++ b/routes/venue.js
@@ -9,7 +9,9 @@ const { refreshReviews } = require("../controllers/venueReviews");
 const { generateLocationDescription } = require("../controllers/venueLocation");
 const { getDashboardOverview } = require("../controllers/venueDashboard");
 const { addInteraction, getInteractions } = require("../controllers/venueLeadInteraction");
+const { listMembers, inviteMember, updateMember, getActivity } = require("../controllers/venueTeam");
 const { venueOwnerAuth } = require("../middlewares/venueOwnerAuth");
+const { requireCapability } = require("../middlewares/venueRole");
 const { adminOrVenueOwnerAuth } = require("../middlewares/adminOrVenueOwnerAuth");
 const { optionalAdminAuth } = require("../middlewares/optionalAdminAuth");
 const { CheckLogin, CheckAdminLogin } = require("../middlewares/auth");
@@ -25,16 +27,25 @@ router.put("/:slug", adminOrVenueOwnerAuth, updateVenue);
 router.post("/:slug/enquiry", createEnquiry);
 router.post("/:slug/enquiries", createEnquiry);
 // Gated manual lead creation (venue owners only) — must precede none, distinct path.
-router.post("/:slug/enquiries/manual", venueOwnerAuth, createManualLead);
-// CSV/Excel bulk import + import history (venue owners only).
-router.post("/:slug/enquiries/import", venueOwnerAuth, importLeads);
+router.post("/:slug/enquiries/manual", venueOwnerAuth, requireCapability("leads"), createManualLead);
+// CSV/Excel bulk import + import history. Import writes leads → leads capability;
+// imports history is an open read under venueOwnerAuth (capability ruling).
+router.post("/:slug/enquiries/import", venueOwnerAuth, requireCapability("leads"), importLeads);
 router.get("/:slug/enquiries/imports", venueOwnerAuth, getImports);
-router.get("/:slug/enquiries", venueOwnerAuth, getVenueEnquiries);
-router.patch("/:slug/enquiries/:enquiryId", venueOwnerAuth, updateEnquiry);
+router.get("/:slug/enquiries", venueOwnerAuth, getVenueEnquiries); // read: all roles
+router.patch("/:slug/enquiries/:enquiryId", venueOwnerAuth, requireCapability("leads"), updateEnquiry);
 // Per-lead communication log (4-segment paths — no shadowing of the routes above).
-router.post("/:slug/enquiries/:enquiryId/interactions", venueOwnerAuth, addInteraction);
-router.get("/:slug/enquiries/:enquiryId/interactions", venueOwnerAuth, getInteractions);
-router.post("/:slug/availability", venueOwnerAuth, saveAvailability);
+// Logging an interaction is a lead write → leads capability; reading is open.
+router.post("/:slug/enquiries/:enquiryId/interactions", venueOwnerAuth, requireCapability("leads"), addInteraction);
+router.get("/:slug/enquiries/:enquiryId/interactions", venueOwnerAuth, getInteractions); // open read
+
+// Team members — invite / list / update-deactivate + activity log (team capability).
+router.get("/:slug/team", venueOwnerAuth, requireCapability("team"), listMembers);
+router.post("/:slug/team", venueOwnerAuth, requireCapability("team"), inviteMember);
+router.get("/:slug/team/activity", venueOwnerAuth, requireCapability("team"), getActivity);
+router.patch("/:slug/team/:memberId", venueOwnerAuth, requireCapability("team"), updateMember);
+
+router.post("/:slug/availability", venueOwnerAuth, requireCapability("availability"), saveAvailability);
 router.post("/:slug/view", CheckLogin, trackView);
 router.post("/:slug/nearby", refreshNearby);
 router.post("/:slug/reviews", refreshReviews);

--- a/routes/venueOwner.js
+++ b/routes/venueOwner.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const router = express.Router();
-const { getClaimInfo, initiateClaim, verifyClaim, verifyDocument, submitManualClaim, sendLoginOTP, login } = require("../controllers/venueOwner");
+const { getClaimInfo, initiateClaim, verifyClaim, verifyDocument, submitManualClaim, sendLoginOTP, login, selectIdentity } = require("../controllers/venueOwner");
 
 router.get("/claim-info/:slug", getClaimInfo);
 router.post("/claim", initiateClaim);
@@ -9,5 +9,8 @@ router.post("/claim/document", verifyDocument);
 router.post("/claim/manual", submitManualClaim);
 router.post("/auth/send-otp", sendLoginOTP);
 router.post("/auth", login);
+// Multi-identity disambiguation: exchange a selection token + chosen identity
+// for the venue_owner session token.
+router.post("/auth/select-identity", selectIdentity);
 
 module.exports = router;

--- a/scripts/e2e-hardening.js
+++ b/scripts/e2e-hardening.js
@@ -1,0 +1,317 @@
+/**
+ * scripts/e2e-hardening.js — permanent adversarial test suite for the venue API.
+ *
+ * Attacks every write endpoint with hostile input, concurrency, IDOR/tenancy,
+ * money-math edges, and rate-limit spoofing. Run against a freshly seeded local
+ * server (seed-test-venue.js). Prints PASS/FAIL/FLAG; exit non-zero on any FAIL.
+ *
+ *   node scripts/e2e-hardening.js
+ */
+require("dotenv").config();
+const jwt = require("jsonwebtoken");
+const API = process.env.API_URL || "http://localhost:8090";
+const A = "test-palace";       // venue A (owner 9999999999)
+const B = "test-palace-two";   // venue B (owner 8888888888 owner-identity)
+
+let pass = 0, fail = 0, flag = 0;
+const PERF = {};
+function rec(s, name, detail) {
+  if (s === "PASS") pass++; else if (s === "FAIL") fail++; else flag++;
+  const tag = s === "PASS" ? "✓ PASS" : s === "FAIL" ? "✗ FAIL" : "⚑ FLAG";
+  console.log(`${tag}  ${name}${detail ? ` — ${detail}` : ""}`);
+}
+const ok = (n, c, d) => rec(c ? "PASS" : "FAIL", n, d);
+const flagIf = (n, c, d) => rec(c ? "FLAG" : "PASS", n, d);
+
+async function api(method, path, { token, body, rawBody, headers } = {}) {
+  const h = { "Content-Type": "application/json", ...(headers || {}) };
+  if (token) h.Authorization = `Bearer ${token}`;
+  const res = await fetch(`${API}${path}`, {
+    method, headers: h,
+    body: rawBody !== undefined ? rawBody : body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  let json = null;
+  try { json = await res.json(); } catch (_) {}
+  return { status: res.status, json };
+}
+async function loginToken(phone) {
+  const r = await api("POST", "/venue-owner/auth", { body: { phone, otp: "000000", referenceId: "dev" } });
+  return r.json && r.json.token;
+}
+
+async function run() {
+  console.log(`[hardening] target ${API}\n`);
+
+  // ── Setup tokens ──
+  const tokenA = await loginToken("9999999999"); // venue A owner
+  // venue B owner via 8888888888 owner identity
+  const multi = await api("POST", "/venue-owner/auth", { body: { phone: "8888888888", otp: "000000", referenceId: "dev" } });
+  const ownerId = (multi.json.identities || []).find((i) => i.kind === "owner");
+  const selB = await api("POST", "/venue-owner/auth/select-identity", { body: { selectionToken: multi.json.selectionToken, kind: "owner", id: ownerId && ownerId.id } });
+  const tokenB = selB.json && selB.json.token;
+  ok("setup: venue A + venue B owner tokens", Boolean(tokenA && tokenB));
+  if (!tokenA || !tokenB) return finish();
+
+  const enquiriesA = (await api("GET", `/venues/${A}/enquiries`, { token: tokenA })).json.enquiries || [];
+  const leadId = enquiriesA[0]._id;
+
+  // ═══════════ 1. HOSTILE INPUT ═══════════
+  console.log("\n— 1. Hostile input —");
+  // whitespace-only required fields
+  {
+    const r = await api("POST", `/venues/${A}/enquiries/manual`, { token: tokenA, body: { coupleName: "   ", couplePhone: "   " } });
+    ok("1 whitespace-only required -> 400", r.status === 400, `status ${r.status}`);
+  }
+  // null / wrong-type bodies on write routes -> 400/4xx never 500
+  for (const [label, path, method] of [
+    ["manual", `/venues/${A}/enquiries/manual`, "POST"],
+    ["patch", `/venues/${A}/enquiries/${leadId}`, "PATCH"],
+    ["bulk", `/venues/${A}/enquiries/bulk`, "POST"],
+    ["quote", `/venues/${A}/quotes`, "POST"],
+    ["invoice", `/venues/${A}/invoices`, "POST"],
+    ["import", `/venues/${A}/enquiries/import`, "POST"],
+  ]) {
+    for (const [bodyLabel, raw] of [["null", "null"], ["string", '"hax"'], ["array", "[]"], ["number", "5"]]) {
+      const r = await api(method, path, { token: tokenA, rawBody: raw });
+      ok(`1 ${label} body=${bodyLabel} -> not 500`, r.status !== 500, `status ${r.status}`);
+    }
+  }
+  // emoji + non-Latin couple name stored intact
+  {
+    const name = "अंकित 💍 José Ñoño 王伟";
+    const r = await api("POST", `/venues/${A}/enquiries/manual`, { token: tokenA, body: { coupleName: name, couplePhone: "9811110001" } });
+    const stored = r.json && r.json.enquiry && r.json.enquiry.coupleName;
+    ok("1 emoji/non-Latin name stored intact", [200, 201].includes(r.status) && stored === name, `status ${r.status}`);
+  }
+  // stored-XSS payload stored verbatim (rendered inert by React; verify not 500 and stored as-is)
+  {
+    const xss = '<script>alert(1)</script><img src=x onerror=alert(1)>';
+    const r = await api("POST", `/venues/${A}/enquiries/manual`, { token: tokenA, body: { coupleName: xss, couplePhone: "9811110002" } });
+    ok("1 XSS payload stored verbatim (inert)", [200, 201].includes(r.status) && r.json.enquiry.coupleName === xss, `status ${r.status}`);
+  }
+  // 10k-char string -> sane maxlength (400) not stored unbounded
+  {
+    const big = "x".repeat(10000);
+    const r = await api("POST", `/venues/${A}/enquiries/manual`, { token: tokenA, body: { coupleName: big, couplePhone: "9811110003" } });
+    const storedLen = r.json && r.json.enquiry ? (r.json.enquiry.coupleName || "").length : 0;
+    ok("1 10k-char name rejected or capped (<=2000)", r.status === 400 || storedLen <= 2000, `status ${r.status} len ${storedLen}`);
+  }
+  // negative / absurd numeric
+  {
+    const r1 = await api("POST", `/venues/${A}/enquiries/manual`, { token: tokenA, body: { coupleName: "Neg Guests", couplePhone: "9811110004", guestCount: -5 } });
+    ok("1 negative guestCount -> 400", r1.status === 400, `status ${r1.status}`);
+    const r2 = await api("POST", `/venues/${A}/enquiries/manual`, { token: tokenA, body: { coupleName: "Neg Value", couplePhone: "9811110005", estimatedValue: -100 } });
+    ok("1 negative estimatedValue -> 400", r2.status === 400, `status ${r2.status}`);
+  }
+  // invalid dates -> 400, not NaN
+  for (const bad of ["31-02-2026", "abc", "not-a-date"]) {
+    const r = await api("POST", `/venues/${A}/enquiries/manual`, { token: tokenA, body: { coupleName: "Bad Date", couplePhone: "9811110006", eventDate: bad } });
+    ok(`1 invalid eventDate "${bad}" -> 400`, r.status === 400, `status ${r.status}`);
+  }
+
+  // ═══════════ 3. CONCURRENCY & IDEMPOTENCY ═══════════
+  console.log("\n— 3. Concurrency & idempotency —");
+  // parallel manual-creates of the same phone
+  {
+    const phone = "9844440001";
+    const results = await Promise.all(Array.from({ length: 5 }, (_, i) =>
+      api("POST", `/venues/${A}/enquiries/manual`, { token: tokenA, body: { coupleName: `Race ${i}`, couplePhone: phone } })));
+    const created = (await api("GET", `/venues/${A}/enquiries`, { token: tokenA })).json.enquiries.filter((e) => (e.couplePhone || "").replace(/\D/g, "").endsWith("9844440001")).length;
+    flagIf("3 parallel same-phone manual create deduped to 1", created !== 1, `created ${created} (no unique index -> flag)`);
+  }
+  // invoice number race: 10 simultaneous creates -> unique sequential
+  {
+    const bookings = (await api("GET", `/venues/${B}/bookings`, { token: tokenB })).json.bookings || [];
+    if (bookings[0]) {
+      const res = await Promise.all(Array.from({ length: 10 }, () =>
+        api("POST", `/venues/${B}/invoices`, { token: tokenB, body: { booking: bookings[0]._id, kind: "advance" } })));
+      const nums = res.filter((r) => r.json && r.json.invoice).map((r) => r.json.invoice.invoiceNumber);
+      const uniq = new Set(nums);
+      ok("3 invoice-number race: 10 creates all succeed", res.every((r) => r.status === 201), `statuses ${res.map((r) => r.status).join(",")}`);
+      ok("3 invoice numbers all unique", nums.length === uniq.size, `${nums.length} created, ${uniq.size} unique`);
+    } else { rec("FLAG", "3 invoice race: no booking on venue B to test", ""); }
+  }
+  // two simultaneous PATCH -> no 500
+  {
+    const res = await Promise.all([
+      api("PATCH", `/venues/${A}/enquiries/${leadId}`, { token: tokenA, body: { stage: "contacted" } }),
+      api("PATCH", `/venues/${A}/enquiries/${leadId}`, { token: tokenA, body: { stage: "negotiating" } }),
+    ]);
+    ok("3 concurrent PATCH no 500", res.every((r) => r.status !== 500), `statuses ${res.map((r) => r.status).join(",")}`);
+  }
+
+  // ═══════════ 4. AUTH & TENANCY (IDOR) ═══════════
+  console.log("\n— 4. Auth & tenancy (IDOR) —");
+  // venue B owner hitting venue A resources
+  {
+    const r1 = await api("PATCH", `/venues/${A}/enquiries/${leadId}`, { token: tokenB, body: { stage: "lost" } });
+    ok("4 IDOR: venueB token PATCH venueA lead -> 403/404", [403, 404].includes(r1.status), `status ${r1.status}`);
+    const r2 = await api("GET", `/venues/${A}/enquiries`, { token: tokenB });
+    ok("4 IDOR: venueB token GET venueA enquiries -> 403/404", [403, 404].includes(r2.status), `status ${r2.status}`);
+  }
+  // tampered / empty JWT
+  {
+    const r1 = await api("GET", `/venues/dashboard/overview`, { token: "garbage.token.here" });
+    ok("4 tampered JWT -> 401", r1.status === 401, `status ${r1.status}`);
+    const r2 = await api("GET", `/venues/dashboard/overview`, { token: jwt.sign({ type: "venue_owner", venueOwnerId: "x", venueId: "y" }, "WRONG_SECRET") });
+    ok("4 wrong-secret JWT -> 401", r2.status === 401, `status ${r2.status}`);
+  }
+  // role-escalation via body ignored
+  {
+    const r = await api("POST", `/venues/${A}/enquiries/manual`, { token: tokenA, body: { coupleName: "Esc", couplePhone: "9855550001", role: "owner", isAdmin: true, venueId: "000000000000000000000000" } });
+    const venueOk = [200, 201].includes(r.status) && r.json.enquiry && String(r.json.enquiry.venueId) !== "000000000000000000000000";
+    ok("4 role/venueId in body ignored (server derives from token)", venueOk, `status ${r.status}`);
+  }
+  // deactivated member JWT rejected on next request
+  {
+    // login the manager member, then deactivate via owner, then reuse token
+    const memToken = await loginToken("9700000001");
+    const team = (await api("GET", `/venues/${A}/team`, { token: tokenA })).json.members || (await api("GET", `/venues/${A}/team`, { token: tokenA })).json.team || [];
+    const mgr = team.find((m) => m.phone === "9700000001");
+    if (memToken && mgr) {
+      await api("PATCH", `/venues/${A}/team/${mgr._id}`, { token: tokenA, body: { isActive: false } });
+      const after = await api("GET", `/venues/${A}/enquiries`, { token: memToken });
+      ok("4 deactivated member token rejected next request", [401, 403].includes(after.status), `status ${after.status}`);
+      // reactivate for idempotent reseed-free reruns
+      await api("PATCH", `/venues/${A}/team/${mgr._id}`, { token: tokenA, body: { isActive: true } });
+    } else { rec("FLAG", "4 deactivated-member: could not resolve member", `token ${!!memToken} mgr ${!!mgr}`); }
+  }
+
+  // ═══════════ 5. MONEY MATH EDGE ═══════════
+  console.log("\n— 5. Money math edge —");
+  const newLead = await api("POST", `/venues/${A}/enquiries/manual`, { token: tokenA, body: { coupleName: "Money Test", couplePhone: "9866660001" } });
+  const mlId = newLead.json.enquiry._id;
+  // GST producing paise: 33333 @ 18% = 5999.94 -> round
+  {
+    const q = await api("POST", `/venues/${A}/quotes`, { token: tokenA, body: { enquiry: mlId, lineItems: [{ label: "x", qty: 1, unitPrice: 33333 }], gstPercent: 18, discount: 0 } });
+    const t = q.json.quote.totals;
+    ok("5 GST 33333@18% rounded consistently (gst=6000, grand=39333)", t.subtotal === 33333 && t.gst === 6000 && t.grandTotal === 39333, `gst=${t.gst} grand=${t.grandTotal}`);
+  }
+  // discount > subtotal -> grandTotal floored at 0
+  {
+    const q = await api("POST", `/venues/${A}/quotes`, { token: tokenA, body: { enquiry: mlId, lineItems: [{ label: "x", qty: 1, unitPrice: 1000 }], gstPercent: 18, discount: 999999 } });
+    const t = q.json.quote.totals;
+    ok("5 discount>subtotal floors grandTotal at 0", t.grandTotal === 0, `grand=${t.grandTotal}`);
+  }
+  // zero line items quote cannot be accepted
+  {
+    const q = await api("POST", `/venues/${A}/quotes`, { token: tokenA, body: { enquiry: mlId, lineItems: [], gstPercent: 18, discount: 0 } });
+    const acc = await api("PATCH", `/venues/${A}/quotes/${q.json.quote._id}`, { token: tokenA, body: { status: "accepted" } });
+    ok("5 zero-line-item quote accept -> 400", acc.status === 400, `status ${acc.status}`);
+  }
+  // payment 0 / negative -> 400 ; payment > balance -> capped/rejected
+  {
+    const bk = (await api("GET", `/venues/${B}/bookings`, { token: tokenB })).json.bookings[0];
+    const inv = await api("POST", `/venues/${B}/invoices`, { token: tokenB, body: { booking: bk._id, kind: "final", lineItems: [{ label: "x", qty: 1, unitPrice: 100000 }], gstPercent: 18 } });
+    const invId = inv.json.invoice._id;
+    const grand = inv.json.invoice.totals.grandTotal; // 118000
+    const p0 = await api("POST", `/venues/${B}/invoices/${invId}/payments`, { token: tokenB, body: { amount: 0 } });
+    ok("5 payment amount 0 -> 400", p0.status === 400, `status ${p0.status}`);
+    const pn = await api("POST", `/venues/${B}/invoices/${invId}/payments`, { token: tokenB, body: { amount: -50 } });
+    ok("5 payment amount negative -> 400", pn.status === 400, `status ${pn.status}`);
+    const over = await api("POST", `/venues/${B}/invoices/${invId}/payments`, { token: tokenB, body: { amount: grand + 50000 } });
+    ok("5 overpayment rejected (> balance -> 400)", over.status === 400, `status ${over.status}`);
+  }
+
+  // ═══════════ 8. RATE-LIMIT INTEGRITY ═══════════
+  console.log("\n— 8. Rate-limit integrity —");
+  {
+    // spoofed X-Forwarded-For should NOT grant fresh buckets per fake IP
+    const phone = "9877770001";
+    let blocked = false;
+    for (let i = 0; i < 6; i++) {
+      const r = await api("POST", `/venues/${A}/enquiry`, { headers: { "X-Forwarded-For": `1.2.3.${i}` }, body: { coupleName: `Spoof ${i}`, couplePhone: phone } });
+      if (r.status === 429) blocked = true;
+    }
+    ok("8 X-Forwarded-For spoof does not bypass per-IP limit", blocked, "expected a 429 within 6 spoofed-IP requests");
+  }
+
+  // ═══════════ 2. IMPORT TORTURE (server takes parsed rows; CSV/xlsx/encoding parsing is client-side) ═══════════
+  console.log("\n— 2. Import torture —");
+  const RUNBASE = 7000000000 + (Date.now() % 1000000000); // run-unique 10-digit phone base
+  const phoneAt = (i) => String(RUNBASE + i);
+  // 5,000-row import — measure time, must complete
+  {
+    const rows = Array.from({ length: 5000 }, (_, i) => ({ coupleName: `Bulk ${i}`, couplePhone: phoneAt(i), source: "google" }));
+    const t0 = Date.now();
+    const r = await api("POST", `/venues/${A}/enquiries/import`, { token: tokenA, body: { rows, fileName: "torture-5000.csv" } });
+    const ms = Date.now() - t0;
+    PERF.import5000 = `${r.json && r.json.created} created / 5000 in ${ms}ms`;
+    ok("2 5,000-row import completes (created>=4990)", r.status === 200 && r.json.created >= 4990, `created ${r.json && r.json.created} in ${ms}ms`);
+  }
+  // same file imported twice -> full dedup skip
+  {
+    const rows = Array.from({ length: 5000 }, (_, i) => ({ coupleName: `Bulk ${i}`, couplePhone: phoneAt(i) }));
+    const r = await api("POST", `/venues/${A}/enquiries/import`, { token: tokenA, body: { rows } });
+    ok("2 re-import same file -> all skipped (created 0)", r.status === 200 && r.json.created === 0 && r.json.skipped >= 4990, `created ${r.json.created} skipped ${r.json.skipped}`);
+  }
+  // all-duplicates file (same phone repeated)
+  {
+    const p = phoneAt(900001);
+    const rows = Array.from({ length: 50 }, () => ({ coupleName: "Dup", couplePhone: p }));
+    const r = await api("POST", `/venues/${A}/enquiries/import`, { token: tokenA, body: { rows } });
+    ok("2 all-duplicates file -> created 1, skipped 49", r.status === 200 && r.json.created === 1 && r.json.skipped === 49, `created ${r.json.created} skipped ${r.json.skipped}`);
+  }
+  // alternating good/bad rows — every good imported, every bad reported
+  {
+    const rows = [];
+    for (let i = 0; i < 10; i++) {
+      rows.push({ coupleName: `Good ${i}`, couplePhone: phoneAt(950000 + i) }); // good
+      rows.push({ coupleName: "", couplePhone: "" }); // bad (no name/phone)
+    }
+    const r = await api("POST", `/venues/${A}/enquiries/import`, { token: tokenA, body: { rows } });
+    const errs = (r.json && r.json.errors) || [];
+    ok("2 alternating good/bad: 10 created, 10 errors reported", r.status === 200 && r.json.created === 10 && errs.length === 10, `created ${r.json.created} errors ${errs.length}`);
+  }
+  // empty file
+  {
+    const r = await api("POST", `/venues/${A}/enquiries/import`, { token: tokenA, body: { rows: [] } });
+    ok("2 empty rows -> 200 created 0 (no crash)", r.status === 200 && r.json.created === 0, `status ${r.status}`);
+  }
+
+  // ═══════════ 6. VOLUME & RENDER (API side) ═══════════
+  console.log("\n— 6. Volume & analytics —");
+  {
+    // after the 5,000-row import, list + analytics must respond quickly
+    let t0 = Date.now();
+    const list = await api("GET", `/venues/${A}/enquiries`, { token: tokenA });
+    const listMs = Date.now() - t0;
+    PERF.list = `${(list.json.enquiries || []).length} leads in ${listMs}ms`;
+    ok("6 enquiries list at 5000+ responds <5s", list.status === 200 && listMs < 5000 && list.json.enquiries.length >= 5000, `${list.json.enquiries.length} in ${listMs}ms`);
+    t0 = Date.now();
+    const an = await api("GET", `/venues/${A}/analytics`, { token: tokenA });
+    const anMs = Date.now() - t0;
+    PERF.analytics = `${anMs}ms over ${an.json && an.json.total} leads`;
+    ok("6 analytics over large dataset responds <5s, no NaN", an.status === 200 && anMs < 5000 && typeof an.json.total === "number" && !Number.isNaN(an.json.funnel.conversion.bookingRate), `${anMs}ms total ${an.json.total}`);
+  }
+  // analytics over an EMPTY range -> designed zero state, no NaN
+  {
+    const an = await api("GET", `/venues/${A}/analytics?from=2000-01-01&to=2000-01-02`, { token: tokenA });
+    const t = an.json;
+    ok("6 analytics empty range -> 0s, no NaN/crash", an.status === 200 && t.total === 0 && t.funnel.conversion.bookingRate === 0 && Array.isArray(t.volume.byMonth), `total ${t.total}`);
+  }
+
+  // ═══════════ 7. RESILIENCE (API-testable subset) ═══════════
+  console.log("\n— 7. Resilience —");
+  {
+    // server stays up + returns clean JSON under a burst of malformed requests
+    const bad = await Promise.all(Array.from({ length: 20 }, () =>
+      api("PATCH", `/venues/${A}/enquiries/${leadId}`, { token: tokenA, rawBody: "{ this is not json" })));
+    ok("7 malformed-JSON burst -> all 4xx, server up", bad.every((r) => r.status >= 400 && r.status < 500), `statuses ${[...new Set(bad.map((r) => r.status))].join(",")}`);
+    const alive = await api("GET", `/venues/${A}/enquiries`, { token: tokenA });
+    ok("7 server still responsive after burst", alive.status === 200, `status ${alive.status}`);
+    // logged-out / no token on a gated route -> 401 (drives the client login redirect)
+    const noTok = await api("GET", "/venues/dashboard/overview", {});
+    ok("7 gated route without token -> 401", noTok.status === 401, `status ${noTok.status}`);
+  }
+
+  finish();
+}
+
+function finish() {
+  console.log(`\n[hardening] perf: ${JSON.stringify(PERF)}`);
+  console.log(`[hardening] ${pass} passed, ${fail} failed, ${flag} flagged`);
+  process.exit(fail > 0 ? 1 : 0);
+}
+
+run().catch((e) => { console.error("[hardening] crashed:", e); process.exit(1); });

--- a/scripts/e2e-venue.js
+++ b/scripts/e2e-venue.js
@@ -1,0 +1,216 @@
+/**
+ * scripts/e2e-venue.js
+ *
+ * API-level end-to-end checks for the venue dashboard backend.
+ * Runs against a live local server (default http://localhost:8090) using the
+ * test owner's token (OTP dev-bypass login). Seed first with seed-test-venue.js.
+ *
+ * Prints PASS / FAIL / WARN per check; process exit code is non-zero if any
+ * hard check FAILs. WARN = known main-feature gap, does not fail the suite.
+ *
+ * Usage: node scripts/e2e-venue.js
+ * Env:   API_URL (default http://localhost:8090)
+ */
+const API = process.env.API_URL || "http://localhost:8090";
+const SLUG = "test-palace";
+const OWNER_PHONE = "9999999999";
+
+let pass = 0, fail = 0, warn = 0;
+const results = [];
+function record(status, name, detail) {
+  results.push({ status, name, detail });
+  if (status === "PASS") pass++;
+  else if (status === "FAIL") fail++;
+  else warn++;
+  const tag = status === "PASS" ? "✓ PASS" : status === "FAIL" ? "✗ FAIL" : "! WARN";
+  console.log(`${tag}  ${name}${detail ? ` — ${detail}` : ""}`);
+}
+function check(name, cond, detail) {
+  record(cond ? "PASS" : "FAIL", name, detail);
+  return cond;
+}
+
+async function api(method, path, { token, body } = {}) {
+  const headers = { "Content-Type": "application/json" };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const res = await fetch(`${API}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  let json = null;
+  try { json = await res.json(); } catch (_) {}
+  return { status: res.status, json };
+}
+
+async function login() {
+  // Dev OTP bypass: login accepts otp "000000" with any non-empty referenceId
+  // when NODE_ENV !== "production". Avoids hitting external OTP senders.
+  const { status, json } = await api("POST", "/venue-owner/auth", {
+    body: { phone: OWNER_PHONE, otp: "000000", referenceId: "e2e-dev" },
+  });
+  if (status !== 200 || !json || !json.token) {
+    throw new Error(`login failed (status ${status}): ${JSON.stringify(json)}`);
+  }
+  return json.token;
+}
+
+async function run() {
+  console.log(`[e2e] target ${API}, venue ${SLUG}\n`);
+  let token;
+  try {
+    token = await login();
+    record("PASS", "owner login (OTP dev-bypass) returns token");
+  } catch (e) {
+    record("FAIL", "owner login", e.message);
+    return finish();
+  }
+
+  // --- Check: dashboard overview shape ---
+  {
+    const { status, json } = await api("GET", "/venues/dashboard/overview", { token });
+    const ok = status === 200 && json
+      && json.onboarding && json.onboarding.steps
+      && typeof json.onboarding.completed === "number"
+      && typeof json.onboarding.total === "number"
+      && typeof json.onboarding.percent === "number"
+      && typeof json.isVerified === "boolean"
+      && json.followUps
+      && typeof json.followUps.dueToday === "number"
+      && typeof json.followUps.overdue === "number";
+    check("dashboard overview shape", ok, `status ${status}`);
+  }
+
+  // --- Check: manual lead create ---
+  let manualId = null;
+  {
+    const phone = "9871230001";
+    const { status, json } = await api("POST", `/venues/${SLUG}/enquiries/manual`, {
+      token,
+      body: { coupleName: "E2E Manual Lead", couplePhone: phone, source: "walk_in", stage: "new", estimatedValue: 333000 },
+    });
+    const ok = [200, 201].includes(status) && json && (json.enquiryId || (json.enquiry && json.enquiry._id));
+    manualId = json && (json.enquiryId || (json.enquiry && json.enquiry._id));
+    check("manual lead create", ok, `status ${status}`);
+  }
+
+  // --- Check: import endpoint with one duplicate ---
+  {
+    // 9810000001 is a seeded lead (duplicate -> skipped); the other is new.
+    const rows = [
+      { coupleName: "Import New One", couplePhone: "9822220001", source: "google", stage: "new" },
+      { coupleName: "Import Dup", couplePhone: "9810000001", source: "google", stage: "new" },
+    ];
+    const { status, json } = await api("POST", `/venues/${SLUG}/enquiries/import`, {
+      token,
+      body: { rows, fileName: "e2e-inline.csv" },
+    });
+    const ok = status === 200 && json && json.created >= 1 && json.skipped >= 1;
+    check("import endpoint (created>=1, dup skipped>=1)", ok, `status ${status} created=${json && json.created} skipped=${json && json.skipped}`);
+  }
+
+  // --- Check: interactions create + list ---
+  {
+    // Use the manual lead created above; fall back to first enquiry if needed.
+    let targetId = manualId;
+    if (!targetId) {
+      const list = await api("GET", `/venues/${SLUG}/enquiries`, { token });
+      targetId = list.json && list.json.enquiries && list.json.enquiries[0] && list.json.enquiries[0]._id;
+    }
+    const create = await api("POST", `/venues/${SLUG}/enquiries/${targetId}/interactions`, {
+      token, body: { type: "call", note: "e2e logged call" },
+    });
+    const createdOk = [200, 201].includes(create.status) && create.json && create.json.interaction;
+    const list = await api("GET", `/venues/${SLUG}/enquiries/${targetId}/interactions`, { token });
+    const listedOk = list.status === 200 && Array.isArray(list.json && list.json.interactions)
+      && list.json.interactions.some((i) => i.note === "e2e logged call");
+    check("interaction create", createdOk, `status ${create.status}`);
+    check("interaction list includes created", listedOk, `status ${list.status}`);
+  }
+
+  // --- Check: enquiry PATCH stage move (+ assignedTo) ---
+  {
+    let targetId = manualId;
+    if (!targetId) {
+      const list = await api("GET", `/venues/${SLUG}/enquiries`, { token });
+      targetId = list.json.enquiries[0]._id;
+    }
+    const { status, json } = await api("PATCH", `/venues/${SLUG}/enquiries/${targetId}`, {
+      token, body: { stage: "contacted", assignedTo: "E2E Manager" },
+    });
+    check("enquiry PATCH stage move", status === 200 && json && json.enquiry && json.enquiry.stage === "contacted", `status ${status}`);
+    // assignedTo on the single-enquiry PATCH is NOT supported on main (controller
+    // whitelist omits it). Report as WARN, not a hard failure.
+    if (json && json.enquiry && json.enquiry.assignedTo === "E2E Manager") {
+      record("PASS", "enquiry PATCH assignedTo persisted");
+    } else {
+      record("WARN", "enquiry PATCH assignedTo NOT persisted", "main controller whitelist omits assignedTo — flagged");
+    }
+  }
+
+  // ================= Task 3: bulk actions + templates + bulk-whatsapp =================
+  if (process.env.E2E_BULK === "1") {
+    const list = await api("GET", `/venues/${SLUG}/enquiries`, { token });
+    const ids = (list.json && list.json.enquiries ? list.json.enquiries : []).slice(0, 2).map((e) => e._id);
+    check("bulk: have >=2 enquiry ids", ids.length >= 2, `got ${ids.length}`);
+
+    {
+      const { status, json } = await api("POST", `/venues/${SLUG}/enquiries/bulk`, {
+        token, body: { enquiryIds: ids, action: "stage", value: "contacted" },
+      });
+      check("bulk action stage (updated==2)", status === 200 && json && json.updated === ids.length && Array.isArray(json.errors), `status ${status} updated=${json && json.updated}`);
+    }
+    {
+      const { status, json } = await api("POST", `/venues/${SLUG}/enquiries/bulk`, {
+        token, body: { enquiryIds: ids, action: "assign", value: "Bulk Assignee" },
+      });
+      check("bulk action assign (updated==2)", status === 200 && json && json.updated === ids.length, `status ${status} updated=${json && json.updated}`);
+    }
+    {
+      const { status, json } = await api("POST", `/venues/${SLUG}/enquiries/bulk`, {
+        token, body: { enquiryIds: ids, action: "note", value: "bulk note from e2e" },
+      });
+      check("bulk action note (updated==2)", status === 200 && json && json.updated === ids.length, `status ${status} updated=${json && json.updated}`);
+    }
+    {
+      const { status } = await api("POST", `/venues/${SLUG}/enquiries/bulk`, {
+        token, body: { enquiryIds: ids, action: "nope", value: "x" },
+      });
+      check("bulk action invalid -> 400", status === 400, `status ${status}`);
+    }
+
+    let templateId = null;
+    {
+      const create = await api("POST", `/venues/${SLUG}/templates`, { token, body: { name: "Welcome", body: "Hi, thanks for your enquiry!" } });
+      templateId = create.json && create.json.template && create.json.template._id;
+      check("template create -> 201", [200, 201].includes(create.status) && templateId, `status ${create.status}`);
+      const listT = await api("GET", `/venues/${SLUG}/templates`, { token });
+      check("template list includes created", listT.status === 200 && listT.json.templates.some((t) => t._id === templateId), `status ${listT.status}`);
+      const upd = await api("PATCH", `/venues/${SLUG}/templates/${templateId}`, { token, body: { name: "Welcome v2" } });
+      check("template update name", upd.status === 200 && upd.json.template.name === "Welcome v2", `status ${upd.status}`);
+      const del = await api("DELETE", `/venues/${SLUG}/templates/${templateId}`, { token });
+      check("template delete", del.status === 200 && del.json.success, `status ${del.status}`);
+    }
+
+    // bulk-whatsapp: e2e server instance runs with WhatsApp creds blanked so the
+    // unconfigured 503 path is exercised — no real messages are ever sent.
+    {
+      const { status, json } = await api("POST", `/venues/${SLUG}/enquiries/bulk-whatsapp`, {
+        token, body: { enquiryIds: ids, body: "hello from e2e" },
+      });
+      check("bulk-whatsapp unconfigured -> 503 {configured:false}", status === 503 && json && json.configured === false, `status ${status}`);
+    }
+  }
+
+  finish();
+}
+
+function finish() {
+  console.log(`\n[e2e] ${pass} passed, ${fail} failed, ${warn} warn`);
+  process.exit(fail > 0 ? 1 : 0);
+}
+
+run().catch((e) => {
+  console.error("[e2e] crashed:", e);
+  process.exit(1);
+});

--- a/scripts/e2e-venue.js
+++ b/scripts/e2e-venue.js
@@ -1,0 +1,175 @@
+/**
+ * scripts/e2e-venue.js
+ *
+ * API-level end-to-end checks for the venue dashboard backend.
+ * Runs against a live local server (default http://localhost:8090) using the
+ * test owner's token (OTP dev-bypass login). Seed first with seed-test-venue.js.
+ *
+ * Prints PASS / FAIL / WARN per check; process exit code is non-zero if any
+ * hard check FAILs. WARN = known main-feature gap, does not fail the suite.
+ *
+ * Usage: node scripts/e2e-venue.js
+ * Env:   API_URL (default http://localhost:8090)
+ */
+const API = process.env.API_URL || "http://localhost:8090";
+const SLUG = "test-palace";
+const OWNER_PHONE = "9999999999";
+
+let pass = 0, fail = 0, warn = 0;
+const results = [];
+function record(status, name, detail) {
+  results.push({ status, name, detail });
+  if (status === "PASS") pass++;
+  else if (status === "FAIL") fail++;
+  else warn++;
+  const tag = status === "PASS" ? "✓ PASS" : status === "FAIL" ? "✗ FAIL" : "! WARN";
+  console.log(`${tag}  ${name}${detail ? ` — ${detail}` : ""}`);
+}
+function check(name, cond, detail) {
+  record(cond ? "PASS" : "FAIL", name, detail);
+  return cond;
+}
+
+async function api(method, path, { token, body } = {}) {
+  const headers = { "Content-Type": "application/json" };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const res = await fetch(`${API}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  let json = null;
+  try { json = await res.json(); } catch (_) {}
+  return { status: res.status, json };
+}
+
+async function login() {
+  // Dev OTP bypass: login accepts otp "000000" with any non-empty referenceId
+  // when NODE_ENV !== "production". Avoids hitting external OTP senders.
+  const { status, json } = await api("POST", "/venue-owner/auth", {
+    body: { phone: OWNER_PHONE, otp: "000000", referenceId: "e2e-dev" },
+  });
+  if (status !== 200 || !json || !json.token) {
+    throw new Error(`login failed (status ${status}): ${JSON.stringify(json)}`);
+  }
+  return json.token;
+}
+
+async function run() {
+  console.log(`[e2e] target ${API}, venue ${SLUG}\n`);
+  let token;
+  try {
+    token = await login();
+    record("PASS", "owner login (OTP dev-bypass) returns token");
+  } catch (e) {
+    record("FAIL", "owner login", e.message);
+    return finish();
+  }
+
+  // --- Check: dashboard overview shape ---
+  {
+    const { status, json } = await api("GET", "/venues/dashboard/overview", { token });
+    const ok = status === 200 && json
+      && json.onboarding && json.onboarding.steps
+      && typeof json.onboarding.completed === "number"
+      && typeof json.onboarding.total === "number"
+      && typeof json.onboarding.percent === "number"
+      && typeof json.isVerified === "boolean"
+      && json.followUps
+      && typeof json.followUps.dueToday === "number"
+      && typeof json.followUps.overdue === "number";
+    check("dashboard overview shape", ok, `status ${status}`);
+  }
+
+  // --- Check: manual lead create ---
+  let manualId = null;
+  {
+    const phone = "9871230001";
+    const { status, json } = await api("POST", `/venues/${SLUG}/enquiries/manual`, {
+      token,
+      body: { coupleName: "E2E Manual Lead", couplePhone: phone, source: "walk_in", stage: "new", estimatedValue: 333000 },
+    });
+    const ok = [200, 201].includes(status) && json && (json.enquiryId || (json.enquiry && json.enquiry._id));
+    manualId = json && (json.enquiryId || (json.enquiry && json.enquiry._id));
+    check("manual lead create", ok, `status ${status}`);
+  }
+
+  // --- Check: import endpoint with one duplicate ---
+  {
+    // 9810000001 is a seeded lead (duplicate -> skipped); the other is new.
+    const rows = [
+      { coupleName: "Import New One", couplePhone: "9822220001", source: "google", stage: "new" },
+      { coupleName: "Import Dup", couplePhone: "9810000001", source: "google", stage: "new" },
+    ];
+    const { status, json } = await api("POST", `/venues/${SLUG}/enquiries/import`, {
+      token,
+      body: { rows, fileName: "e2e-inline.csv" },
+    });
+    const ok = status === 200 && json && json.created >= 1 && json.skipped >= 1;
+    check("import endpoint (created>=1, dup skipped>=1)", ok, `status ${status} created=${json && json.created} skipped=${json && json.skipped}`);
+  }
+
+  // --- Check: interactions create + list ---
+  {
+    // Use the manual lead created above; fall back to first enquiry if needed.
+    let targetId = manualId;
+    if (!targetId) {
+      const list = await api("GET", `/venues/${SLUG}/enquiries`, { token });
+      targetId = list.json && list.json.enquiries && list.json.enquiries[0] && list.json.enquiries[0]._id;
+    }
+    const create = await api("POST", `/venues/${SLUG}/enquiries/${targetId}/interactions`, {
+      token, body: { type: "call", note: "e2e logged call" },
+    });
+    const createdOk = [200, 201].includes(create.status) && create.json && create.json.interaction;
+    const list = await api("GET", `/venues/${SLUG}/enquiries/${targetId}/interactions`, { token });
+    const listedOk = list.status === 200 && Array.isArray(list.json && list.json.interactions)
+      && list.json.interactions.some((i) => i.note === "e2e logged call");
+    check("interaction create", createdOk, `status ${create.status}`);
+    check("interaction list includes created", listedOk, `status ${list.status}`);
+  }
+
+  // --- Check: enquiry PATCH stage move (+ assignedTo) ---
+  {
+    let targetId = manualId;
+    if (!targetId) {
+      const list = await api("GET", `/venues/${SLUG}/enquiries`, { token });
+      targetId = list.json.enquiries[0]._id;
+    }
+    const { status, json } = await api("PATCH", `/venues/${SLUG}/enquiries/${targetId}`, {
+      token, body: { stage: "contacted", assignedTo: "E2E Manager" },
+    });
+    check("enquiry PATCH stage move", status === 200 && json && json.enquiry && json.enquiry.stage === "contacted", `status ${status}`);
+    // assignedTo on the single-enquiry PATCH is NOT supported on main (controller
+    // whitelist omits it). Report as WARN, not a hard failure.
+    if (json && json.enquiry && json.enquiry.assignedTo === "E2E Manager") {
+      record("PASS", "enquiry PATCH assignedTo persisted");
+    } else {
+      record("WARN", "enquiry PATCH assignedTo NOT persisted", "main controller whitelist omits assignedTo — flagged");
+    }
+  }
+
+  // ================= Task 9: EV charging amenity (toggle -> save -> public read) =================
+  if (process.env.E2E_EV === "1") {
+    const on = await api("PUT", `/venues/${SLUG}`, { token, body: { amenities: { evCharging: true } } });
+    check("EV: PUT amenities.evCharging=true", [200, 201].includes(on.status), `status ${on.status}`);
+    const pub1 = await api("GET", `/venues/${SLUG}`, {});
+    const v1 = pub1.json && (pub1.json.venue || pub1.json);
+    check("EV: public venue reflects evCharging=true", v1 && v1.amenities && v1.amenities.evCharging === true);
+    const off = await api("PUT", `/venues/${SLUG}`, { token, body: { amenities: { evCharging: false } } });
+    const pub2 = await api("GET", `/venues/${SLUG}`, {});
+    const v2 = pub2.json && (pub2.json.venue || pub2.json);
+    check("EV: toggle back to false persists", off.status >= 200 && v2 && v2.amenities && v2.amenities.evCharging === false);
+  }
+
+  finish();
+}
+
+function finish() {
+  console.log(`\n[e2e] ${pass} passed, ${fail} failed, ${warn} warn`);
+  process.exit(fail > 0 ? 1 : 0);
+}
+
+run().catch((e) => {
+  console.error("[e2e] crashed:", e);
+  process.exit(1);
+});

--- a/scripts/e2e-venue.js
+++ b/scripts/e2e-venue.js
@@ -1,0 +1,162 @@
+/**
+ * scripts/e2e-venue.js
+ *
+ * API-level end-to-end checks for the venue dashboard backend.
+ * Runs against a live local server (default http://localhost:8090) using the
+ * test owner's token (OTP dev-bypass login). Seed first with seed-test-venue.js.
+ *
+ * Prints PASS / FAIL / WARN per check; process exit code is non-zero if any
+ * hard check FAILs. WARN = known main-feature gap, does not fail the suite.
+ *
+ * Usage: node scripts/e2e-venue.js
+ * Env:   API_URL (default http://localhost:8090)
+ */
+const API = process.env.API_URL || "http://localhost:8090";
+const SLUG = "test-palace";
+const OWNER_PHONE = "9999999999";
+
+let pass = 0, fail = 0, warn = 0;
+const results = [];
+function record(status, name, detail) {
+  results.push({ status, name, detail });
+  if (status === "PASS") pass++;
+  else if (status === "FAIL") fail++;
+  else warn++;
+  const tag = status === "PASS" ? "✓ PASS" : status === "FAIL" ? "✗ FAIL" : "! WARN";
+  console.log(`${tag}  ${name}${detail ? ` — ${detail}` : ""}`);
+}
+function check(name, cond, detail) {
+  record(cond ? "PASS" : "FAIL", name, detail);
+  return cond;
+}
+
+async function api(method, path, { token, body } = {}) {
+  const headers = { "Content-Type": "application/json" };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const res = await fetch(`${API}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  let json = null;
+  try { json = await res.json(); } catch (_) {}
+  return { status: res.status, json };
+}
+
+async function login() {
+  // Dev OTP bypass: login accepts otp "000000" with any non-empty referenceId
+  // when NODE_ENV !== "production". Avoids hitting external OTP senders.
+  const { status, json } = await api("POST", "/venue-owner/auth", {
+    body: { phone: OWNER_PHONE, otp: "000000", referenceId: "e2e-dev" },
+  });
+  if (status !== 200 || !json || !json.token) {
+    throw new Error(`login failed (status ${status}): ${JSON.stringify(json)}`);
+  }
+  return json.token;
+}
+
+async function run() {
+  console.log(`[e2e] target ${API}, venue ${SLUG}\n`);
+  let token;
+  try {
+    token = await login();
+    record("PASS", "owner login (OTP dev-bypass) returns token");
+  } catch (e) {
+    record("FAIL", "owner login", e.message);
+    return finish();
+  }
+
+  // --- Check: dashboard overview shape ---
+  {
+    const { status, json } = await api("GET", "/venues/dashboard/overview", { token });
+    const ok = status === 200 && json
+      && json.onboarding && json.onboarding.steps
+      && typeof json.onboarding.completed === "number"
+      && typeof json.onboarding.total === "number"
+      && typeof json.onboarding.percent === "number"
+      && typeof json.isVerified === "boolean"
+      && json.followUps
+      && typeof json.followUps.dueToday === "number"
+      && typeof json.followUps.overdue === "number";
+    check("dashboard overview shape", ok, `status ${status}`);
+  }
+
+  // --- Check: manual lead create ---
+  let manualId = null;
+  {
+    const phone = "9871230001";
+    const { status, json } = await api("POST", `/venues/${SLUG}/enquiries/manual`, {
+      token,
+      body: { coupleName: "E2E Manual Lead", couplePhone: phone, source: "walk_in", stage: "new", estimatedValue: 333000 },
+    });
+    const ok = [200, 201].includes(status) && json && (json.enquiryId || (json.enquiry && json.enquiry._id));
+    manualId = json && (json.enquiryId || (json.enquiry && json.enquiry._id));
+    check("manual lead create", ok, `status ${status}`);
+  }
+
+  // --- Check: import endpoint with one duplicate ---
+  {
+    // 9810000001 is a seeded lead (duplicate -> skipped); the other is new.
+    const rows = [
+      { coupleName: "Import New One", couplePhone: "9822220001", source: "google", stage: "new" },
+      { coupleName: "Import Dup", couplePhone: "9810000001", source: "google", stage: "new" },
+    ];
+    const { status, json } = await api("POST", `/venues/${SLUG}/enquiries/import`, {
+      token,
+      body: { rows, fileName: "e2e-inline.csv" },
+    });
+    const ok = status === 200 && json && json.created >= 1 && json.skipped >= 1;
+    check("import endpoint (created>=1, dup skipped>=1)", ok, `status ${status} created=${json && json.created} skipped=${json && json.skipped}`);
+  }
+
+  // --- Check: interactions create + list ---
+  {
+    // Use the manual lead created above; fall back to first enquiry if needed.
+    let targetId = manualId;
+    if (!targetId) {
+      const list = await api("GET", `/venues/${SLUG}/enquiries`, { token });
+      targetId = list.json && list.json.enquiries && list.json.enquiries[0] && list.json.enquiries[0]._id;
+    }
+    const create = await api("POST", `/venues/${SLUG}/enquiries/${targetId}/interactions`, {
+      token, body: { type: "call", note: "e2e logged call" },
+    });
+    const createdOk = [200, 201].includes(create.status) && create.json && create.json.interaction;
+    const list = await api("GET", `/venues/${SLUG}/enquiries/${targetId}/interactions`, { token });
+    const listedOk = list.status === 200 && Array.isArray(list.json && list.json.interactions)
+      && list.json.interactions.some((i) => i.note === "e2e logged call");
+    check("interaction create", createdOk, `status ${create.status}`);
+    check("interaction list includes created", listedOk, `status ${list.status}`);
+  }
+
+  // --- Check: enquiry PATCH stage move (+ assignedTo) ---
+  {
+    let targetId = manualId;
+    if (!targetId) {
+      const list = await api("GET", `/venues/${SLUG}/enquiries`, { token });
+      targetId = list.json.enquiries[0]._id;
+    }
+    const { status, json } = await api("PATCH", `/venues/${SLUG}/enquiries/${targetId}`, {
+      token, body: { stage: "contacted", assignedTo: "E2E Manager" },
+    });
+    check("enquiry PATCH stage move", status === 200 && json && json.enquiry && json.enquiry.stage === "contacted", `status ${status}`);
+    // assignedTo on the single-enquiry PATCH is NOT supported on main (controller
+    // whitelist omits it). Report as WARN, not a hard failure.
+    if (json && json.enquiry && json.enquiry.assignedTo === "E2E Manager") {
+      record("PASS", "enquiry PATCH assignedTo persisted");
+    } else {
+      record("WARN", "enquiry PATCH assignedTo NOT persisted", "main controller whitelist omits assignedTo — flagged");
+    }
+  }
+
+  finish();
+}
+
+function finish() {
+  console.log(`\n[e2e] ${pass} passed, ${fail} failed, ${warn} warn`);
+  process.exit(fail > 0 ? 1 : 0);
+}
+
+run().catch((e) => {
+  console.error("[e2e] crashed:", e);
+  process.exit(1);
+});

--- a/scripts/e2e-venue.js
+++ b/scripts/e2e-venue.js
@@ -472,6 +472,34 @@ async function run() {
     const hasTP = (byAmenity.json.venues || []).some((x) => x.slug === SLUG);
     check("couple: browse amenities=evCharging includes the toggled venue", byAmenity.status === 200 && hasTP, `found ${hasTP}`);
     await api("PUT", `/venues/${SLUG}`, { token, body: { amenities: { evCharging: false } } });
+
+    // ── Places proxy contract (auth-gated; no live Google call to avoid cost/key) ──
+    const acNoAuth = await api("GET", `/places/autocomplete?input=mumbai`, {});
+    check("places: autocomplete requires auth -> 401", acNoAuth.status === 401, `status ${acNoAuth.status}`);
+    const detNoAuth = await api("GET", `/places/details?placeId=x`, {});
+    check("places: details requires auth -> 401", detNoAuth.status === 401, `status ${detNoAuth.status}`);
+
+    // ── policyDoc structured policies + backward compat ──
+    await api("PUT", `/venues/${SLUG}`, { token, body: { policies: { otherRestrictions: "No outside DJ after 11pm", cancellation: "50% refund before 30 days", refund: "No refund within 7 days" } } });
+    const r1 = await api("GET", `/venues/${SLUG}`, {});
+    const pd1 = r1.json.venue.policyDoc;
+    check("policyDoc: legacy policies migrated on read (otherRestrictions->policies, cancel/refund->refund)",
+      pd1 && pd1.policies.includes("No outside DJ after 11pm") && pd1.refund.length >= 1, JSON.stringify(pd1));
+    await api("PUT", `/venues/${SLUG}`, { token, body: { policyDoc: { policies: ["Clause A", "Clause B"], terms: ["T1"], refund: ["R1"] } } });
+    const r2 = await api("GET", `/venues/${SLUG}`, {});
+    const pd2 = r2.json.venue.policyDoc;
+    check("policyDoc: structured value persists + precedes legacy",
+      pd2 && pd2.policies.length === 2 && pd2.policies[0] === "Clause A" && pd2.terms[0] === "T1" && pd2.refund[0] === "R1", JSON.stringify(pd2));
+
+    // ── onboarding requests (public) create + hostile input ──
+    const onb = await api("POST", `/venues/onboarding-requests`, { body: { name: "Rohaan", venueName: "Crown Estate", city: "Bangalore", phone: "+91 98765 43210" } });
+    check("onboarding: create -> 201 + id", [200, 201].includes(onb.status) && onb.json.id, `status ${onb.status}`);
+    const onbMissing = await api("POST", `/venues/onboarding-requests`, { body: { venueName: "X", phone: "9876543210" } });
+    check("onboarding: missing name -> 400", onbMissing.status === 400, `status ${onbMissing.status}`);
+    const onbShort = await api("POST", `/venues/onboarding-requests`, { body: { name: "  ", venueName: "X", phone: "123" } });
+    check("onboarding: blank name / short phone -> 400", onbShort.status === 400, `status ${onbShort.status}`);
+    const onbNull = await api("POST", `/venues/onboarding-requests`, { rawBody: "null" });
+    check("onboarding: null body -> not 500", onbNull.status !== 500, `status ${onbNull.status}`);
   }
 
   // ================= Public-route rate limiting (callback + generate-location) =================
@@ -486,6 +514,9 @@ async function run() {
     // so generate-location-description 429s at the limiter — BEFORE invoking Anthropic.
     const gen = await api("POST", `/venues/${SLUG}/generate-location-description`, {});
     check("public-ratelimit: generate-location-description over-limit -> 429 (no Anthropic call)", gen.status === 429, `status ${gen.status}`);
+    // Shared bucket exhausted -> onboarding 429s at the limiter (no record created).
+    const onbOver = await api("POST", `/venues/onboarding-requests`, { body: { name: "R", venueName: "V", phone: "9876543210" } });
+    check("public-ratelimit: onboarding over-limit -> 429 (no record created)", onbOver.status === 429, `status ${onbOver.status}`);
   }
 
   finish();

--- a/scripts/e2e-venue.js
+++ b/scripts/e2e-venue.js
@@ -1,0 +1,186 @@
+/**
+ * scripts/e2e-venue.js
+ *
+ * API-level end-to-end checks for the venue dashboard backend.
+ * Runs against a live local server (default http://localhost:8090) using the
+ * test owner's token (OTP dev-bypass login). Seed first with seed-test-venue.js.
+ *
+ * Prints PASS / FAIL / WARN per check; process exit code is non-zero if any
+ * hard check FAILs. WARN = known main-feature gap, does not fail the suite.
+ *
+ * Usage: node scripts/e2e-venue.js
+ * Env:   API_URL (default http://localhost:8090)
+ */
+const API = process.env.API_URL || "http://localhost:8090";
+const SLUG = "test-palace";
+const OWNER_PHONE = "9999999999";
+
+let pass = 0, fail = 0, warn = 0;
+const results = [];
+function record(status, name, detail) {
+  results.push({ status, name, detail });
+  if (status === "PASS") pass++;
+  else if (status === "FAIL") fail++;
+  else warn++;
+  const tag = status === "PASS" ? "✓ PASS" : status === "FAIL" ? "✗ FAIL" : "! WARN";
+  console.log(`${tag}  ${name}${detail ? ` — ${detail}` : ""}`);
+}
+function check(name, cond, detail) {
+  record(cond ? "PASS" : "FAIL", name, detail);
+  return cond;
+}
+
+async function api(method, path, { token, body } = {}) {
+  const headers = { "Content-Type": "application/json" };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const res = await fetch(`${API}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  let json = null;
+  try { json = await res.json(); } catch (_) {}
+  return { status: res.status, json };
+}
+
+async function login() {
+  // Dev OTP bypass: login accepts otp "000000" with any non-empty referenceId
+  // when NODE_ENV !== "production". Avoids hitting external OTP senders.
+  const { status, json } = await api("POST", "/venue-owner/auth", {
+    body: { phone: OWNER_PHONE, otp: "000000", referenceId: "e2e-dev" },
+  });
+  if (status !== 200 || !json || !json.token) {
+    throw new Error(`login failed (status ${status}): ${JSON.stringify(json)}`);
+  }
+  return json.token;
+}
+
+async function run() {
+  console.log(`[e2e] target ${API}, venue ${SLUG}\n`);
+  let token;
+  try {
+    token = await login();
+    record("PASS", "owner login (OTP dev-bypass) returns token");
+  } catch (e) {
+    record("FAIL", "owner login", e.message);
+    return finish();
+  }
+
+  // --- Check: dashboard overview shape ---
+  {
+    const { status, json } = await api("GET", "/venues/dashboard/overview", { token });
+    const ok = status === 200 && json
+      && json.onboarding && json.onboarding.steps
+      && typeof json.onboarding.completed === "number"
+      && typeof json.onboarding.total === "number"
+      && typeof json.onboarding.percent === "number"
+      && typeof json.isVerified === "boolean"
+      && json.followUps
+      && typeof json.followUps.dueToday === "number"
+      && typeof json.followUps.overdue === "number";
+    check("dashboard overview shape", ok, `status ${status}`);
+  }
+
+  // --- Check: manual lead create ---
+  let manualId = null;
+  {
+    const phone = "9871230001";
+    const { status, json } = await api("POST", `/venues/${SLUG}/enquiries/manual`, {
+      token,
+      body: { coupleName: "E2E Manual Lead", couplePhone: phone, source: "walk_in", stage: "new", estimatedValue: 333000 },
+    });
+    const ok = [200, 201].includes(status) && json && (json.enquiryId || (json.enquiry && json.enquiry._id));
+    manualId = json && (json.enquiryId || (json.enquiry && json.enquiry._id));
+    check("manual lead create", ok, `status ${status}`);
+  }
+
+  // --- Check: import endpoint with one duplicate ---
+  {
+    // 9810000001 is a seeded lead (duplicate -> skipped); the other is new.
+    const rows = [
+      { coupleName: "Import New One", couplePhone: "9822220001", source: "google", stage: "new" },
+      { coupleName: "Import Dup", couplePhone: "9810000001", source: "google", stage: "new" },
+    ];
+    const { status, json } = await api("POST", `/venues/${SLUG}/enquiries/import`, {
+      token,
+      body: { rows, fileName: "e2e-inline.csv" },
+    });
+    const ok = status === 200 && json && json.created >= 1 && json.skipped >= 1;
+    check("import endpoint (created>=1, dup skipped>=1)", ok, `status ${status} created=${json && json.created} skipped=${json && json.skipped}`);
+  }
+
+  // --- Check: interactions create + list ---
+  {
+    // Use the manual lead created above; fall back to first enquiry if needed.
+    let targetId = manualId;
+    if (!targetId) {
+      const list = await api("GET", `/venues/${SLUG}/enquiries`, { token });
+      targetId = list.json && list.json.enquiries && list.json.enquiries[0] && list.json.enquiries[0]._id;
+    }
+    const create = await api("POST", `/venues/${SLUG}/enquiries/${targetId}/interactions`, {
+      token, body: { type: "call", note: "e2e logged call" },
+    });
+    const createdOk = [200, 201].includes(create.status) && create.json && create.json.interaction;
+    const list = await api("GET", `/venues/${SLUG}/enquiries/${targetId}/interactions`, { token });
+    const listedOk = list.status === 200 && Array.isArray(list.json && list.json.interactions)
+      && list.json.interactions.some((i) => i.note === "e2e logged call");
+    check("interaction create", createdOk, `status ${create.status}`);
+    check("interaction list includes created", listedOk, `status ${list.status}`);
+  }
+
+  // --- Check: enquiry PATCH stage move (+ assignedTo) ---
+  {
+    let targetId = manualId;
+    if (!targetId) {
+      const list = await api("GET", `/venues/${SLUG}/enquiries`, { token });
+      targetId = list.json.enquiries[0]._id;
+    }
+    const { status, json } = await api("PATCH", `/venues/${SLUG}/enquiries/${targetId}`, {
+      token, body: { stage: "contacted", assignedTo: "E2E Manager" },
+    });
+    check("enquiry PATCH stage move", status === 200 && json && json.enquiry && json.enquiry.stage === "contacted", `status ${status}`);
+    // assignedTo on the single-enquiry PATCH is NOT supported on main (controller
+    // whitelist omits it). Report as WARN, not a hard failure.
+    if (json && json.enquiry && json.enquiry.assignedTo === "E2E Manager") {
+      record("PASS", "enquiry PATCH assignedTo persisted");
+    } else {
+      record("WARN", "enquiry PATCH assignedTo NOT persisted", "main controller whitelist omits assignedTo — flagged");
+    }
+  }
+
+  // ================= Task 4: public enquiry rate limiting =================
+  // Run against a freshly-started server (in-memory counters reset on restart).
+  // Posts the same phone repeatedly to the PUBLIC enquiry endpoint; with the
+  // default per-phone limit of 3/day, the 4th submission must return 429.
+  if (process.env.E2E_RATELIMIT === "1") {
+    const phone = "9871239999";
+    let last = 0;
+    let earlyOk = true;
+    for (let i = 1; i <= 4; i++) {
+      const { status } = await api("POST", `/venues/${SLUG}/enquiry`, {
+        body: { coupleName: `RateLimit ${i}`, couplePhone: phone, source: "wedsy" },
+      });
+      if (i <= 3 && ![200, 201].includes(status)) earlyOk = false;
+      last = status;
+    }
+    check("rate-limit: first 3 public enquiries accepted", earlyOk);
+    check("rate-limit: 4th same-phone enquiry -> 429", last === 429, `last status ${last}`);
+    // The gated /manual route must remain unaffected by the public limiter.
+    const manual = await api("POST", `/venues/${SLUG}/enquiries/manual`, {
+      token, body: { coupleName: "Manual Not Limited", couplePhone: "9871230077" },
+    });
+    check("rate-limit: gated /manual still works (not limited)", [200, 201].includes(manual.status), `status ${manual.status}`);
+  }
+
+  finish();
+}
+
+function finish() {
+  console.log(`\n[e2e] ${pass} passed, ${fail} failed, ${warn} warn`);
+  process.exit(fail > 0 ? 1 : 0);
+}
+
+run().catch((e) => {
+  console.error("[e2e] crashed:", e);
+  process.exit(1);
+});

--- a/scripts/e2e-venue.js
+++ b/scripts/e2e-venue.js
@@ -393,6 +393,42 @@ async function run() {
     check("member-login: single-identity returns token directly (no picker)", single.status === 200 && single.json.token && !single.json.multiple, `status ${single.status}`);
   }
 
+  // ================= Polish: role-gated sheets + member listing edit =================
+  if (process.env.E2E_ROLES === "1") {
+    const jwt = require("jsonwebtoken");
+    require("dotenv").config();
+    const loginToken = async (phone) => {
+      const r = await api("POST", "/venue-owner/auth", { body: { phone, otp: "000000", referenceId: "dev" } });
+      return r.json && r.json.token;
+    };
+    // listing_manager (single-identity member: listing+availability, NO leads).
+    const lmToken = await loginToken("9700000002");
+    // sales token via 8888888888's member identity (sales: leads only, NO listing).
+    const multi = await api("POST", "/venue-owner/auth", { body: { phone: "8888888888", otp: "000000", referenceId: "dev" } });
+    const memId = (multi.json.identities || []).find((i) => i.kind === "member");
+    const salesSel = await api("POST", "/venue-owner/auth/select-identity", { body: { selectionToken: multi.json.selectionToken, kind: "member", id: memId && memId.id } });
+    const salesToken = salesSel.json && salesSel.json.token;
+    const adminToken = jwt.sign({ _id: "000000000000000000000001", isAdmin: true }, process.env.JWT_SECRET, { expiresIn: "1h" });
+
+    // (b) member listing edit via adminOrVenueOwnerAuth member-token support.
+    const lmPut = await api("PUT", `/venues/${SLUG}`, { token: lmToken, body: { tagline: "lm-edit" } });
+    check("roles: listing_manager listing PUT -> 200", lmPut.status === 200, `status ${lmPut.status}`);
+    const salesPut = await api("PUT", `/venues/${SLUG}`, { token: salesToken, body: { tagline: "sales-edit" } });
+    check("roles: sales listing PUT -> 403 (no listing cap)", salesPut.status === 403, `status ${salesPut.status}`);
+    const adminPut = await api("PUT", `/venues/${SLUG}`, { token: adminToken, body: { tagline: "admin-edit" } });
+    check("roles: admin listing PUT -> 200", adminPut.status === 200, `status ${adminPut.status}`);
+
+    // (a) sheets routes now require leads -> listing_manager 403; open reads -> 200.
+    const lmSheets = await api("GET", `/venues/${SLUG}/integrations/google-sheets`, { token: lmToken });
+    check("roles: listing_manager sheets GET -> 403", lmSheets.status === 403, `status ${lmSheets.status}`);
+    const lmSync = await api("POST", `/venues/${SLUG}/integrations/google-sheets/sync`, { token: lmToken });
+    check("roles: listing_manager sheets sync -> 403", lmSync.status === 403, `status ${lmSync.status}`);
+    const lmBookings = await api("GET", `/venues/${SLUG}/bookings`, { token: lmToken });
+    check("roles: listing_manager bookings GET -> 200 (open read)", lmBookings.status === 200, `status ${lmBookings.status}`);
+    const lmPayments = await api("GET", `/venues/${SLUG}/payments/summary`, { token: lmToken });
+    check("roles: listing_manager payments GET -> 200 (open read)", lmPayments.status === 200, `status ${lmPayments.status}`);
+  }
+
   finish();
 }
 

--- a/scripts/e2e-venue.js
+++ b/scripts/e2e-venue.js
@@ -463,6 +463,7 @@ async function run() {
     // browse filters (public list)
     const byType = await api("GET", `/venues?venueType=banquet_hall&status=published`, {});
     check("couple: browse venueType filter returns matches", byType.status === 200 && Array.isArray(byType.json.venues) && byType.json.venues.every((x) => x.venueType === "banquet_hall"), `n ${byType.json && byType.json.venues && byType.json.venues.length}`);
+    check("couple: browse list items expose isVerified (future-proof cards)", byType.json.venues.length > 0 && byType.json.venues.every((x) => typeof x.isVerified === "boolean"), "");
     const paged = await api("GET", `/venues?limit=1&status=published`, {});
     check("couple: browse pagination (limit=1 + total)", paged.status === 200 && paged.json.venues.length <= 1 && typeof paged.json.total === "number", `n ${paged.json.venues.length} total ${paged.json.total}`);
     // amenity filter: enable evCharging on test-palace, then filter

--- a/scripts/e2e-venue.js
+++ b/scripts/e2e-venue.js
@@ -1,0 +1,190 @@
+/**
+ * scripts/e2e-venue.js
+ *
+ * API-level end-to-end checks for the venue dashboard backend.
+ * Runs against a live local server (default http://localhost:8090) using the
+ * test owner's token (OTP dev-bypass login). Seed first with seed-test-venue.js.
+ *
+ * Prints PASS / FAIL / WARN per check; process exit code is non-zero if any
+ * hard check FAILs. WARN = known main-feature gap, does not fail the suite.
+ *
+ * Usage: node scripts/e2e-venue.js
+ * Env:   API_URL (default http://localhost:8090)
+ */
+const API = process.env.API_URL || "http://localhost:8090";
+const SLUG = "test-palace";
+const OWNER_PHONE = "9999999999";
+
+let pass = 0, fail = 0, warn = 0;
+const results = [];
+function record(status, name, detail) {
+  results.push({ status, name, detail });
+  if (status === "PASS") pass++;
+  else if (status === "FAIL") fail++;
+  else warn++;
+  const tag = status === "PASS" ? "✓ PASS" : status === "FAIL" ? "✗ FAIL" : "! WARN";
+  console.log(`${tag}  ${name}${detail ? ` — ${detail}` : ""}`);
+}
+function check(name, cond, detail) {
+  record(cond ? "PASS" : "FAIL", name, detail);
+  return cond;
+}
+
+async function api(method, path, { token, body } = {}) {
+  const headers = { "Content-Type": "application/json" };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const res = await fetch(`${API}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  let json = null;
+  try { json = await res.json(); } catch (_) {}
+  return { status: res.status, json };
+}
+
+async function login() {
+  // Dev OTP bypass: login accepts otp "000000" with any non-empty referenceId
+  // when NODE_ENV !== "production". Avoids hitting external OTP senders.
+  const { status, json } = await api("POST", "/venue-owner/auth", {
+    body: { phone: OWNER_PHONE, otp: "000000", referenceId: "e2e-dev" },
+  });
+  if (status !== 200 || !json || !json.token) {
+    throw new Error(`login failed (status ${status}): ${JSON.stringify(json)}`);
+  }
+  return json.token;
+}
+
+async function run() {
+  console.log(`[e2e] target ${API}, venue ${SLUG}\n`);
+  let token;
+  try {
+    token = await login();
+    record("PASS", "owner login (OTP dev-bypass) returns token");
+  } catch (e) {
+    record("FAIL", "owner login", e.message);
+    return finish();
+  }
+
+  // --- Check: dashboard overview shape ---
+  {
+    const { status, json } = await api("GET", "/venues/dashboard/overview", { token });
+    const ok = status === 200 && json
+      && json.onboarding && json.onboarding.steps
+      && typeof json.onboarding.completed === "number"
+      && typeof json.onboarding.total === "number"
+      && typeof json.onboarding.percent === "number"
+      && typeof json.isVerified === "boolean"
+      && json.followUps
+      && typeof json.followUps.dueToday === "number"
+      && typeof json.followUps.overdue === "number";
+    check("dashboard overview shape", ok, `status ${status}`);
+  }
+
+  // --- Check: manual lead create ---
+  let manualId = null;
+  {
+    const phone = "9871230001";
+    const { status, json } = await api("POST", `/venues/${SLUG}/enquiries/manual`, {
+      token,
+      body: { coupleName: "E2E Manual Lead", couplePhone: phone, source: "walk_in", stage: "new", estimatedValue: 333000 },
+    });
+    const ok = [200, 201].includes(status) && json && (json.enquiryId || (json.enquiry && json.enquiry._id));
+    manualId = json && (json.enquiryId || (json.enquiry && json.enquiry._id));
+    check("manual lead create", ok, `status ${status}`);
+  }
+
+  // --- Check: import endpoint with one duplicate ---
+  {
+    // 9810000001 is a seeded lead (duplicate -> skipped); the other is new.
+    const rows = [
+      { coupleName: "Import New One", couplePhone: "9822220001", source: "google", stage: "new" },
+      { coupleName: "Import Dup", couplePhone: "9810000001", source: "google", stage: "new" },
+    ];
+    const { status, json } = await api("POST", `/venues/${SLUG}/enquiries/import`, {
+      token,
+      body: { rows, fileName: "e2e-inline.csv" },
+    });
+    const ok = status === 200 && json && json.created >= 1 && json.skipped >= 1;
+    check("import endpoint (created>=1, dup skipped>=1)", ok, `status ${status} created=${json && json.created} skipped=${json && json.skipped}`);
+  }
+
+  // --- Check: interactions create + list ---
+  {
+    // Use the manual lead created above; fall back to first enquiry if needed.
+    let targetId = manualId;
+    if (!targetId) {
+      const list = await api("GET", `/venues/${SLUG}/enquiries`, { token });
+      targetId = list.json && list.json.enquiries && list.json.enquiries[0] && list.json.enquiries[0]._id;
+    }
+    const create = await api("POST", `/venues/${SLUG}/enquiries/${targetId}/interactions`, {
+      token, body: { type: "call", note: "e2e logged call" },
+    });
+    const createdOk = [200, 201].includes(create.status) && create.json && create.json.interaction;
+    const list = await api("GET", `/venues/${SLUG}/enquiries/${targetId}/interactions`, { token });
+    const listedOk = list.status === 200 && Array.isArray(list.json && list.json.interactions)
+      && list.json.interactions.some((i) => i.note === "e2e logged call");
+    check("interaction create", createdOk, `status ${create.status}`);
+    check("interaction list includes created", listedOk, `status ${list.status}`);
+  }
+
+  // --- Check: enquiry PATCH stage move (+ assignedTo) ---
+  {
+    let targetId = manualId;
+    if (!targetId) {
+      const list = await api("GET", `/venues/${SLUG}/enquiries`, { token });
+      targetId = list.json.enquiries[0]._id;
+    }
+    const { status, json } = await api("PATCH", `/venues/${SLUG}/enquiries/${targetId}`, {
+      token, body: { stage: "contacted", assignedTo: "E2E Manager" },
+    });
+    check("enquiry PATCH stage move", status === 200 && json && json.enquiry && json.enquiry.stage === "contacted", `status ${status}`);
+    // assignedTo on the single-enquiry PATCH is NOT supported on main (controller
+    // whitelist omits it). Report as WARN, not a hard failure.
+    if (json && json.enquiry && json.enquiry.assignedTo === "E2E Manager") {
+      record("PASS", "enquiry PATCH assignedTo persisted");
+    } else {
+      record("WARN", "enquiry PATCH assignedTo NOT persisted", "main controller whitelist omits assignedTo — flagged");
+    }
+  }
+
+  // ================= Task B: member login determinism =================
+  if (process.env.E2E_MEMBER_LOGIN === "1") {
+    const MULTI = "8888888888";
+    const r = await api("POST", "/venue-owner/auth", { body: { phone: MULTI, otp: "000000", referenceId: "dev" } });
+    check("member-login: multi-identity returns multiple:true (no token)", r.status === 200 && r.json && r.json.multiple === true && !r.json.token, `status ${r.status}`);
+    const ids = (r.json && r.json.identities) || [];
+    check("member-login: 2 identities (owner + member)", ids.length === 2 && ids.some((i) => i.kind === "owner") && ids.some((i) => i.kind === "member"), `n=${ids.length}`);
+    const selToken = r.json && r.json.selectionToken;
+    check("member-login: selection token issued", Boolean(selToken));
+
+    const ownerId = ids.find((i) => i.kind === "owner");
+    const selO = await api("POST", "/venue-owner/auth/select-identity", { body: { selectionToken: selToken, kind: "owner", id: ownerId && ownerId.id } });
+    const selOvenue = selO.json && selO.json.venueOwner && selO.json.venueOwner.venue;
+    check("member-login: select owner identity mints token (Test Palace Two)", selO.status === 200 && selO.json.token && selOvenue && /Test Palace Two/.test(selOvenue.name || ""), `status ${selO.status}`);
+    const ov = await api("GET", "/venues/dashboard/overview", { token: selO.json && selO.json.token });
+    check("member-login: minted owner token authorizes dashboard", ov.status === 200, `status ${ov.status}`);
+
+    const memId = ids.find((i) => i.kind === "member");
+    const selM = await api("POST", "/venue-owner/auth/select-identity", { body: { selectionToken: selToken, kind: "member", id: memId && memId.id } });
+    check("member-login: select member identity mints member token", selM.status === 200 && selM.json.token && selM.json.venueOwner && selM.json.venueOwner.isMember === true, `status ${selM.status}`);
+
+    const bad = await api("POST", "/venue-owner/auth/select-identity", { body: { selectionToken: selToken, kind: "owner", id: "000000000000000000000000" } });
+    check("member-login: unoffered identity -> 403", bad.status === 403, `status ${bad.status}`);
+
+    const single = await api("POST", "/venue-owner/auth", { body: { phone: OWNER_PHONE, otp: "000000", referenceId: "dev" } });
+    check("member-login: single-identity returns token directly (no picker)", single.status === 200 && single.json.token && !single.json.multiple, `status ${single.status}`);
+  }
+
+  finish();
+}
+
+function finish() {
+  console.log(`\n[e2e] ${pass} passed, ${fail} failed, ${warn} warn`);
+  process.exit(fail > 0 ? 1 : 0);
+}
+
+run().catch((e) => {
+  console.error("[e2e] crashed:", e);
+  process.exit(1);
+});

--- a/scripts/e2e-venue.js
+++ b/scripts/e2e-venue.js
@@ -429,6 +429,50 @@ async function run() {
     check("roles: listing_manager payments GET -> 200 (open read)", lmPayments.status === 200, `status ${lmPayments.status}`);
   }
 
+  // ================= Couple-side: isVerified, view beacon, availability, browse =================
+  if (process.env.E2E_COUPLE === "1") {
+    // isVerified on public detail (derived from status; test-palace is published -> false)
+    const det = await api("GET", `/venues/${SLUG}`, {});
+    check("couple: public detail exposes isVerified (false for published)", det.status === 200 && det.json.isVerified === false && det.json.venue, `isVerified ${det.json && det.json.isVerified}`);
+
+    // view beacon (public) increments analytics views + conversion shape
+    const beforeAn = await api("GET", `/venues/${SLUG}/analytics`, { token });
+    const beforeViews = beforeAn.json.traffic ? beforeAn.json.traffic.views : -1;
+    const v = await api("POST", `/venues/${SLUG}/view`, {});
+    check("couple: public view beacon -> 200", v.status === 200, `status ${v.status}`);
+    // The beacon is fire-and-forget (writes AFTER responding) — poll for the async write.
+    let tr = null;
+    for (let i = 0; i < 15; i++) {
+      const a = await api("GET", `/venues/${SLUG}/analytics`, { token });
+      tr = a.json.traffic;
+      if (tr && tr.views > beforeViews) break;
+      await new Promise((r) => setTimeout(r, 150));
+    }
+    check("couple: analytics traffic shape {views,enquiries,conversionRate}", tr && typeof tr.views === "number" && typeof tr.enquiries === "number" && typeof tr.conversionRate === "number", JSON.stringify(tr));
+    check("couple: view recorded (views >= 1)", tr && tr.views >= 1, `views ${tr && tr.views}`);
+
+    // availability-check: block a date, then query
+    await api("POST", `/venues/${SLUG}/availability`, { token, body: { blockedDates: ["2027-01-01"] } });
+    const unavail = await api("GET", `/venues/${SLUG}/availability-check?date=2027-01-01`, {});
+    check("couple: availability-check blocked date -> unavailable", unavail.status === 200 && unavail.json.status === "unavailable", `status ${unavail.json && unavail.json.status}`);
+    const avail = await api("GET", `/venues/${SLUG}/availability-check?date=2027-06-15`, {});
+    check("couple: availability-check free date -> available", avail.status === 200 && avail.json.status === "available", `status ${avail.json && avail.json.status}`);
+    const badDate = await api("GET", `/venues/${SLUG}/availability-check?date=31-02-2026`, {});
+    check("couple: availability-check invalid date -> 400", badDate.status === 400, `status ${badDate.status}`);
+
+    // browse filters (public list)
+    const byType = await api("GET", `/venues?venueType=banquet_hall&status=published`, {});
+    check("couple: browse venueType filter returns matches", byType.status === 200 && Array.isArray(byType.json.venues) && byType.json.venues.every((x) => x.venueType === "banquet_hall"), `n ${byType.json && byType.json.venues && byType.json.venues.length}`);
+    const paged = await api("GET", `/venues?limit=1&status=published`, {});
+    check("couple: browse pagination (limit=1 + total)", paged.status === 200 && paged.json.venues.length <= 1 && typeof paged.json.total === "number", `n ${paged.json.venues.length} total ${paged.json.total}`);
+    // amenity filter: enable evCharging on test-palace, then filter
+    await api("PUT", `/venues/${SLUG}`, { token, body: { amenities: { evCharging: true } } });
+    const byAmenity = await api("GET", `/venues?amenities=evCharging&status=published`, {});
+    const hasTP = (byAmenity.json.venues || []).some((x) => x.slug === SLUG);
+    check("couple: browse amenities=evCharging includes the toggled venue", byAmenity.status === 200 && hasTP, `found ${hasTP}`);
+    await api("PUT", `/venues/${SLUG}`, { token, body: { amenities: { evCharging: false } } });
+  }
+
   finish();
 }
 

--- a/scripts/e2e-venue.js
+++ b/scripts/e2e-venue.js
@@ -474,6 +474,20 @@ async function run() {
     await api("PUT", `/venues/${SLUG}`, { token, body: { amenities: { evCharging: false } } });
   }
 
+  // ================= Public-route rate limiting (callback + generate-location) =================
+  // Run on a freshly-started server (publicReadLimiter counters reset on restart).
+  if (process.env.E2E_PUBLIC_RATELIMIT === "1") {
+    // Burst the public sheets OAuth callback past the per-IP publicReadLimiter.
+    const burst = await Promise.all(Array.from({ length: 75 }, () =>
+      api("GET", `/venues/${SLUG}/integrations/google-sheets/callback`, {})));
+    const statuses = [...new Set(burst.map((r) => r.status))];
+    check("public-ratelimit: sheets callback burst -> 429 present", burst.some((r) => r.status === 429), `statuses ${statuses.join(",")}`);
+    // The per-IP bucket (shared across publicReadLimiter routes) is now exhausted,
+    // so generate-location-description 429s at the limiter — BEFORE invoking Anthropic.
+    const gen = await api("POST", `/venues/${SLUG}/generate-location-description`, {});
+    check("public-ratelimit: generate-location-description over-limit -> 429 (no Anthropic call)", gen.status === 429, `status ${gen.status}`);
+  }
+
   finish();
 }
 

--- a/scripts/e2e-venue.js
+++ b/scripts/e2e-venue.js
@@ -90,6 +90,27 @@ async function run() {
     check("dashboard overview shape", ok, `status ${status}`);
   }
 
+  // ================= Task 8 (Analytics 4.1) — runs FIRST, against pristine seed =================
+  if (process.env.E2E_ANALYTICS === "1") {
+    const { status, json } = await api("GET", `/venues/${SLUG}/analytics`, { token });
+    check("analytics: total === 20 (seed)", status === 200 && json.total === 20, `total ${json && json.total}`);
+    const volSum = (json.volume && json.volume.byMonth || []).reduce((s, r) => s + r.count, 0);
+    check("analytics: volume byMonth sums to 20", volSum === 20, `sum ${volSum}`);
+    check("analytics: funnel new=20 / site_visit_done=9 / booked=2",
+      json.funnel && json.funnel.new === 20 && json.funnel.site_visit_done === 9 && json.funnel.booked === 2,
+      json.funnel && `new=${json.funnel.new} svd=${json.funnel.site_visit_done} booked=${json.funnel.booked}`);
+    check("analytics: funnel bookingRate = 10%", json.funnel && json.funnel.conversion.bookingRate === 10, json.funnel && `${json.funnel.conversion.bookingRate}`);
+    const wedsy = (json.sources || []).find((s) => s.source === "wedsy");
+    const srcSum = (json.sources || []).reduce((s, r) => s + r.count, 0);
+    check("analytics: 8 sources, sum 20, wedsy count 3", json.sources.length === 8 && srcSum === 20 && wedsy && wedsy.count === 3, `len ${json.sources.length} sum ${srcSum} wedsy ${wedsy && wedsy.count}`);
+    const lostTotal = (json.lostReasons || []).reduce((s, r) => s + r.count, 0);
+    check("analytics: lost reasons total 2 (too_expensive + chose_competitor)", lostTotal === 2 && json.lostReasons.length === 2, `total ${lostTotal}`);
+    check("analytics: revenue.byMonth is array, responseTime omitted (null)", Array.isArray(json.revenue.byMonth) && json.responseTime === null);
+  }
+
+  // The remaining checks mutate data, so when running analytics-only we stop here.
+  if (process.env.E2E_ANALYTICS_ONLY === "1") return finish();
+
   // --- Check: manual lead create ---
   let manualId = null;
   {

--- a/scripts/e2e-venue.js
+++ b/scripts/e2e-venue.js
@@ -1,0 +1,267 @@
+/**
+ * scripts/e2e-venue.js
+ *
+ * API-level end-to-end checks for the venue dashboard backend.
+ * Runs against a live local server (default http://localhost:8090) using the
+ * test owner's token (OTP dev-bypass login). Seed first with seed-test-venue.js.
+ *
+ * Prints PASS / FAIL / WARN per check; process exit code is non-zero if any
+ * hard check FAILs. WARN = known main-feature gap, does not fail the suite.
+ *
+ * Usage: node scripts/e2e-venue.js
+ * Env:   API_URL (default http://localhost:8090)
+ */
+const API = process.env.API_URL || "http://localhost:8090";
+const SLUG = "test-palace";
+const OWNER_PHONE = "9999999999";
+
+let pass = 0, fail = 0, warn = 0;
+const results = [];
+function record(status, name, detail) {
+  results.push({ status, name, detail });
+  if (status === "PASS") pass++;
+  else if (status === "FAIL") fail++;
+  else warn++;
+  const tag = status === "PASS" ? "✓ PASS" : status === "FAIL" ? "✗ FAIL" : "! WARN";
+  console.log(`${tag}  ${name}${detail ? ` — ${detail}` : ""}`);
+}
+function check(name, cond, detail) {
+  record(cond ? "PASS" : "FAIL", name, detail);
+  return cond;
+}
+
+async function api(method, path, { token, body } = {}) {
+  const headers = { "Content-Type": "application/json" };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const res = await fetch(`${API}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  let json = null;
+  try { json = await res.json(); } catch (_) {}
+  return { status: res.status, json };
+}
+
+// Fetch a binary endpoint (e.g. PDF). Returns { status, contentType, bytes, head }.
+async function apiBinary(path, { token } = {}) {
+  const headers = {};
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const res = await fetch(`${API}${path}`, { method: "GET", headers });
+  const buf = Buffer.from(await res.arrayBuffer());
+  return { status: res.status, contentType: res.headers.get("content-type") || "", bytes: buf.length, head: buf.slice(0, 5).toString("latin1") };
+}
+
+async function login() {
+  // Dev OTP bypass: login accepts otp "000000" with any non-empty referenceId
+  // when NODE_ENV !== "production". Avoids hitting external OTP senders.
+  const { status, json } = await api("POST", "/venue-owner/auth", {
+    body: { phone: OWNER_PHONE, otp: "000000", referenceId: "e2e-dev" },
+  });
+  if (status !== 200 || !json || !json.token) {
+    throw new Error(`login failed (status ${status}): ${JSON.stringify(json)}`);
+  }
+  return json.token;
+}
+
+async function run() {
+  console.log(`[e2e] target ${API}, venue ${SLUG}\n`);
+  let token;
+  try {
+    token = await login();
+    record("PASS", "owner login (OTP dev-bypass) returns token");
+  } catch (e) {
+    record("FAIL", "owner login", e.message);
+    return finish();
+  }
+
+  // --- Check: dashboard overview shape ---
+  {
+    const { status, json } = await api("GET", "/venues/dashboard/overview", { token });
+    const ok = status === 200 && json
+      && json.onboarding && json.onboarding.steps
+      && typeof json.onboarding.completed === "number"
+      && typeof json.onboarding.total === "number"
+      && typeof json.onboarding.percent === "number"
+      && typeof json.isVerified === "boolean"
+      && json.followUps
+      && typeof json.followUps.dueToday === "number"
+      && typeof json.followUps.overdue === "number";
+    check("dashboard overview shape", ok, `status ${status}`);
+  }
+
+  // --- Check: manual lead create ---
+  let manualId = null;
+  {
+    const phone = "9871230001";
+    const { status, json } = await api("POST", `/venues/${SLUG}/enquiries/manual`, {
+      token,
+      body: { coupleName: "E2E Manual Lead", couplePhone: phone, source: "walk_in", stage: "new", estimatedValue: 333000 },
+    });
+    const ok = [200, 201].includes(status) && json && (json.enquiryId || (json.enquiry && json.enquiry._id));
+    manualId = json && (json.enquiryId || (json.enquiry && json.enquiry._id));
+    check("manual lead create", ok, `status ${status}`);
+  }
+
+  // --- Check: import endpoint with one duplicate ---
+  {
+    // 9810000001 is a seeded lead (duplicate -> skipped); the other is new.
+    const rows = [
+      { coupleName: "Import New One", couplePhone: "9822220001", source: "google", stage: "new" },
+      { coupleName: "Import Dup", couplePhone: "9810000001", source: "google", stage: "new" },
+    ];
+    const { status, json } = await api("POST", `/venues/${SLUG}/enquiries/import`, {
+      token,
+      body: { rows, fileName: "e2e-inline.csv" },
+    });
+    const ok = status === 200 && json && json.created >= 1 && json.skipped >= 1;
+    check("import endpoint (created>=1, dup skipped>=1)", ok, `status ${status} created=${json && json.created} skipped=${json && json.skipped}`);
+  }
+
+  // --- Check: interactions create + list ---
+  {
+    // Use the manual lead created above; fall back to first enquiry if needed.
+    let targetId = manualId;
+    if (!targetId) {
+      const list = await api("GET", `/venues/${SLUG}/enquiries`, { token });
+      targetId = list.json && list.json.enquiries && list.json.enquiries[0] && list.json.enquiries[0]._id;
+    }
+    const create = await api("POST", `/venues/${SLUG}/enquiries/${targetId}/interactions`, {
+      token, body: { type: "call", note: "e2e logged call" },
+    });
+    const createdOk = [200, 201].includes(create.status) && create.json && create.json.interaction;
+    const list = await api("GET", `/venues/${SLUG}/enquiries/${targetId}/interactions`, { token });
+    const listedOk = list.status === 200 && Array.isArray(list.json && list.json.interactions)
+      && list.json.interactions.some((i) => i.note === "e2e logged call");
+    check("interaction create", createdOk, `status ${create.status}`);
+    check("interaction list includes created", listedOk, `status ${list.status}`);
+  }
+
+  // --- Check: enquiry PATCH stage move (+ assignedTo) ---
+  {
+    let targetId = manualId;
+    if (!targetId) {
+      const list = await api("GET", `/venues/${SLUG}/enquiries`, { token });
+      targetId = list.json.enquiries[0]._id;
+    }
+    const { status, json } = await api("PATCH", `/venues/${SLUG}/enquiries/${targetId}`, {
+      token, body: { stage: "contacted", assignedTo: "E2E Manager" },
+    });
+    check("enquiry PATCH stage move", status === 200 && json && json.enquiry && json.enquiry.stage === "contacted", `status ${status}`);
+    // assignedTo on the single-enquiry PATCH is NOT supported on main (controller
+    // whitelist omits it). Report as WARN, not a hard failure.
+    if (json && json.enquiry && json.enquiry.assignedTo === "E2E Manager") {
+      record("PASS", "enquiry PATCH assignedTo persisted");
+    } else {
+      record("WARN", "enquiry PATCH assignedTo NOT persisted", "main controller whitelist omits assignedTo — flagged");
+    }
+  }
+
+  // ================= Task 7 (Phase 3): lost reason, bookings, quotes, invoices, payments =================
+  if (process.env.E2E_PHASE3 === "1") {
+    const mk = async (name, estimatedValue) => {
+      const r = await api("POST", `/venues/${SLUG}/enquiries/manual`, {
+        token, body: { coupleName: name, couplePhone: `98${Math.floor(Math.random() * 1e8)}`.slice(0, 10), estimatedValue },
+      });
+      return r.json && (r.json.enquiryId || (r.json.enquiry && r.json.enquiry._id));
+    };
+
+    // 7a — lost reason
+    {
+      const L = await mk("P3 Lost", 100000);
+      const ok = await api("PATCH", `/venues/${SLUG}/enquiries/${L}`, { token, body: { stage: "lost", lostReason: "too_expensive" } });
+      check("7a lost reason set", ok.status === 200 && ok.json.enquiry.lostReason === "too_expensive", `status ${ok.status}`);
+      const bad = await api("PATCH", `/venues/${SLUG}/enquiries/${L}`, { token, body: { lostReason: "banana" } });
+      check("7a invalid lostReason -> 400", bad.status === 400, `status ${bad.status}`);
+    }
+
+    // 7b — booked -> auto-booking (idempotent)
+    let bookingBV = null;
+    const B = await mk("P3 Booked", 200000);
+    {
+      const r1 = await api("PATCH", `/venues/${SLUG}/enquiries/${B}`, { token, body: { stage: "booked" } });
+      check("7b booked PATCH returns booking", r1.status === 200 && r1.json.booking && r1.json.booking._id, `status ${r1.status}`);
+      const list1 = await api("GET", `/venues/${SLUG}/bookings`, { token });
+      const forB = list1.json.bookings.filter((b) => String(b.enquiry) === String(B));
+      bookingBV = forB[0] && forB[0]._id;
+      check("7b exactly one booking for enquiry", forB.length === 1, `count ${forB.length}`);
+      // idempotent: re-book
+      await api("PATCH", `/venues/${SLUG}/enquiries/${B}`, { token, body: { stage: "negotiating" } });
+      await api("PATCH", `/venues/${SLUG}/enquiries/${B}`, { token, body: { stage: "booked" } });
+      const list2 = await api("GET", `/venues/${SLUG}/bookings`, { token });
+      check("7b auto-booking idempotent (still one)", list2.json.bookings.filter((b) => String(b.enquiry) === String(B)).length === 1);
+    }
+
+    // 7c — quote create/version/totals/pdf + accept->booking
+    let quoteV2 = null, bookingQV = null;
+    const Q = await mk("P3 Quote", 0);
+    {
+      const c1 = await api("POST", `/venues/${SLUG}/quotes`, {
+        token, body: { enquiry: Q, lineItems: [{ label: "Venue hire", category: "venue_hire", qty: 1, unitPrice: 100000 }], gstPercent: 18, discount: 5000 },
+      });
+      const t = c1.json.quote && c1.json.quote.totals;
+      check("7c quote v1 totals (100000 / 18% / -5000 => 17100 / 112100)",
+        c1.status === 201 && c1.json.quote.version === 1 && t.subtotal === 100000 && t.gst === 17100 && t.grandTotal === 112100,
+        t && `subtotal=${t.subtotal} gst=${t.gst} grand=${t.grandTotal}`);
+      const c2 = await api("POST", `/venues/${SLUG}/quotes`, {
+        token, body: { enquiry: Q, lineItems: [{ label: "Venue hire", qty: 1, unitPrice: 100000 }], gstPercent: 18, discount: 5000 },
+      });
+      quoteV2 = c2.json.quote && c2.json.quote._id;
+      check("7c new version supersedes prior", c2.json.quote.version === 2, `version ${c2.json.quote && c2.json.quote.version}`);
+      const listQ = await api("GET", `/venues/${SLUG}/quotes?enquiry=${Q}`, { token });
+      const v1 = listQ.json.quotes.find((x) => x.version === 1);
+      check("7c prior version marked superseded", v1 && v1.status === "superseded", v1 && v1.status);
+      const pdf = await apiBinary(`/venues/${SLUG}/quotes/${quoteV2}/pdf`, { token });
+      check("7c quote PDF returns bytes", pdf.status === 200 && pdf.contentType.includes("pdf") && pdf.bytes > 500 && pdf.head.startsWith("%PDF"), `bytes=${pdf.bytes} ct=${pdf.contentType}`);
+      const acc = await api("PATCH", `/venues/${SLUG}/quotes/${quoteV2}`, { token, body: { status: "accepted" } });
+      bookingQV = acc.json.booking && acc.json.booking._id;
+      check("7c accept quote -> booking (totalValue=grandTotal)", acc.status === 200 && acc.json.booking && acc.json.booking.totalValue === 112100, `tv=${acc.json.booking && acc.json.booking.totalValue}`);
+    }
+
+    // 7d — invoices: number increment, payments, status transitions, pdf
+    {
+      const i1 = await api("POST", `/venues/${SLUG}/invoices`, { token, body: { booking: bookingBV, kind: "advance" } });
+      check("7d invoice create from booking", i1.status === 201 && i1.json.invoice.invoiceNumber, `#${i1.json.invoice && i1.json.invoice.invoiceNumber}`);
+      const i1seq = i1.json.invoice.seq;
+      const i1grand = i1.json.invoice.totals.grandTotal; // 200000 + 18% = 236000
+      check("7d invoice totals from booking (200000 => 236000)", i1.json.invoice.totals.subtotal === 200000 && i1grand === 236000, `grand=${i1grand}`);
+      const i2 = await api("POST", `/venues/${SLUG}/invoices`, { token, body: { booking: bookingQV } });
+      check("7d invoice number increments", i2.json.invoice.seq === i1seq + 1, `seq ${i1seq} -> ${i2.json.invoice.seq}`);
+
+      const invId = i1.json.invoice._id;
+      const p1 = await api("POST", `/venues/${SLUG}/invoices/${invId}/payments`, { token, body: { amount: 100000, mode: "upi" } });
+      check("7d partial payment -> partially_paid", p1.status === 200 && p1.json.invoice.status === "partially_paid" && p1.json.balance === 136000, `status=${p1.json.invoice.status} bal=${p1.json.balance}`);
+      const p2 = await api("POST", `/venues/${SLUG}/invoices/${invId}/payments`, { token, body: { amount: 136000, mode: "bank_transfer" } });
+      check("7d final payment -> paid (balance 0)", p2.status === 200 && p2.json.invoice.status === "paid" && p2.json.balance === 0, `status=${p2.json.invoice.status} bal=${p2.json.balance}`);
+      const pdf = await apiBinary(`/venues/${SLUG}/invoices/${invId}/pdf`, { token });
+      check("7d invoice PDF returns bytes", pdf.status === 200 && pdf.contentType.includes("pdf") && pdf.bytes > 500 && pdf.head.startsWith("%PDF"), `bytes=${pdf.bytes}`);
+    }
+
+    // 7e — payments summary math + overview revenue
+    {
+      const s = await api("GET", `/venues/${SLUG}/payments/summary`, { token });
+      const t = s.json.totals;
+      // confirmed = 200000 (BV) + 112100 (QV) = 312100 ; received = 236000 (BV invoice) ; pending = 76100
+      check("7e payments summary math (312100 / 236000 / 76100)",
+        s.status === 200 && t.confirmedValue === 312100 && t.received === 236000 && t.pending === 76100,
+        `confirmed=${t.confirmedValue} received=${t.received} pending=${t.pending}`);
+      const ov = await api("GET", `/venues/dashboard/overview`, { token });
+      const r = ov.json.revenue;
+      check("7e overview revenue shape + matches summary",
+        r && r.confirmedValue === 312100 && r.received === 236000 && r.pending === 76100,
+        r && `confirmed=${r.confirmedValue} received=${r.received} pending=${r.pending}`);
+    }
+  }
+
+  finish();
+}
+
+function finish() {
+  console.log(`\n[e2e] ${pass} passed, ${fail} failed, ${warn} warn`);
+  process.exit(fail > 0 ? 1 : 0);
+}
+
+run().catch((e) => {
+  console.error("[e2e] crashed:", e);
+  process.exit(1);
+});

--- a/scripts/migrate-lostreason-cleanup.js
+++ b/scripts/migrate-lostreason-cleanup.js
@@ -1,0 +1,65 @@
+/**
+ * scripts/migrate-lostreason-cleanup.js
+ *
+ * Unset VenueEnquiry.lostReason on docs where it is the empty string "".
+ * Phase 3 tightened lostReason to an enum (with "" tolerated for legacy data);
+ * this removes the noisy empty-string values so only real reasons remain.
+ *
+ * SAFETY: refuses to run unless DATABASE_URL points at a local Mongo host
+ * (same guard as scripts/seed-test-venue.js).
+ *
+ * Usage:
+ *   node scripts/migrate-lostreason-cleanup.js           # dry-run (default)
+ *   node scripts/migrate-lostreason-cleanup.js --apply   # perform the $unset
+ */
+require("dotenv").config();
+const mongoose = require("mongoose");
+const VenueEnquiry = require("../models/VenueEnquiry");
+
+const LOCAL_HOSTS = new Set(["127.0.0.1", "localhost", "::1", "0.0.0.0"]);
+const APPLY = process.argv.includes("--apply");
+
+function assertLocalMongo() {
+  const url = process.env.DATABASE_URL || "";
+  let host;
+  try {
+    host = new URL(url).hostname;
+  } catch (e) {
+    throw new Error(`Cannot parse DATABASE_URL to verify host: ${e.message}`);
+  }
+  if (!LOCAL_HOSTS.has(host)) {
+    throw new Error(
+      `Refusing to run: DATABASE_URL host "${host}" is not local. ` +
+        `This migration only runs against a local dev Mongo (127.0.0.1/localhost).`
+    );
+  }
+  return host;
+}
+
+async function run() {
+  const host = assertLocalMongo();
+  await mongoose.connect(process.env.DATABASE_URL, { serverSelectionTimeoutMS: 8000 });
+  console.log(`[migrate-lostreason] connected to local Mongo @ ${host} (${APPLY ? "APPLY" : "DRY-RUN"})`);
+
+  const filter = { lostReason: "" };
+  const count = await VenueEnquiry.countDocuments(filter);
+  console.log(`[migrate-lostreason] ${count} enquiries have lostReason === ""`);
+
+  if (!APPLY) {
+    console.log("[migrate-lostreason] DRY-RUN — no changes written. Re-run with --apply to unset them.");
+  } else if (count > 0) {
+    const res = await VenueEnquiry.updateMany(filter, { $unset: { lostReason: "" } });
+    console.log(`[migrate-lostreason] unset lostReason on ${res.modifiedCount} enquiries.`);
+  } else {
+    console.log("[migrate-lostreason] nothing to do.");
+  }
+
+  await mongoose.disconnect();
+  console.log("[migrate-lostreason] DONE");
+}
+
+run().catch(async (err) => {
+  console.error("[migrate-lostreason] FAILED:", err.message);
+  try { await mongoose.disconnect(); } catch (_) {}
+  process.exit(1);
+});

--- a/scripts/seed-test-venue.js
+++ b/scripts/seed-test-venue.js
@@ -1,0 +1,189 @@
+/**
+ * scripts/seed-test-venue.js
+ *
+ * Idempotent LOCAL seed for the venue test harness.
+ * Creates / resets one published test venue ("Test Palace", slug "test-palace"),
+ * one VenueOwner (phone 9999999999), ~20 VenueEnquiry leads spread across all 8
+ * stages and all sources with a mix of follow-up dates (overdue / today / future),
+ * and a few VenueLeadInteractions.
+ *
+ * SAFETY: hard-refuses to run unless DATABASE_URL points at a local Mongo host.
+ * Usage: node scripts/seed-test-venue.js
+ */
+require("dotenv").config();
+const mongoose = require("mongoose");
+
+const Venue = require("../models/Venue");
+const VenueOwner = require("../models/VenueOwner");
+const VenueEnquiry = require("../models/VenueEnquiry");
+const VenueLeadInteraction = require("../models/VenueLeadInteraction");
+
+const LOCAL_HOSTS = new Set(["127.0.0.1", "localhost", "::1", "0.0.0.0"]);
+
+// Stable identifiers other harness scripts (e2e) rely on.
+const VENUE_SLUG = "test-palace";
+const OWNER_PHONE = "9999999999";
+
+function assertLocalMongo() {
+  const url = process.env.DATABASE_URL || "";
+  let host;
+  try {
+    host = new URL(url).hostname;
+  } catch (e) {
+    throw new Error(`Cannot parse DATABASE_URL to verify host: ${e.message}`);
+  }
+  if (!LOCAL_HOSTS.has(host)) {
+    throw new Error(
+      `Refusing to seed: DATABASE_URL host "${host}" is not local. ` +
+        `This script only runs against a local dev Mongo (127.0.0.1/localhost).`
+    );
+  }
+  return host;
+}
+
+// Date helpers relative to "now" — script run time, not a fixed value.
+const DAY = 24 * 60 * 60 * 1000;
+const now = new Date();
+function daysFromNow(n) {
+  return new Date(now.getTime() + n * DAY);
+}
+function todayAt(hour) {
+  const d = new Date(now);
+  d.setHours(hour, 0, 0, 0);
+  return d;
+}
+
+// Deterministic 20-lead dataset. fu = followUpDate intent: "overdue" | "today" | "future" | null
+// Stages: new x4, contacted x3, site_visit_scheduled x2, site_visit_done x3,
+//         proposal_sent x2, negotiating x2, booked x2, lost x2  => 20 total.
+const LEAD_SPECS = [
+  { coupleName: "Aarav & Diya",      couplePhone: "9810000001", source: "wedsy",     stage: "new",                  fu: "overdue", estimatedValue: 450000 },
+  { coupleName: "Vivaan & Anika",    couplePhone: "9810000002", source: "instagram", stage: "new",                  fu: "today",   estimatedValue: 520000 },
+  { coupleName: "Aditya & Ira",      couplePhone: "9810000003", source: "referral",  stage: "new",                  fu: "future",  estimatedValue: 380000 },
+  { coupleName: "Reyansh & Myra",    couplePhone: "9810000004", source: "walk_in",   stage: "new",                  fu: null,      estimatedValue: 600000 },
+  { coupleName: "Arjun & Saanvi",    couplePhone: "9810000005", source: "justdial",  stage: "contacted",            fu: "overdue", estimatedValue: 710000 },
+  { coupleName: "Vihaan & Aadhya",   couplePhone: "9810000006", source: "wedmegood", stage: "contacted",            fu: "today",   estimatedValue: 480000 },
+  { coupleName: "Krishna & Pari",    couplePhone: "9810000007", source: "google",    stage: "contacted",            fu: "future",  estimatedValue: 550000 },
+  { coupleName: "Ishaan & Anaya",    couplePhone: "9810000008", source: "other",     stage: "site_visit_scheduled", fu: "today",   estimatedValue: 640000 },
+  { coupleName: "Shaurya & Aarohi",  couplePhone: "9810000009", source: "wedsy",     stage: "site_visit_scheduled", fu: "future",  estimatedValue: 720000 },
+  { coupleName: "Atharv & Kiara",    couplePhone: "9810000010", source: "instagram", stage: "site_visit_done",      fu: "overdue", estimatedValue: 900000 },
+  { coupleName: "Advik & Navya",     couplePhone: "9810000011", source: "referral",  stage: "site_visit_done",      fu: "today",   estimatedValue: 810000 },
+  { coupleName: "Kabir & Riya",      couplePhone: "9810000012", source: "walk_in",   stage: "site_visit_done",      fu: "future",  estimatedValue: 770000 },
+  { coupleName: "Aryan & Sara",      couplePhone: "9810000013", source: "justdial",  stage: "proposal_sent",        fu: "overdue", estimatedValue: 1000000 },
+  { coupleName: "Dhruv & Aisha",     couplePhone: "9810000014", source: "wedmegood", stage: "proposal_sent",        fu: "future",  estimatedValue: 950000 },
+  { coupleName: "Veer & Tara",       couplePhone: "9810000015", source: "google",    stage: "negotiating",          fu: "today",   estimatedValue: 1100000 },
+  { coupleName: "Rudra & Mishka",    couplePhone: "9810000016", source: "other",     stage: "negotiating",          fu: "future",  estimatedValue: 1250000 },
+  { coupleName: "Shivansh & Zara",   couplePhone: "9810000017", source: "wedsy",     stage: "booked",               fu: null,      estimatedValue: 1300000 },
+  { coupleName: "Ayaan & Anvi",      couplePhone: "9810000018", source: "instagram", stage: "booked",               fu: null,      estimatedValue: 1450000 },
+  { coupleName: "Yuvaan & Siya",     couplePhone: "9810000019", source: "referral",  stage: "lost",                 fu: null,      estimatedValue: 500000, lostReason: "too_expensive" },
+  { coupleName: "Reyaan & Pihu",     couplePhone: "9810000020", source: "walk_in",   stage: "lost",                 fu: null,      estimatedValue: 470000, lostReason: "chose_competitor" },
+];
+
+function resolveFollowUp(intent) {
+  if (intent === "overdue") return daysFromNow(-3);
+  if (intent === "today") return todayAt(11);
+  if (intent === "future") return daysFromNow(7);
+  return null;
+}
+
+async function run() {
+  const host = assertLocalMongo();
+  await mongoose.connect(process.env.DATABASE_URL, { serverSelectionTimeoutMS: 8000 });
+  console.log(`[seed] connected to local Mongo @ ${host}`);
+
+  // 1. Venue (upsert by slug). Set a handful of profile fields so the dashboard
+  //    onboarding/overview endpoint returns a meaningful shape.
+  let venue = await Venue.findOne({ slug: VENUE_SLUG });
+  const venueDefaults = {
+    name: "Test Palace",
+    slug: VENUE_SLUG,
+    status: "published",
+    city: "Bangalore",
+    venueType: "banquet_hall",
+    contact: { primaryName: "Test Owner", primaryPhone: OWNER_PHONE, whatsappPhone: OWNER_PHONE, email: "owner@test-palace.local" },
+    pricing: { currency: "INR", perPlate: { veg: 1500, nonVeg: 1900 }, tiers: [{ hours: 12, price: 250000 }] },
+    coverPhoto: "https://example.local/test-palace-cover.jpg",
+  };
+  if (!venue) {
+    venue = await Venue.create(venueDefaults);
+    console.log(`[seed] created venue ${venue.slug} (${venue._id})`);
+  } else {
+    Object.assign(venue, venueDefaults);
+    await venue.save();
+    console.log(`[seed] reset venue ${venue.slug} (${venue._id})`);
+  }
+
+  // 2. Owner (upsert by phone). role owner, phone-verified so dashboard treats it as a real account.
+  let owner = await VenueOwner.findOne({ phone: OWNER_PHONE });
+  const ownerDefaults = {
+    name: "Test Owner",
+    phone: OWNER_PHONE,
+    email: "owner@test-palace.local",
+    role: "owner",
+    venueId: venue._id,
+    verificationStatus: "phone_verified",
+    isActive: true,
+  };
+  if (!owner) {
+    owner = await VenueOwner.create(ownerDefaults);
+    console.log(`[seed] created owner ${owner.phone} (${owner._id})`);
+  } else {
+    Object.assign(owner, ownerDefaults);
+    await owner.save();
+    console.log(`[seed] reset owner ${owner.phone} (${owner._id})`);
+  }
+
+  // 3. Reset enquiries + interactions for this venue (idempotent rebuild).
+  await VenueLeadInteraction.deleteMany({ venue: venue._id });
+  await VenueEnquiry.deleteMany({ venueId: venue._id });
+
+  const enquiries = [];
+  for (const spec of LEAD_SPECS) {
+    const fu = resolveFollowUp(spec.fu);
+    const doc = await VenueEnquiry.create({
+      venueId: venue._id,
+      coupleName: spec.coupleName,
+      couplePhone: spec.couplePhone,
+      name: spec.coupleName,
+      phone: spec.couplePhone,
+      email: `${spec.couplePhone}@leads.test-palace.local`,
+      eventDate: daysFromNow(60),
+      guestCount: 300,
+      source: spec.source,
+      stage: spec.stage,
+      estimatedValue: spec.estimatedValue,
+      lostReason: spec.lostReason || "",
+      followUpDate: fu,
+      activities: [{ type: "created", description: "Seeded lead", timestamp: now }],
+    });
+    enquiries.push(doc);
+  }
+  console.log(`[seed] created ${enquiries.length} enquiries across all 8 stages / 8 sources`);
+
+  // 4. A few interactions on the first three leads.
+  const interactionSeeds = [
+    { idx: 0, type: "enquiry", note: "Inbound enquiry from website" },
+    { idx: 0, type: "call", note: "Called couple, discussed dates" },
+    { idx: 1, type: "whatsapp", note: "Sent brochure on WhatsApp" },
+    { idx: 4, type: "site_visit", note: "Site visit scheduled for next week" },
+  ];
+  for (const s of interactionSeeds) {
+    await VenueLeadInteraction.create({
+      enquiry: enquiries[s.idx]._id,
+      venue: venue._id,
+      type: s.type,
+      note: s.note,
+      createdBy: s.type === "enquiry" ? null : owner._id,
+    });
+  }
+  console.log(`[seed] created ${interactionSeeds.length} interactions`);
+
+  console.log("[seed] DONE");
+  await mongoose.disconnect();
+}
+
+run().catch(async (err) => {
+  console.error("[seed] FAILED:", err.message);
+  try { await mongoose.disconnect(); } catch (_) {}
+  process.exit(1);
+});

--- a/scripts/seed-test-venue.js
+++ b/scripts/seed-test-venue.js
@@ -1,0 +1,198 @@
+/**
+ * scripts/seed-test-venue.js
+ *
+ * Idempotent LOCAL seed for the venue test harness.
+ * Creates / resets one published test venue ("Test Palace", slug "test-palace"),
+ * one VenueOwner (phone 9999999999), ~20 VenueEnquiry leads spread across all 8
+ * stages and all sources with a mix of follow-up dates (overdue / today / future),
+ * and a few VenueLeadInteractions.
+ *
+ * SAFETY: hard-refuses to run unless DATABASE_URL points at a local Mongo host.
+ * Usage: node scripts/seed-test-venue.js
+ */
+require("dotenv").config();
+const mongoose = require("mongoose");
+
+const Venue = require("../models/Venue");
+const VenueOwner = require("../models/VenueOwner");
+const VenueEnquiry = require("../models/VenueEnquiry");
+const VenueLeadInteraction = require("../models/VenueLeadInteraction");
+// Phase 3 collections (optional — only present on Phase 3+ branches).
+let VenueBooking, VenueQuote, VenueInvoice;
+try { VenueBooking = require("../models/VenueBooking"); } catch (_) {}
+try { VenueQuote = require("../models/VenueQuote"); } catch (_) {}
+try { VenueInvoice = require("../models/VenueInvoice"); } catch (_) {}
+
+const LOCAL_HOSTS = new Set(["127.0.0.1", "localhost", "::1", "0.0.0.0"]);
+
+// Stable identifiers other harness scripts (e2e) rely on.
+const VENUE_SLUG = "test-palace";
+const OWNER_PHONE = "9999999999";
+
+function assertLocalMongo() {
+  const url = process.env.DATABASE_URL || "";
+  let host;
+  try {
+    host = new URL(url).hostname;
+  } catch (e) {
+    throw new Error(`Cannot parse DATABASE_URL to verify host: ${e.message}`);
+  }
+  if (!LOCAL_HOSTS.has(host)) {
+    throw new Error(
+      `Refusing to seed: DATABASE_URL host "${host}" is not local. ` +
+        `This script only runs against a local dev Mongo (127.0.0.1/localhost).`
+    );
+  }
+  return host;
+}
+
+// Date helpers relative to "now" — script run time, not a fixed value.
+const DAY = 24 * 60 * 60 * 1000;
+const now = new Date();
+function daysFromNow(n) {
+  return new Date(now.getTime() + n * DAY);
+}
+function todayAt(hour) {
+  const d = new Date(now);
+  d.setHours(hour, 0, 0, 0);
+  return d;
+}
+
+// Deterministic 20-lead dataset. fu = followUpDate intent: "overdue" | "today" | "future" | null
+// Stages: new x4, contacted x3, site_visit_scheduled x2, site_visit_done x3,
+//         proposal_sent x2, negotiating x2, booked x2, lost x2  => 20 total.
+const LEAD_SPECS = [
+  { coupleName: "Aarav & Diya",      couplePhone: "9810000001", source: "wedsy",     stage: "new",                  fu: "overdue", estimatedValue: 450000 },
+  { coupleName: "Vivaan & Anika",    couplePhone: "9810000002", source: "instagram", stage: "new",                  fu: "today",   estimatedValue: 520000 },
+  { coupleName: "Aditya & Ira",      couplePhone: "9810000003", source: "referral",  stage: "new",                  fu: "future",  estimatedValue: 380000 },
+  { coupleName: "Reyansh & Myra",    couplePhone: "9810000004", source: "walk_in",   stage: "new",                  fu: null,      estimatedValue: 600000 },
+  { coupleName: "Arjun & Saanvi",    couplePhone: "9810000005", source: "justdial",  stage: "contacted",            fu: "overdue", estimatedValue: 710000 },
+  { coupleName: "Vihaan & Aadhya",   couplePhone: "9810000006", source: "wedmegood", stage: "contacted",            fu: "today",   estimatedValue: 480000 },
+  { coupleName: "Krishna & Pari",    couplePhone: "9810000007", source: "google",    stage: "contacted",            fu: "future",  estimatedValue: 550000 },
+  { coupleName: "Ishaan & Anaya",    couplePhone: "9810000008", source: "other",     stage: "site_visit_scheduled", fu: "today",   estimatedValue: 640000 },
+  { coupleName: "Shaurya & Aarohi",  couplePhone: "9810000009", source: "wedsy",     stage: "site_visit_scheduled", fu: "future",  estimatedValue: 720000 },
+  { coupleName: "Atharv & Kiara",    couplePhone: "9810000010", source: "instagram", stage: "site_visit_done",      fu: "overdue", estimatedValue: 900000 },
+  { coupleName: "Advik & Navya",     couplePhone: "9810000011", source: "referral",  stage: "site_visit_done",      fu: "today",   estimatedValue: 810000 },
+  { coupleName: "Kabir & Riya",      couplePhone: "9810000012", source: "walk_in",   stage: "site_visit_done",      fu: "future",  estimatedValue: 770000 },
+  { coupleName: "Aryan & Sara",      couplePhone: "9810000013", source: "justdial",  stage: "proposal_sent",        fu: "overdue", estimatedValue: 1000000 },
+  { coupleName: "Dhruv & Aisha",     couplePhone: "9810000014", source: "wedmegood", stage: "proposal_sent",        fu: "future",  estimatedValue: 950000 },
+  { coupleName: "Veer & Tara",       couplePhone: "9810000015", source: "google",    stage: "negotiating",          fu: "today",   estimatedValue: 1100000 },
+  { coupleName: "Rudra & Mishka",    couplePhone: "9810000016", source: "other",     stage: "negotiating",          fu: "future",  estimatedValue: 1250000 },
+  { coupleName: "Shivansh & Zara",   couplePhone: "9810000017", source: "wedsy",     stage: "booked",               fu: null,      estimatedValue: 1300000 },
+  { coupleName: "Ayaan & Anvi",      couplePhone: "9810000018", source: "instagram", stage: "booked",               fu: null,      estimatedValue: 1450000 },
+  { coupleName: "Yuvaan & Siya",     couplePhone: "9810000019", source: "referral",  stage: "lost",                 fu: null,      estimatedValue: 500000, lostReason: "too_expensive" },
+  { coupleName: "Reyaan & Pihu",     couplePhone: "9810000020", source: "walk_in",   stage: "lost",                 fu: null,      estimatedValue: 470000, lostReason: "chose_competitor" },
+];
+
+function resolveFollowUp(intent) {
+  if (intent === "overdue") return daysFromNow(-3);
+  if (intent === "today") return todayAt(11);
+  if (intent === "future") return daysFromNow(7);
+  return null;
+}
+
+async function run() {
+  const host = assertLocalMongo();
+  await mongoose.connect(process.env.DATABASE_URL, { serverSelectionTimeoutMS: 8000 });
+  console.log(`[seed] connected to local Mongo @ ${host}`);
+
+  // 1. Venue (upsert by slug). Set a handful of profile fields so the dashboard
+  //    onboarding/overview endpoint returns a meaningful shape.
+  let venue = await Venue.findOne({ slug: VENUE_SLUG });
+  const venueDefaults = {
+    name: "Test Palace",
+    slug: VENUE_SLUG,
+    status: "published",
+    city: "Bangalore",
+    venueType: "banquet_hall",
+    contact: { primaryName: "Test Owner", primaryPhone: OWNER_PHONE, whatsappPhone: OWNER_PHONE, email: "owner@test-palace.local" },
+    pricing: { currency: "INR", perPlate: { veg: 1500, nonVeg: 1900 }, tiers: [{ hours: 12, price: 250000 }] },
+    coverPhoto: "https://example.local/test-palace-cover.jpg",
+  };
+  if (!venue) {
+    venue = await Venue.create(venueDefaults);
+    console.log(`[seed] created venue ${venue.slug} (${venue._id})`);
+  } else {
+    Object.assign(venue, venueDefaults);
+    await venue.save();
+    console.log(`[seed] reset venue ${venue.slug} (${venue._id})`);
+  }
+
+  // 2. Owner (upsert by phone). role owner, phone-verified so dashboard treats it as a real account.
+  let owner = await VenueOwner.findOne({ phone: OWNER_PHONE });
+  const ownerDefaults = {
+    name: "Test Owner",
+    phone: OWNER_PHONE,
+    email: "owner@test-palace.local",
+    role: "owner",
+    venueId: venue._id,
+    verificationStatus: "phone_verified",
+    isActive: true,
+  };
+  if (!owner) {
+    owner = await VenueOwner.create(ownerDefaults);
+    console.log(`[seed] created owner ${owner.phone} (${owner._id})`);
+  } else {
+    Object.assign(owner, ownerDefaults);
+    await owner.save();
+    console.log(`[seed] reset owner ${owner.phone} (${owner._id})`);
+  }
+
+  // 3. Reset enquiries + interactions for this venue (idempotent rebuild).
+  await VenueLeadInteraction.deleteMany({ venue: venue._id });
+  await VenueEnquiry.deleteMany({ venueId: venue._id });
+  // Clear Phase 3 collections too (keeps invoice sequences + revenue math deterministic).
+  if (VenueBooking) await VenueBooking.deleteMany({ venue: venue._id });
+  if (VenueQuote) await VenueQuote.deleteMany({ venue: venue._id });
+  if (VenueInvoice) await VenueInvoice.deleteMany({ venue: venue._id });
+
+  const enquiries = [];
+  for (const spec of LEAD_SPECS) {
+    const fu = resolveFollowUp(spec.fu);
+    const doc = await VenueEnquiry.create({
+      venueId: venue._id,
+      coupleName: spec.coupleName,
+      couplePhone: spec.couplePhone,
+      name: spec.coupleName,
+      phone: spec.couplePhone,
+      email: `${spec.couplePhone}@leads.test-palace.local`,
+      eventDate: daysFromNow(60),
+      guestCount: 300,
+      source: spec.source,
+      stage: spec.stage,
+      estimatedValue: spec.estimatedValue,
+      lostReason: spec.lostReason || "",
+      followUpDate: fu,
+      activities: [{ type: "created", description: "Seeded lead", timestamp: now }],
+    });
+    enquiries.push(doc);
+  }
+  console.log(`[seed] created ${enquiries.length} enquiries across all 8 stages / 8 sources`);
+
+  // 4. A few interactions on the first three leads.
+  const interactionSeeds = [
+    { idx: 0, type: "enquiry", note: "Inbound enquiry from website" },
+    { idx: 0, type: "call", note: "Called couple, discussed dates" },
+    { idx: 1, type: "whatsapp", note: "Sent brochure on WhatsApp" },
+    { idx: 4, type: "site_visit", note: "Site visit scheduled for next week" },
+  ];
+  for (const s of interactionSeeds) {
+    await VenueLeadInteraction.create({
+      enquiry: enquiries[s.idx]._id,
+      venue: venue._id,
+      type: s.type,
+      note: s.note,
+      createdBy: s.type === "enquiry" ? null : owner._id,
+    });
+  }
+  console.log(`[seed] created ${interactionSeeds.length} interactions`);
+
+  console.log("[seed] DONE");
+  await mongoose.disconnect();
+}
+
+run().catch(async (err) => {
+  console.error("[seed] FAILED:", err.message);
+  try { await mongoose.disconnect(); } catch (_) {}
+  process.exit(1);
+});

--- a/scripts/seed-test-venue.js
+++ b/scripts/seed-test-venue.js
@@ -1,0 +1,211 @@
+/**
+ * scripts/seed-test-venue.js
+ *
+ * Idempotent LOCAL seed for the venue test harness.
+ * Creates / resets one published test venue ("Test Palace", slug "test-palace"),
+ * one VenueOwner (phone 9999999999), ~20 VenueEnquiry leads spread across all 8
+ * stages and all sources with a mix of follow-up dates (overdue / today / future),
+ * and a few VenueLeadInteractions.
+ *
+ * SAFETY: hard-refuses to run unless DATABASE_URL points at a local Mongo host.
+ * Usage: node scripts/seed-test-venue.js
+ */
+require("dotenv").config();
+const mongoose = require("mongoose");
+
+const Venue = require("../models/Venue");
+const VenueOwner = require("../models/VenueOwner");
+const VenueEnquiry = require("../models/VenueEnquiry");
+const VenueLeadInteraction = require("../models/VenueLeadInteraction");
+
+const LOCAL_HOSTS = new Set(["127.0.0.1", "localhost", "::1", "0.0.0.0"]);
+
+// Stable identifiers other harness scripts (e2e) rely on.
+const VENUE_SLUG = "test-palace";
+const OWNER_PHONE = "9999999999";
+
+function assertLocalMongo() {
+  const url = process.env.DATABASE_URL || "";
+  let host;
+  try {
+    host = new URL(url).hostname;
+  } catch (e) {
+    throw new Error(`Cannot parse DATABASE_URL to verify host: ${e.message}`);
+  }
+  if (!LOCAL_HOSTS.has(host)) {
+    throw new Error(
+      `Refusing to seed: DATABASE_URL host "${host}" is not local. ` +
+        `This script only runs against a local dev Mongo (127.0.0.1/localhost).`
+    );
+  }
+  return host;
+}
+
+// Date helpers relative to "now" — script run time, not a fixed value.
+const DAY = 24 * 60 * 60 * 1000;
+const now = new Date();
+function daysFromNow(n) {
+  return new Date(now.getTime() + n * DAY);
+}
+function todayAt(hour) {
+  const d = new Date(now);
+  d.setHours(hour, 0, 0, 0);
+  return d;
+}
+
+// Deterministic 20-lead dataset. fu = followUpDate intent: "overdue" | "today" | "future" | null
+// Stages: new x4, contacted x3, site_visit_scheduled x2, site_visit_done x3,
+//         proposal_sent x2, negotiating x2, booked x2, lost x2  => 20 total.
+const LEAD_SPECS = [
+  { coupleName: "Aarav & Diya",      couplePhone: "9810000001", source: "wedsy",     stage: "new",                  fu: "overdue", estimatedValue: 450000 },
+  { coupleName: "Vivaan & Anika",    couplePhone: "9810000002", source: "instagram", stage: "new",                  fu: "today",   estimatedValue: 520000 },
+  { coupleName: "Aditya & Ira",      couplePhone: "9810000003", source: "referral",  stage: "new",                  fu: "future",  estimatedValue: 380000 },
+  { coupleName: "Reyansh & Myra",    couplePhone: "9810000004", source: "walk_in",   stage: "new",                  fu: null,      estimatedValue: 600000 },
+  { coupleName: "Arjun & Saanvi",    couplePhone: "9810000005", source: "justdial",  stage: "contacted",            fu: "overdue", estimatedValue: 710000 },
+  { coupleName: "Vihaan & Aadhya",   couplePhone: "9810000006", source: "wedmegood", stage: "contacted",            fu: "today",   estimatedValue: 480000 },
+  { coupleName: "Krishna & Pari",    couplePhone: "9810000007", source: "google",    stage: "contacted",            fu: "future",  estimatedValue: 550000 },
+  { coupleName: "Ishaan & Anaya",    couplePhone: "9810000008", source: "other",     stage: "site_visit_scheduled", fu: "today",   estimatedValue: 640000 },
+  { coupleName: "Shaurya & Aarohi",  couplePhone: "9810000009", source: "wedsy",     stage: "site_visit_scheduled", fu: "future",  estimatedValue: 720000 },
+  { coupleName: "Atharv & Kiara",    couplePhone: "9810000010", source: "instagram", stage: "site_visit_done",      fu: "overdue", estimatedValue: 900000 },
+  { coupleName: "Advik & Navya",     couplePhone: "9810000011", source: "referral",  stage: "site_visit_done",      fu: "today",   estimatedValue: 810000 },
+  { coupleName: "Kabir & Riya",      couplePhone: "9810000012", source: "walk_in",   stage: "site_visit_done",      fu: "future",  estimatedValue: 770000 },
+  { coupleName: "Aryan & Sara",      couplePhone: "9810000013", source: "justdial",  stage: "proposal_sent",        fu: "overdue", estimatedValue: 1000000 },
+  { coupleName: "Dhruv & Aisha",     couplePhone: "9810000014", source: "wedmegood", stage: "proposal_sent",        fu: "future",  estimatedValue: 950000 },
+  { coupleName: "Veer & Tara",       couplePhone: "9810000015", source: "google",    stage: "negotiating",          fu: "today",   estimatedValue: 1100000 },
+  { coupleName: "Rudra & Mishka",    couplePhone: "9810000016", source: "other",     stage: "negotiating",          fu: "future",  estimatedValue: 1250000 },
+  { coupleName: "Shivansh & Zara",   couplePhone: "9810000017", source: "wedsy",     stage: "booked",               fu: null,      estimatedValue: 1300000 },
+  { coupleName: "Ayaan & Anvi",      couplePhone: "9810000018", source: "instagram", stage: "booked",               fu: null,      estimatedValue: 1450000 },
+  { coupleName: "Yuvaan & Siya",     couplePhone: "9810000019", source: "referral",  stage: "lost",                 fu: null,      estimatedValue: 500000, lostReason: "too_expensive" },
+  { coupleName: "Reyaan & Pihu",     couplePhone: "9810000020", source: "walk_in",   stage: "lost",                 fu: null,      estimatedValue: 470000, lostReason: "chose_competitor" },
+];
+
+function resolveFollowUp(intent) {
+  if (intent === "overdue") return daysFromNow(-3);
+  if (intent === "today") return todayAt(11);
+  if (intent === "future") return daysFromNow(7);
+  return null;
+}
+
+async function run() {
+  const host = assertLocalMongo();
+  await mongoose.connect(process.env.DATABASE_URL, { serverSelectionTimeoutMS: 8000 });
+  console.log(`[seed] connected to local Mongo @ ${host}`);
+
+  // 1. Venue (upsert by slug). Set a handful of profile fields so the dashboard
+  //    onboarding/overview endpoint returns a meaningful shape.
+  let venue = await Venue.findOne({ slug: VENUE_SLUG });
+  const venueDefaults = {
+    name: "Test Palace",
+    slug: VENUE_SLUG,
+    status: "published",
+    city: "Bangalore",
+    venueType: "banquet_hall",
+    contact: { primaryName: "Test Owner", primaryPhone: OWNER_PHONE, whatsappPhone: OWNER_PHONE, email: "owner@test-palace.local" },
+    pricing: { currency: "INR", perPlate: { veg: 1500, nonVeg: 1900 }, tiers: [{ hours: 12, price: 250000 }] },
+    coverPhoto: "https://example.local/test-palace-cover.jpg",
+  };
+  if (!venue) {
+    venue = await Venue.create(venueDefaults);
+    console.log(`[seed] created venue ${venue.slug} (${venue._id})`);
+  } else {
+    Object.assign(venue, venueDefaults);
+    await venue.save();
+    console.log(`[seed] reset venue ${venue.slug} (${venue._id})`);
+  }
+
+  // 2. Owner (upsert by phone). role owner, phone-verified so dashboard treats it as a real account.
+  let owner = await VenueOwner.findOne({ phone: OWNER_PHONE });
+  const ownerDefaults = {
+    name: "Test Owner",
+    phone: OWNER_PHONE,
+    email: "owner@test-palace.local",
+    role: "owner",
+    venueId: venue._id,
+    verificationStatus: "phone_verified",
+    isActive: true,
+  };
+  if (!owner) {
+    owner = await VenueOwner.create(ownerDefaults);
+    console.log(`[seed] created owner ${owner.phone} (${owner._id})`);
+  } else {
+    Object.assign(owner, ownerDefaults);
+    await owner.save();
+    console.log(`[seed] reset owner ${owner.phone} (${owner._id})`);
+  }
+
+  // 3. Reset enquiries + interactions for this venue (idempotent rebuild).
+  await VenueLeadInteraction.deleteMany({ venue: venue._id });
+  await VenueEnquiry.deleteMany({ venueId: venue._id });
+
+  const enquiries = [];
+  for (const spec of LEAD_SPECS) {
+    const fu = resolveFollowUp(spec.fu);
+    const doc = await VenueEnquiry.create({
+      venueId: venue._id,
+      coupleName: spec.coupleName,
+      couplePhone: spec.couplePhone,
+      name: spec.coupleName,
+      phone: spec.couplePhone,
+      email: `${spec.couplePhone}@leads.test-palace.local`,
+      eventDate: daysFromNow(60),
+      guestCount: 300,
+      source: spec.source,
+      stage: spec.stage,
+      estimatedValue: spec.estimatedValue,
+      lostReason: spec.lostReason || "",
+      followUpDate: fu,
+      activities: [{ type: "created", description: "Seeded lead", timestamp: now }],
+    });
+    enquiries.push(doc);
+  }
+  console.log(`[seed] created ${enquiries.length} enquiries across all 8 stages / 8 sources`);
+
+  // 4. A few interactions on the first three leads.
+  const interactionSeeds = [
+    { idx: 0, type: "enquiry", note: "Inbound enquiry from website" },
+    { idx: 0, type: "call", note: "Called couple, discussed dates" },
+    { idx: 1, type: "whatsapp", note: "Sent brochure on WhatsApp" },
+    { idx: 4, type: "site_visit", note: "Site visit scheduled for next week" },
+  ];
+  for (const s of interactionSeeds) {
+    await VenueLeadInteraction.create({
+      enquiry: enquiries[s.idx]._id,
+      venue: venue._id,
+      type: s.type,
+      note: s.note,
+      createdBy: s.type === "enquiry" ? null : owner._id,
+    });
+  }
+  console.log(`[seed] created ${interactionSeeds.length} interactions`);
+
+  // 5. Multi-identity login scenario (only on team-derived branches that have
+  //    VenueTeamMember). Phone 8888888888 is BOTH an OWNER of a second venue and
+  //    an ACTIVE MEMBER of Test Palace → 2 identities. 9999999999 stays single.
+  let VenueTeamMember;
+  try { VenueTeamMember = require("../models/VenueTeamMember"); } catch (_) {}
+  if (VenueTeamMember) {
+    const MULTI_PHONE = "8888888888";
+    let venue2 = await Venue.findOne({ slug: "test-palace-two" });
+    const v2 = { name: "Test Palace Two", slug: "test-palace-two", status: "published", city: "Bangalore", venueType: "banquet_hall" };
+    if (!venue2) venue2 = await Venue.create(v2);
+    else { Object.assign(venue2, v2); await venue2.save(); }
+
+    let owner2 = await VenueOwner.findOne({ phone: MULTI_PHONE });
+    const o2 = { name: "Multi Identity", phone: MULTI_PHONE, role: "owner", venueId: venue2._id, verificationStatus: "phone_verified", isActive: true };
+    if (!owner2) owner2 = await VenueOwner.create(o2);
+    else { Object.assign(owner2, o2); await owner2.save(); }
+
+    await VenueTeamMember.deleteMany({ phone: MULTI_PHONE });
+    await VenueTeamMember.create({ venueId: venue._id, ownerId: owner._id, name: "Multi Identity", phone: MULTI_PHONE, role: "sales", isActive: true });
+    console.log("[seed] multi-identity 8888888888 -> owner(test-palace-two) + member(test-palace)");
+  }
+
+  console.log("[seed] DONE");
+  await mongoose.disconnect();
+}
+
+run().catch(async (err) => {
+  console.error("[seed] FAILED:", err.message);
+  try { await mongoose.disconnect(); } catch (_) {}
+  process.exit(1);
+});

--- a/scripts/seed-test-venue.js
+++ b/scripts/seed-test-venue.js
@@ -18,10 +18,13 @@ const VenueOwner = require("../models/VenueOwner");
 const VenueEnquiry = require("../models/VenueEnquiry");
 const VenueLeadInteraction = require("../models/VenueLeadInteraction");
 // Phase 3 collections (optional — only present on Phase 3+ branches).
-let VenueBooking, VenueQuote, VenueInvoice;
+let VenueBooking, VenueQuote, VenueInvoice, VenueMessageTemplate, VenueTeamMember, computeTotals;
 try { VenueBooking = require("../models/VenueBooking"); } catch (_) {}
 try { VenueQuote = require("../models/VenueQuote"); } catch (_) {}
 try { VenueInvoice = require("../models/VenueInvoice"); } catch (_) {}
+try { VenueMessageTemplate = require("../models/VenueMessageTemplate"); } catch (_) {}
+try { VenueTeamMember = require("../models/VenueTeamMember"); } catch (_) {}
+try { ({ computeTotals } = require("../utils/venueMoney")); } catch (_) {}
 
 const LOCAL_HOSTS = new Set(["127.0.0.1", "localhost", "::1", "0.0.0.0"]);
 
@@ -187,15 +190,24 @@ async function run() {
   }
   console.log(`[seed] created ${interactionSeeds.length} interactions`);
 
-  // 5. Multi-identity login scenario (only on team-derived branches that have
-  //    VenueTeamMember). Phone 8888888888 is BOTH an OWNER of a second venue and
-  //    an ACTIVE MEMBER of Test Palace → 2 identities. 9999999999 stays single.
-  let VenueTeamMember;
-  try { VenueTeamMember = require("../models/VenueTeamMember"); } catch (_) {}
+  // 5. Templates (Test Palace) — safe for the e2e (it creates/deletes its own).
+  if (VenueMessageTemplate) {
+    await VenueMessageTemplate.deleteMany({ venue: venue._id });
+    await VenueMessageTemplate.create([
+      { venue: venue._id, name: "Site visit invite", body: "Hi {{name}}, we'd love to host you for a site visit at Test Palace. When works?", createdBy: owner._id },
+      { venue: venue._id, name: "Quote follow-up", body: "Hi {{name}}, following up on your quote — happy to answer any questions!", createdBy: owner._id },
+    ]);
+    console.log("[seed] 2 message templates (test-palace)");
+  }
+
+  // 6. Multi-identity login + team members in all 5 roles (team-derived branches).
+  //    Phone 8888888888 is BOTH an OWNER of a second venue and an ACTIVE MEMBER of
+  //    Test Palace → 2 identities. 9999999999 stays single.
+  let venue2 = null;
   if (VenueTeamMember) {
     const MULTI_PHONE = "8888888888";
-    let venue2 = await Venue.findOne({ slug: "test-palace-two" });
-    const v2 = { name: "Test Palace Two", slug: "test-palace-two", status: "published", city: "Bangalore", venueType: "banquet_hall" };
+    venue2 = await Venue.findOne({ slug: "test-palace-two" });
+    const v2 = { name: "Test Palace Two", slug: "test-palace-two", status: "verified", city: "Bangalore", venueType: "banquet_hall", invoicePrefix: "TP2-", gstin: "29ABCDE1234F1Z5", pan: "ABCDE1234F" };
     if (!venue2) venue2 = await Venue.create(v2);
     else { Object.assign(venue2, v2); await venue2.save(); }
 
@@ -204,9 +216,79 @@ async function run() {
     if (!owner2) owner2 = await VenueOwner.create(o2);
     else { Object.assign(owner2, o2); await owner2.save(); }
 
-    await VenueTeamMember.deleteMany({ phone: MULTI_PHONE });
-    await VenueTeamMember.create({ venueId: venue._id, ownerId: owner._id, name: "Multi Identity", phone: MULTI_PHONE, role: "sales", isActive: true });
-    console.log("[seed] multi-identity 8888888888 -> owner(test-palace-two) + member(test-palace)");
+    // Reset + seed team members across all 5 roles on Test Palace (8888888888 is the
+    // shared "sales" member that drives the multi-identity scenario).
+    await VenueTeamMember.deleteMany({ venueId: venue._id });
+    const teamSpecs = [
+      { phone: MULTI_PHONE, name: "Multi Identity", role: "sales" },
+      { phone: "9700000001", name: "Maya Manager", role: "manager" },
+      { phone: "9700000002", name: "Lina Listing", role: "listing_manager" },
+      { phone: "9700000003", name: "Mira Marketing", role: "marketing" },
+      { phone: "9700000004", name: "Otis Owner", role: "owner" },
+    ];
+    for (const t of teamSpecs) {
+      await VenueTeamMember.create({ venueId: venue._id, ownerId: owner._id, name: t.name, phone: t.phone, role: t.role, isActive: true });
+    }
+    console.log(`[seed] ${teamSpecs.length} team members (all 5 roles) + multi-identity 8888888888`);
+  }
+
+  // 7. Rich Phase-3 demo data on Test Palace Two (kept OFF test-palace so the e2e
+  //    money math on test-palace stays deterministic): bookings in all 4 statuses,
+  //    quotes in 2 versions, invoices paid / partially_paid / unpaid.
+  if (venue2 && VenueBooking && VenueQuote && VenueInvoice && computeTotals) {
+    await VenueBooking.deleteMany({ venue: venue2._id });
+    await VenueQuote.deleteMany({ venue: venue2._id });
+    await VenueInvoice.deleteMany({ venue: venue2._id });
+    await VenueEnquiry.deleteMany({ venueId: venue2._id });
+
+    const statuses = ["confirmed", "in_progress", "completed", "cancelled"];
+    const bookings = [];
+    for (let i = 0; i < statuses.length; i++) {
+      const enq = await VenueEnquiry.create({
+        venueId: venue2._id, coupleName: `Demo Couple ${i + 1}`, couplePhone: `9760000${i}01`,
+        name: `Demo Couple ${i + 1}`, phone: `9760000${i}01`, stage: "booked", source: "wedsy",
+        estimatedValue: 500000 + i * 100000, eventDate: daysFromNow(40 + i * 10), guestCount: 250,
+      });
+      const b = await VenueBooking.create({
+        venue: venue2._id, enquiry: enq._id, coupleName: enq.coupleName, couplePhone: enq.couplePhone,
+        days: [{ date: daysFromNow(40 + i * 10), eventType: "Wedding", guestCount: 250, spaces: ["Main Lawn"] }],
+        totalValue: 500000 + i * 100000, status: statuses[i],
+        paymentSchedule: [
+          { label: "Advance", dueDate: daysFromNow(-5), amount: 150000 },
+          { label: "Balance", dueDate: daysFromNow(30), amount: (500000 + i * 100000) - 150000 },
+        ],
+        createdBy: owner._id,
+      });
+      bookings.push(b);
+    }
+    console.log(`[seed] 4 bookings (all statuses) on test-palace-two`);
+
+    // Quotes in 2 versions for the first booking's enquiry (v1 superseded, v2 sent).
+    const lineItems = [{ label: "Venue hire", category: "venue_hire", qty: 1, unitPrice: 400000 }, { label: "Catering", category: "catering", qty: 250, unitPrice: 1500, perDay: false }];
+    const t1 = computeTotals(lineItems, 18, 0);
+    await VenueQuote.create({ venue: venue2._id, enquiry: bookings[0].enquiry, version: 1, lineItems, gstPercent: 18, discount: 0, totals: t1, status: "superseded" });
+    const t2 = computeTotals(lineItems, 18, 25000);
+    await VenueQuote.create({ venue: venue2._id, enquiry: bookings[0].enquiry, version: 2, lineItems, gstPercent: 18, discount: 25000, totals: t2, status: "sent" });
+    console.log(`[seed] 2 quote versions on test-palace-two`);
+
+    // Invoices: paid / partially_paid / unpaid, with auto-incrementing numbers.
+    const prefix = venue2.invoicePrefix || "INV-";
+    const invSpecs = [
+      { booking: bookings[0], kind: "advance", unit: 200000, pay: 236000, status: "paid" },        // 200000+18% = 236000 fully paid
+      { booking: bookings[1], kind: "advance", unit: 300000, pay: 150000, status: "partially_paid" },
+      { booking: bookings[2], kind: "final", unit: 400000, pay: 0, status: "unpaid" },
+    ];
+    for (let i = 0; i < invSpecs.length; i++) {
+      const s = invSpecs[i];
+      const items = [{ label: "Venue booking", category: "venue_hire", qty: 1, unitPrice: s.unit }];
+      const totals = computeTotals(items, 18, 0);
+      const payments = s.pay > 0 ? [{ date: daysFromNow(-2), amount: s.pay, mode: "bank_transfer", note: "Seed payment" }] : [];
+      await VenueInvoice.create({
+        venue: venue2._id, booking: s.booking._id, invoiceNumber: `${prefix}${String(i + 1).padStart(4, "0")}`,
+        seq: i + 1, kind: s.kind, lineItems: items, gstPercent: 18, discount: 0, totals, status: s.status, payments,
+      });
+    }
+    console.log(`[seed] 3 invoices (paid / partial / unpaid) on test-palace-two`);
   }
 
   console.log("[seed] DONE");

--- a/scripts/test-sheets-writeback.js
+++ b/scripts/test-sheets-writeback.js
@@ -1,0 +1,75 @@
+/**
+ * scripts/test-sheets-writeback.js
+ *
+ * Unit-style test of the Google Sheets write-back MAPPING logic — pure functions
+ * only, NO live Google call and NO database. Run: node scripts/test-sheets-writeback.js
+ */
+const assert = require("assert");
+const {
+  columnIndexToLetter,
+  buildRowMap,
+  stageColumnLetter,
+  resolveWriteTarget,
+} = require("../utils/venueSheetWriteBack");
+
+let pass = 0, fail = 0;
+function t(name, fn) {
+  try { fn(); pass++; console.log(`✓ ${name}`); }
+  catch (e) { fail++; console.log(`✗ ${name} — ${e.message}`); }
+}
+
+t("columnIndexToLetter handles A..Z, AA, AB, and invalid", () => {
+  assert.strictEqual(columnIndexToLetter(0), "A");
+  assert.strictEqual(columnIndexToLetter(7), "H");
+  assert.strictEqual(columnIndexToLetter(25), "Z");
+  assert.strictEqual(columnIndexToLetter(26), "AA");
+  assert.strictEqual(columnIndexToLetter(27), "AB");
+  assert.strictEqual(columnIndexToLetter(-1), "");
+});
+
+t("buildRowMap maps phone digits → 1-based sheet row (header offset, first wins)", () => {
+  const header = ["Couple", "Phone", "Stage"];
+  const rows = [
+    ["Aarav", "98100-00001", "new"],     // sheet row 2
+    ["Vivaan", "9810000002", "contacted"], // sheet row 3
+    ["Dup", "9810000001", "lost"],        // duplicate phone → ignored (row 2 wins)
+    ["NoPhone", "", "new"],               // skipped (no phone)
+  ];
+  const map = buildRowMap(header, rows, "Phone");
+  assert.strictEqual(map["9810000001"], 2);
+  assert.strictEqual(map["9810000002"], 3);
+  assert.strictEqual(Object.keys(map).length, 2);
+});
+
+t("buildRowMap returns {} when phone column missing", () => {
+  assert.deepStrictEqual(buildRowMap(["A", "B"], [["1", "2"]], "Phone"), {});
+});
+
+t("stageColumnLetter resolves the mapped stage column", () => {
+  const header = ["Couple", "Phone", "Stage"];
+  assert.strictEqual(stageColumnLetter(header, { stage: "Stage" }), "C");
+  assert.strictEqual(stageColumnLetter(header, { stage: "Missing" }), ""); // indexOf -1 → ""
+  assert.strictEqual(stageColumnLetter(header, {}), "");
+});
+
+t("resolveWriteTarget happy path returns A1 + value", () => {
+  const integration = {
+    refreshToken: "enc", spreadsheetId: "sid", sheetName: "Tab",
+    stageColumn: "C", rowMap: { "9810000001": 2 },
+  };
+  const out = resolveWriteTarget(integration, { couplePhone: "98100-00001", stage: "booked" });
+  assert.deepStrictEqual(out, { a1: "C2", value: "booked" });
+});
+
+t("resolveWriteTarget skip reasons", () => {
+  const base = { refreshToken: "enc", spreadsheetId: "sid", sheetName: "Tab", stageColumn: "C", rowMap: { "9810000001": 2 } };
+  assert.strictEqual(resolveWriteTarget(null, {}).skip, "not_connected");
+  assert.strictEqual(resolveWriteTarget({ refreshToken: "" }, {}).skip, "not_connected");
+  assert.strictEqual(resolveWriteTarget({ refreshToken: "x" }, {}).skip, "not_configured");
+  assert.strictEqual(resolveWriteTarget({ ...base, stageColumn: "" }, { couplePhone: "9810000001" }).skip, "no_stage_column");
+  assert.strictEqual(resolveWriteTarget(base, { couplePhone: "" }).skip, "no_phone");
+  assert.strictEqual(resolveWriteTarget(base, { couplePhone: "9999999999" }).skip, "no_row");
+});
+
+console.log(`\n[test-sheets-writeback] ${pass} passed, ${fail} failed`);
+process.exit(fail > 0 ? 1 : 0);

--- a/server.js
+++ b/server.js
@@ -19,6 +19,7 @@ const {
 } = require("./utils/notificationJobs");
 const socketStore = require("./utils/socket");
 const Chat = require("./models/Chat");
+const { runScheduledSheetSync } = require("./controllers/venueSheetsSync");
 
 //Creating Express App
 const app = express();
@@ -161,4 +162,8 @@ httpServer.listen(port, function () {
 
   // Vendor birthday message — 9am IST
   cron.schedule("0 9 * * *", () => { birthdayReminder(); }, IST);
+
+  // Google Sheets one-way sync (sheet → leads) for every connected venue — every 15 min.
+  // No-op when Google creds aren't configured (runScheduledSheetSync guards internally).
+  cron.schedule("*/15 * * * *", () => { runScheduledSheetSync(); }, IST);
 });

--- a/server.js
+++ b/server.js
@@ -48,7 +48,8 @@ const limiter = rateLimit({
   message: { error: 'Too many requests, please try again later.' },
   standardHeaders: true,
   legacyHeaders: false,
-  skip: (req) => req.ip === '127.0.0.1', // skip localhost
+  // Skip localhost — both IPv4 and IPv6 loopback (::1, and the IPv4-mapped form).
+  skip: (req) => ['127.0.0.1', '::1', '::ffff:127.0.0.1'].includes(req.ip), // skip localhost
 });
 app.use(limiter);
 

--- a/server.js
+++ b/server.js
@@ -23,7 +23,8 @@ const Chat = require("./models/Chat");
 //Creating Express App
 const app = express();
 // Behind nginx on EC2 (sets X-Forwarded-For) — trust the first proxy hop so
-// express-rate-limit reads the real client IP instead of throwing ValidationError.
+// express-rate-limit reads the real client IP instead of throwing
+// ERR_ERL_UNEXPECTED_X_FORWARDED_FOR (its trust-proxy validation error).
 app.set('trust proxy', 1);
 
 //Applying middlewares

--- a/server.js
+++ b/server.js
@@ -17,6 +17,7 @@ const {
   artistDetailReminder,
   birthdayReminder,
 } = require("./utils/notificationJobs");
+const { runDailyFollowUpReminders } = require("./utils/venueReminderJob");
 const socketStore = require("./utils/socket");
 const Chat = require("./models/Chat");
 
@@ -161,4 +162,8 @@ httpServer.listen(port, function () {
 
   // Vendor birthday message — 9am IST
   cron.schedule("0 9 * * *", () => { birthdayReminder(); }, IST);
+
+  // Venue owner follow-up reminders (Phase 1.4) — 9am IST. Env-gated + log-only
+  // by default (REMINDERS_LOG_ONLY); no-ops gracefully without WhatsApp creds.
+  cron.schedule("0 9 * * *", () => { runDailyFollowUpReminders(); }, IST);
 });

--- a/services/PlacesService.js
+++ b/services/PlacesService.js
@@ -64,6 +64,11 @@ const details = async (placeId) => {
         componentOf(components, "locality") ||
         componentOf(components, "postal_town") ||
         componentOf(components, "administrative_area_level_2"),
+      // Neighbourhood / area — maps to Venue.locality so the owner form autofills it.
+      area:
+        componentOf(components, "sublocality_level_1") ||
+        componentOf(components, "sublocality") ||
+        componentOf(components, "neighborhood"),
       state: componentOf(components, "administrative_area_level_1"),
       pincode: componentOf(components, "postal_code"),
       country: componentOf(components, "country"),

--- a/services/VenueService.js
+++ b/services/VenueService.js
@@ -196,6 +196,18 @@ const updateVenueBySlug = async (slug, ownerVenueId, updates = {}) => {
     }
   }
 
+  // Structured policy clauses — arrays of trimmed, length-capped clause strings.
+  if (updates.policyDoc && typeof updates.policyDoc === "object") {
+    const cleanClauses = (arr) =>
+      (Array.isArray(arr) ? arr : [])
+        .map((s) => String(s == null ? "" : s).trim().slice(0, 2000))
+        .filter(Boolean)
+        .slice(0, 100);
+    for (const k of ["policies", "terms", "refund"]) {
+      if (updates.policyDoc[k] !== undefined) $set[`policyDoc.${k}`] = cleanClauses(updates.policyDoc[k]);
+    }
+  }
+
   if (updates.contact && typeof updates.contact === "object") {
     for (const k of CONTACT_SCALARS) {
       if (updates.contact[k] !== undefined) $set[`contact.${k}`] = updates.contact[k];

--- a/services/VenueService.js
+++ b/services/VenueService.js
@@ -68,6 +68,8 @@ const SCALAR_TOP_LEVEL = [
   "coverPhoto", "featurePhoto",
   // Places-enrich location fields (additive)
   "state", "pincode", "googlePlaceId", "formattedAddress",
+  // Phase 3 invoicing profile (additive)
+  "gstin", "pan", "invoicePrefix",
 ];
 
 const ARRAY_TOP_LEVEL = ["areas", "blockedDates", "spaces"];

--- a/services/VenueService.js
+++ b/services/VenueService.js
@@ -1,7 +1,7 @@
 const VenueRepository = require("../repositories/VenueRepository");
 
-const getAllVenues = async ({ status, limit, skip, zone, area, search } = {}) => {
-  return VenueRepository.findAll({ status, limit, skip, zone, area, search });
+const getAllVenues = async (params = {}) => {
+  return VenueRepository.findAll(params);
 };
 
 const getVenueBySlug = async (slug) => {

--- a/services/VenueService.js
+++ b/services/VenueService.js
@@ -97,6 +97,7 @@ const AMENITY_BOOLEANS = [
   "groomRoom", "makeupRoom", "changingRooms", "prayerRoom", "fireNOC",
   "liquorLicense", "dayOfCoordinator", "securityStaff", "housekeeping",
   "valetParking", "shuttleService", "petFriendly", "smokingAllowed",
+  "evCharging",
 ];
 
 const PHOTO_BUCKETS = ["venue", "decor", "rooms", "spaces"];

--- a/services/VenueService.js
+++ b/services/VenueService.js
@@ -68,6 +68,9 @@ const SCALAR_TOP_LEVEL = [
   "coverPhoto", "featurePhoto",
   // Places-enrich location fields (additive)
   "state", "pincode", "googlePlaceId", "formattedAddress",
+  // Neighbourhood (area, from Places) + Bangalore region — editable from the
+  // Places-powered location flow / dropdown.
+  "locality", "zone",
   // Phase 3 invoicing profile (additive)
   "gstin", "pan", "invoicePrefix",
 ];

--- a/utils/googleSheets.js
+++ b/utils/googleSheets.js
@@ -8,10 +8,14 @@ const { google } = require("googleapis");
 //   SHEETS_TOKEN_ENC_KEY      (any secret string; used to derive the AES-256 key)
 //   VENUE_OWNER_APP_URL       (optional; where the OAuth callback redirects back to)
 
-// Read-only scopes: list spreadsheets (Drive metadata) + read values (Sheets).
+// Scopes: list spreadsheets (Drive metadata, read-only) + read AND write values
+// (Sheets). The Sheets scope was widened from spreadsheets.readonly to
+// spreadsheets to support stage write-back (2-way). NOTE: existing connected
+// integrations were consented under the narrower scope and must RE-CONSENT
+// (disconnect + reconnect) before write-back will be authorized.
 const SCOPES = [
   "https://www.googleapis.com/auth/drive.metadata.readonly",
-  "https://www.googleapis.com/auth/spreadsheets.readonly",
+  "https://www.googleapis.com/auth/spreadsheets",
 ];
 
 function sheetsConfigured() {
@@ -111,6 +115,17 @@ async function readSheetValues(refreshToken, spreadsheetId, sheetName) {
   };
 }
 
+// Write a single cell. `a1` is a cell reference within the tab, e.g. "H5".
+async function updateCell(refreshToken, spreadsheetId, sheetName, a1, value) {
+  const sheets = google.sheets({ version: "v4", auth: clientFromRefreshToken(refreshToken) });
+  await sheets.spreadsheets.values.update({
+    spreadsheetId,
+    range: `${sheetName}!${a1}`,
+    valueInputOption: "RAW",
+    requestBody: { values: [[value]] },
+  });
+}
+
 module.exports = {
   SCOPES,
   sheetsConfigured,
@@ -121,4 +136,5 @@ module.exports = {
   listSpreadsheets,
   listTabs,
   readSheetValues,
+  updateCell,
 };

--- a/utils/googleSheets.js
+++ b/utils/googleSheets.js
@@ -1,0 +1,124 @@
+const crypto = require("crypto");
+const { google } = require("googleapis");
+
+// All Google credentials come from ENV only — nothing hardcoded.
+//   GOOGLE_SHEETS_CLIENT_ID
+//   GOOGLE_SHEETS_CLIENT_SECRET
+//   GOOGLE_SHEETS_REDIRECT_URI
+//   SHEETS_TOKEN_ENC_KEY      (any secret string; used to derive the AES-256 key)
+//   VENUE_OWNER_APP_URL       (optional; where the OAuth callback redirects back to)
+
+// Read-only scopes: list spreadsheets (Drive metadata) + read values (Sheets).
+const SCOPES = [
+  "https://www.googleapis.com/auth/drive.metadata.readonly",
+  "https://www.googleapis.com/auth/spreadsheets.readonly",
+];
+
+function sheetsConfigured() {
+  return Boolean(
+    process.env.GOOGLE_SHEETS_CLIENT_ID &&
+      process.env.GOOGLE_SHEETS_CLIENT_SECRET &&
+      process.env.GOOGLE_SHEETS_REDIRECT_URI
+  );
+}
+
+function oauthClient() {
+  if (!sheetsConfigured()) throw new Error("Google Sheets integration is not configured");
+  return new google.auth.OAuth2(
+    process.env.GOOGLE_SHEETS_CLIENT_ID,
+    process.env.GOOGLE_SHEETS_CLIENT_SECRET,
+    process.env.GOOGLE_SHEETS_REDIRECT_URI
+  );
+}
+
+function generateAuthUrl(state) {
+  return oauthClient().generateAuthUrl({
+    access_type: "offline",
+    prompt: "consent", // force a refresh_token back
+    scope: SCOPES,
+    state,
+  });
+}
+
+async function exchangeCode(code) {
+  const { tokens } = await oauthClient().getToken(code);
+  return tokens; // { refresh_token, access_token, ... }
+}
+
+// An OAuth client primed with a stored refresh token (auto-refreshes access tokens).
+function clientFromRefreshToken(refreshToken) {
+  const client = oauthClient();
+  client.setCredentials({ refresh_token: refreshToken });
+  return client;
+}
+
+// ── Refresh-token encryption (AES-256-GCM; key derived from SHEETS_TOKEN_ENC_KEY) ──
+
+function encKey() {
+  const secret = process.env.SHEETS_TOKEN_ENC_KEY;
+  if (!secret) return null;
+  return crypto.createHash("sha256").update(secret).digest(); // 32 bytes
+}
+
+function encryptToken(plain) {
+  const key = encKey();
+  if (!key) throw new Error("SHEETS_TOKEN_ENC_KEY is not configured");
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  const enc = Buffer.concat([cipher.update(String(plain), "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return [iv.toString("base64"), tag.toString("base64"), enc.toString("base64")].join(":");
+}
+
+function decryptToken(blob) {
+  const key = encKey();
+  if (!key) throw new Error("SHEETS_TOKEN_ENC_KEY is not configured");
+  const [ivB, tagB, dataB] = String(blob).split(":");
+  if (!ivB || !tagB || !dataB) throw new Error("Malformed encrypted token");
+  const decipher = crypto.createDecipheriv("aes-256-gcm", key, Buffer.from(ivB, "base64"));
+  decipher.setAuthTag(Buffer.from(tagB, "base64"));
+  return Buffer.concat([decipher.update(Buffer.from(dataB, "base64")), decipher.final()]).toString("utf8");
+}
+
+// ── Sheets/Drive reads ──
+
+async function listSpreadsheets(refreshToken) {
+  const drive = google.drive({ version: "v3", auth: clientFromRefreshToken(refreshToken) });
+  const resp = await drive.files.list({
+    q: "mimeType='application/vnd.google-apps.spreadsheet' and trashed=false",
+    fields: "files(id, name)",
+    pageSize: 100,
+    orderBy: "modifiedTime desc",
+  });
+  return (resp.data.files || []).map((f) => ({ id: f.id, name: f.name }));
+}
+
+async function listTabs(refreshToken, spreadsheetId) {
+  const sheets = google.sheets({ version: "v4", auth: clientFromRefreshToken(refreshToken) });
+  const resp = await sheets.spreadsheets.get({ spreadsheetId, fields: "sheets.properties.title" });
+  return (resp.data.sheets || []).map((s) => s.properties.title);
+}
+
+// Returns { header: string[], rows: string[][] } for a tab.
+async function readSheetValues(refreshToken, spreadsheetId, sheetName) {
+  const sheets = google.sheets({ version: "v4", auth: clientFromRefreshToken(refreshToken) });
+  const resp = await sheets.spreadsheets.values.get({ spreadsheetId, range: sheetName });
+  const values = resp.data.values || [];
+  if (!values.length) return { header: [], rows: [] };
+  return {
+    header: values[0].map((h) => String(h).trim()),
+    rows: values.slice(1),
+  };
+}
+
+module.exports = {
+  SCOPES,
+  sheetsConfigured,
+  generateAuthUrl,
+  exchangeCode,
+  encryptToken,
+  decryptToken,
+  listSpreadsheets,
+  listTabs,
+  readSheetValues,
+};

--- a/utils/venueEnquiryRateLimit.js
+++ b/utils/venueEnquiryRateLimit.js
@@ -56,4 +56,16 @@ const enquiryPhoneLimiter = rateLimit({
   keyGenerator: (req) => `${req.params.slug || "?"}:${effectivePhone(req)}`,
 });
 
-module.exports = { enquiryIpLimiter, enquiryPhoneLimiter };
+// Public read/beacon limiter (view tracking + availability-check). Generous —
+// a couple browsing many venues is normal — but caps inflation/abuse per IP.
+const PUBLIC_READ_WINDOW_MS = num(process.env.VENUE_PUBLIC_READ_WINDOW_MS, 60 * 1000); // 1m
+const PUBLIC_READ_MAX = num(process.env.VENUE_PUBLIC_READ_MAX, 60);
+const publicReadLimiter = rateLimit({
+  windowMs: PUBLIC_READ_WINDOW_MS,
+  max: PUBLIC_READ_MAX,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { message: "Too many requests, please slow down." },
+});
+
+module.exports = { enquiryIpLimiter, enquiryPhoneLimiter, publicReadLimiter };

--- a/utils/venueEnquiryRateLimit.js
+++ b/utils/venueEnquiryRateLimit.js
@@ -1,0 +1,59 @@
+/**
+ * utils/venueEnquiryRateLimit.js
+ *
+ * Per-route rate limiting for the PUBLIC venue enquiry endpoint
+ * (POST /venues/:slug/enquiry | /enquiries). Built on express-rate-limit
+ * (already a project dependency; the global limiter in server.js uses it too).
+ *
+ * Two layers, both env-tunable, both returning a clean 429:
+ *   1. Per IP            — default 5 / hour
+ *   2. Per phone + venue — default 3 / day
+ *
+ * Unlike the global limiter, these do NOT skip localhost, so the limits apply
+ * uniformly (and are testable from a local harness). The gated /manual route is
+ * never wrapped by these.
+ */
+const rateLimit = require("express-rate-limit");
+
+const num = (v, d) => {
+  const n = Number(v);
+  return Number.isFinite(n) && n > 0 ? n : d;
+};
+
+const IP_WINDOW_MS = num(process.env.VENUE_ENQUIRY_IP_WINDOW_MS, 60 * 60 * 1000); // 1h
+const IP_MAX = num(process.env.VENUE_ENQUIRY_IP_MAX, 5);
+const PHONE_WINDOW_MS = num(process.env.VENUE_ENQUIRY_PHONE_WINDOW_MS, 24 * 60 * 60 * 1000); // 1d
+const PHONE_MAX = num(process.env.VENUE_ENQUIRY_PHONE_MAX, 3);
+
+const message429 = {
+  message: "Too many enquiries from this source. Please try again later.",
+};
+
+// Layer 1: per client IP.
+const enquiryIpLimiter = rateLimit({
+  windowMs: IP_WINDOW_MS,
+  max: IP_MAX,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: message429,
+});
+
+// Pull the effective phone (couplePhone preferred, then phone), digits only.
+function effectivePhone(req) {
+  const raw = (req.body && (req.body.couplePhone || req.body.phone)) || "";
+  return String(raw).replace(/\D/g, "");
+}
+
+// Layer 2: per phone number, scoped to the venue slug. Skips when no phone is
+// present (the controller will 400 those) so the IP layer remains the guard.
+const enquiryPhoneLimiter = rateLimit({
+  windowMs: PHONE_WINDOW_MS,
+  max: PHONE_MAX,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: message429,
+  skip: (req) => !effectivePhone(req),
+  keyGenerator: (req) => `${req.params.slug || "?"}:${effectivePhone(req)}`,
+});
+
+module.exports = { enquiryIpLimiter, enquiryPhoneLimiter };

--- a/utils/venueInput.js
+++ b/utils/venueInput.js
@@ -1,0 +1,54 @@
+/**
+ * utils/venueInput.js — shared hostile-input validation for venue write routes.
+ * Helpers return { ok, value } or { ok:false, message } so controllers can 400
+ * cleanly instead of 500-ing on bad casts (e.g. invalid dates) or storing junk.
+ */
+const MAXLEN = { name: 200, phone: 30, email: 200, text: 5000, label: 200, generic: 2000 };
+
+const cleanStr = (v) => (typeof v === "string" ? v.trim() : v == null ? "" : String(v).trim());
+
+// Required short string (e.g. couple name/phone): non-blank, within maxlen.
+function reqStr(v, field, max = MAXLEN.generic) {
+  const s = cleanStr(v);
+  if (!s) return { ok: false, message: `${field} is required` };
+  if (s.length > max) return { ok: false, message: `${field} is too long (max ${max})` };
+  return { ok: true, value: s };
+}
+
+// Optional string: blank allowed; within maxlen.
+function optStr(v, field, max = MAXLEN.generic) {
+  const s = cleanStr(v);
+  if (s.length > max) return { ok: false, message: `${field} is too long (max ${max})` };
+  return { ok: true, value: s };
+}
+
+// Strict date: rejects NaN and absurd years (outside 2000..2099). "" / null → null.
+function optDate(v, field) {
+  if (v == null || v === "") return { ok: true, value: null };
+  const d = new Date(v);
+  if (Number.isNaN(d.getTime())) return { ok: false, message: `${field} is not a valid date` };
+  const y = d.getFullYear();
+  if (y < 2000 || y >= 2100) return { ok: false, message: `${field} year is out of range` };
+  return { ok: true, value: d };
+}
+
+// Optional non-negative number with an upper sanity cap. blank/undefined → undefined.
+function optNumber(v, field, { min = 0, max = 1e12 } = {}) {
+  if (v === undefined || v === null || v === "") return { ok: true, value: undefined };
+  const n = Number(v);
+  if (!Number.isFinite(n)) return { ok: false, message: `${field} must be a number` };
+  if (n < min) return { ok: false, message: `${field} must be >= ${min}` };
+  if (n > max) return { ok: false, message: `${field} is out of range` };
+  return { ok: true, value: n };
+}
+
+// Optional positive integer count with a sanity cap (e.g. guestCount): >0.
+function optCount(v, field, { max = 1e7 } = {}) {
+  if (v === undefined || v === null || v === "") return { ok: true, value: undefined };
+  const n = Number(v);
+  if (!Number.isInteger(n) || n <= 0) return { ok: false, message: `${field} must be a positive whole number` };
+  if (n > max) return { ok: false, message: `${field} is out of range` };
+  return { ok: true, value: n };
+}
+
+module.exports = { MAXLEN, cleanStr, reqStr, optStr, optDate, optNumber, optCount };

--- a/utils/venueMoney.js
+++ b/utils/venueMoney.js
@@ -1,0 +1,37 @@
+/**
+ * utils/venueMoney.js — single source of truth for quote/invoice money math.
+ *
+ * Convention: discount reduces the taxable base; GST is charged on the
+ * post-discount base. All amounts are integer rupees (Math.round).
+ *
+ *   subtotal   = Σ(qty × unitPrice)
+ *   base       = max(0, subtotal − discount)
+ *   gst        = round(base × gstPercent / 100)
+ *   grandTotal = base + gst
+ */
+function computeTotals(lineItems, gstPercent = 18, discount = 0) {
+  const items = Array.isArray(lineItems) ? lineItems : [];
+  const subtotal = items.reduce((sum, li) => {
+    const qty = Number(li && li.qty) || 0;
+    const unit = Number(li && li.unitPrice) || 0;
+    return sum + qty * unit;
+  }, 0);
+  const pct = Number(gstPercent) || 0;
+  const disc = Number(discount) || 0;
+  const base = Math.max(0, subtotal - disc);
+  const gst = Math.round((base * pct) / 100);
+  const grandTotal = base + gst;
+  return {
+    subtotal: Math.round(subtotal),
+    gst,
+    grandTotal,
+  };
+}
+
+// Format integer rupees as "₹1,12,100" (Indian grouping).
+function formatINR(amount) {
+  const n = Math.round(Number(amount) || 0);
+  return "₹" + n.toLocaleString("en-IN");
+}
+
+module.exports = { computeTotals, formatINR };

--- a/utils/venuePdf.js
+++ b/utils/venuePdf.js
@@ -1,0 +1,119 @@
+/**
+ * utils/venuePdf.js — branded PDF generation (pdfkit) for quotes and invoices.
+ * Each function streams directly to the Express response.
+ */
+const PDFDocument = require("pdfkit");
+const { formatINR } = require("./venueMoney");
+
+const BURGUNDY = "#6b1e2e";
+const GOLD = "#c9a961";
+const GREY = "#555555";
+
+function startDoc(res, filename) {
+  const doc = new PDFDocument({ size: "A4", margin: 50 });
+  res.setHeader("Content-Type", "application/pdf");
+  res.setHeader("Content-Disposition", `inline; filename="${filename}"`);
+  doc.pipe(res);
+  return doc;
+}
+
+function venueHeader(doc, venue, titleText) {
+  doc.fillColor(BURGUNDY).fontSize(22).text(venue.name || "Venue", { continued: false });
+  const contact = venue.contact || {};
+  const lines = [
+    venue.address || venue.formattedAddress || "",
+    contact.primaryPhone || venue.phone || "",
+    contact.email || venue.email || "",
+  ].filter(Boolean);
+  doc.moveDown(0.2).fillColor(GREY).fontSize(9).text(lines.join("  •  "));
+  doc.moveDown(0.6);
+  doc.fillColor(GOLD).fontSize(16).text(titleText);
+  doc.moveTo(50, doc.y + 4).lineTo(545, doc.y + 4).strokeColor(GOLD).stroke();
+  doc.moveDown(0.8);
+}
+
+function lineItemsTable(doc, lineItems) {
+  doc.fillColor(BURGUNDY).fontSize(10);
+  const top = doc.y;
+  doc.text("Item", 50, top);
+  doc.text("Day", 280, top, { width: 40, align: "right" });
+  doc.text("Qty", 330, top, { width: 40, align: "right" });
+  doc.text("Unit", 380, top, { width: 75, align: "right" });
+  doc.text("Amount", 460, top, { width: 85, align: "right" });
+  doc.moveTo(50, doc.y + 2).lineTo(545, doc.y + 2).strokeColor("#dddddd").stroke();
+  doc.moveDown(0.4);
+  doc.fillColor("#222222").fontSize(10);
+  (lineItems || []).forEach((li) => {
+    const y = doc.y;
+    const qty = Number(li.qty) || 0;
+    const unit = Number(li.unitPrice) || 0;
+    const label = li.perDay && li.day ? `${li.label} (per day)` : li.label;
+    doc.text(String(label || "—"), 50, y, { width: 220 });
+    doc.text(li.day != null ? String(li.day) : "—", 280, y, { width: 40, align: "right" });
+    doc.text(String(qty), 330, y, { width: 40, align: "right" });
+    doc.text(formatINR(unit), 380, y, { width: 75, align: "right" });
+    doc.text(formatINR(qty * unit), 460, y, { width: 85, align: "right" });
+    doc.moveDown(0.3);
+  });
+  doc.moveTo(50, doc.y + 2).lineTo(545, doc.y + 2).strokeColor("#dddddd").stroke();
+  doc.moveDown(0.5);
+}
+
+function totalsBlock(doc, totals, gstPercent, discount) {
+  const right = (label, value, opts = {}) => {
+    const y = doc.y;
+    doc.fillColor(opts.bold ? BURGUNDY : GREY).fontSize(opts.bold ? 12 : 10);
+    doc.text(label, 330, y, { width: 110, align: "right" });
+    doc.text(value, 450, y, { width: 95, align: "right" });
+    doc.moveDown(0.3);
+  };
+  right("Subtotal", formatINR(totals.subtotal));
+  if (discount) right("Discount", "− " + formatINR(discount));
+  right(`GST (${gstPercent}%)`, formatINR(totals.gst));
+  doc.moveDown(0.1);
+  right("Grand Total", formatINR(totals.grandTotal), { bold: true });
+}
+
+// Quote PDF.
+function streamQuotePdf(res, { venue, enquiry, quote }) {
+  const doc = startDoc(res, `quote-${quote.version || 1}.pdf`);
+  venueHeader(doc, venue, `Quotation  ·  v${quote.version || 1}`);
+  doc.fillColor(GREY).fontSize(10);
+  doc.text(`For: ${(enquiry && (enquiry.coupleName || enquiry.name)) || "—"}`);
+  if (enquiry && enquiry.couplePhone) doc.text(`Phone: ${enquiry.couplePhone}`);
+  doc.text(`Status: ${quote.status || "draft"}`);
+  doc.moveDown(0.8);
+  lineItemsTable(doc, quote.lineItems);
+  totalsBlock(doc, quote.totals || {}, quote.gstPercent, quote.discount);
+  doc.moveDown(2).fillColor(GREY).fontSize(8).text("This is a system-generated quotation.", 50, doc.y, { align: "center", width: 495 });
+  doc.end();
+}
+
+// Invoice PDF (GST format).
+function streamInvoicePdf(res, { venue, booking, invoice }) {
+  const doc = startDoc(res, `${invoice.invoiceNumber}.pdf`);
+  venueHeader(doc, venue, `Tax Invoice  ·  ${invoice.invoiceNumber}`);
+  doc.fillColor(GREY).fontSize(10);
+  const taxLines = [];
+  if (venue.gstin) taxLines.push(`GSTIN: ${venue.gstin}`);
+  if (venue.pan) taxLines.push(`PAN: ${venue.pan}`);
+  if (taxLines.length) doc.text(taxLines.join("   "));
+  doc.text(`Invoice No: ${invoice.invoiceNumber}    Kind: ${invoice.kind}`);
+  if (booking && booking.coupleName) doc.text(`Billed to: ${booking.coupleName}${booking.couplePhone ? "  ·  " + booking.couplePhone : ""}`);
+  doc.text(`Payment status: ${invoice.status}`);
+  doc.moveDown(0.8);
+  lineItemsTable(doc, invoice.lineItems);
+  totalsBlock(doc, invoice.totals || {}, invoice.gstPercent, invoice.discount);
+
+  const paid = (invoice.payments || []).reduce((s, p) => s + (Number(p.amount) || 0), 0);
+  const balance = (invoice.totals ? invoice.totals.grandTotal : 0) - paid;
+  doc.moveDown(0.5).fillColor(GREY).fontSize(10);
+  doc.text(`Received: ${formatINR(paid)}`, 330, doc.y, { width: 110, align: "right" });
+  doc.text(formatINR(paid), 450, doc.y - 12, { width: 95, align: "right" });
+  doc.text(`Balance: ${formatINR(balance)}`, 330, doc.y, { width: 110, align: "right" });
+  doc.text(formatINR(balance), 450, doc.y - 12, { width: 95, align: "right" });
+  doc.moveDown(2).fillColor(GREY).fontSize(8).text("This is a system-generated tax invoice.", 50, doc.y, { align: "center", width: 495 });
+  doc.end();
+}
+
+module.exports = { streamQuotePdf, streamInvoicePdf };

--- a/utils/venueReminderJob.js
+++ b/utils/venueReminderJob.js
@@ -1,0 +1,67 @@
+/**
+ * utils/venueReminderJob.js — Phase 1.4 (optional) follow-up reminder scaffold.
+ *
+ * Daily job: for each venue that has leads with a follow-up due TODAY, send the
+ * owner a WhatsApp summary via the Meta Cloud API.
+ *
+ *  - Env-gated: with no WhatsApp creds it no-ops gracefully (logs, never throws).
+ *  - Log-only mode (REMINDERS_LOG_ONLY, default "true"): compose + log the
+ *    summary but DO NOT actually send. Set REMINDERS_LOG_ONLY=false to send.
+ */
+const VenueEnquiry = require("../models/VenueEnquiry");
+const VenueOwner = require("../models/VenueOwner");
+const { sendWhatsAppText } = require("./whatsapp");
+
+const TERMINAL_STAGES = ["booked", "lost"];
+
+function whatsappConfigured() {
+  const token = process.env.WHATSAPP_CLOUD_TOKEN || process.env.META_WA_ACCESS_TOKEN;
+  const phoneId = process.env.WHATSAPP_PHONE_NUMBER_ID || process.env.META_WA_PHONE_NUMBER_ID;
+  return Boolean(token && phoneId);
+}
+
+async function runDailyFollowUpReminders() {
+  try {
+    const logOnly = process.env.REMINDERS_LOG_ONLY !== "false"; // default true
+    const now = new Date();
+    const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0, 0);
+    const endOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59, 999);
+
+    // Count of leads due today, grouped by venue.
+    const dueToday = await VenueEnquiry.aggregate([
+      { $match: { stage: { $nin: TERMINAL_STAGES }, followUpDate: { $gte: startOfToday, $lte: endOfToday } } },
+      { $group: { _id: "$venueId", count: { $sum: 1 } } },
+    ]);
+
+    if (!dueToday.length) {
+      console.log("[venueReminders] no venues with follow-ups due today");
+      return { venues: 0, sent: 0 };
+    }
+
+    const configured = whatsappConfigured();
+    let sent = 0;
+    for (const row of dueToday) {
+      const owners = await VenueOwner.find({ venueId: row._id, isActive: true }).select("phone name").lean();
+      const summary = `Wedsy reminder: you have ${row.count} lead${row.count === 1 ? "" : "s"} with a follow-up due today. Open your dashboard to act on them.`;
+      for (const owner of owners) {
+        if (logOnly || !configured) {
+          console.log(`[venueReminders]${logOnly ? " (log-only)" : " (no creds)"} -> ${owner.phone}: ${summary}`);
+          continue;
+        }
+        try {
+          await sendWhatsAppText(owner.phone, summary);
+          sent += 1;
+        } catch (e) {
+          console.error(`[venueReminders] send failed for ${owner.phone}:`, e.message);
+        }
+      }
+    }
+    console.log(`[venueReminders] venues=${dueToday.length} sent=${sent} logOnly=${logOnly} configured=${configured}`);
+    return { venues: dueToday.length, sent };
+  } catch (err) {
+    console.error("[venueReminders] error:", err.message);
+    return { error: err.message };
+  }
+}
+
+module.exports = { runDailyFollowUpReminders, whatsappConfigured };

--- a/utils/venueRoles.js
+++ b/utils/venueRoles.js
@@ -1,0 +1,30 @@
+// One venue role vocabulary, shared by VenueOwner.role and VenueTeamMember.role.
+// No "admin" here — that collides with the platform Admin; listing-only is "marketing"
+// and listing+availability is "listing_manager".
+const VENUE_ROLES = ["owner", "manager", "sales", "listing_manager", "marketing"];
+
+// Capability tokens used by the route-level role gate.
+const CAPABILITIES = {
+  LEADS: "leads", // manual add, import, sheets sync, stage moves, assign, comm log
+  LISTING: "listing", // listing/content editing
+  AVAILABILITY: "availability", // calendar / blocked dates
+  TEAM: "team", // invite / list / deactivate members
+  BILLING: "billing", // billing + owner-management (e.g. granting the owner role)
+};
+
+// role -> capabilities. (Confirmed matrix: marketing = listing only.)
+const ROLE_CAPABILITIES = {
+  owner: ["leads", "listing", "availability", "team", "billing"],
+  manager: ["leads", "listing", "availability", "team"],
+  sales: ["leads"],
+  listing_manager: ["listing", "availability"],
+  marketing: ["listing"],
+};
+
+function roleHasCapability(role, capability) {
+  // Missing role → legacy single-owner token; treat as owner (full access).
+  const caps = ROLE_CAPABILITIES[role || "owner"] || [];
+  return caps.includes(capability);
+}
+
+module.exports = { VENUE_ROLES, CAPABILITIES, ROLE_CAPABILITIES, roleHasCapability };

--- a/utils/venueSheetWriteBack.js
+++ b/utils/venueSheetWriteBack.js
@@ -1,0 +1,101 @@
+/**
+ * utils/venueSheetWriteBack.js
+ *
+ * Two-way Google Sheets write-back: when a sheet-synced lead's stage changes in
+ * the dashboard, update that lead's stage cell in the source sheet.
+ *
+ * Design note: the per-row mapping lives on VenueSheetIntegration (rowMap +
+ * stageColumn, captured at sync time) rather than on the shared VenueEnquiry
+ * model — the less invasive of the two options, and it keeps VenueEnquiry
+ * additive-single-field only.
+ *
+ * The pure helpers (columnIndexToLetter / buildRowMap / stageColumnLetter /
+ * resolveWriteTarget) are unit-testable without any live Google call. The single
+ * I/O entry point — writeBackLeadToSheet — is fire-and-forget and never throws;
+ * it no-ops gracefully whenever creds, connection, mapping, or row are missing.
+ */
+const VenueSheetIntegration = require("../models/VenueSheetIntegration");
+const { sheetsConfigured, decryptToken, updateCell } = require("./googleSheets");
+
+const digitsOnly = (v) => String(v == null ? "" : v).replace(/\D/g, "");
+
+// 0-based column index → A1 column letters. 0→A, 25→Z, 26→AA, 27→AB ...
+function columnIndexToLetter(idx) {
+  if (idx == null || idx < 0 || !Number.isFinite(idx)) return "";
+  let n = Math.floor(idx);
+  let s = "";
+  while (n >= 0) {
+    s = String.fromCharCode((n % 26) + 65) + s;
+    n = Math.floor(n / 26) - 1;
+  }
+  return s;
+}
+
+/**
+ * Build { phoneDigits: sheetRowNumber } from a sheet's header + data rows.
+ * sheetRowNumber is 1-based and accounts for the header row (data row i → i+2).
+ * First occurrence of a phone wins, mirroring the import dedup behaviour.
+ */
+function buildRowMap(header, rows, phoneColName) {
+  const map = {};
+  if (!Array.isArray(header) || !Array.isArray(rows) || !phoneColName) return map;
+  const idx = header.indexOf(phoneColName);
+  if (idx < 0) return map;
+  rows.forEach((rowArr, i) => {
+    const phone = digitsOnly(rowArr && rowArr[idx]);
+    if (phone && map[phone] == null) map[phone] = i + 2;
+  });
+  return map;
+}
+
+// Resolve the A1 column letter of the mapped stage column, or "" if unmapped.
+function stageColumnLetter(header, columnMap) {
+  const colName = columnMap && columnMap.stage;
+  if (!Array.isArray(header) || !colName) return "";
+  return columnIndexToLetter(header.indexOf(colName));
+}
+
+/**
+ * Pure: given an integration's stored mapping state and an enquiry, return
+ * either { a1, value } describing the cell to write, or { skip: <reason> }.
+ */
+function resolveWriteTarget(integration, enquiry) {
+  if (!integration || !integration.refreshToken) return { skip: "not_connected" };
+  if (!integration.spreadsheetId || !integration.sheetName) return { skip: "not_configured" };
+  if (!integration.stageColumn) return { skip: "no_stage_column" };
+  const phone = digitsOnly(enquiry && (enquiry.couplePhone || enquiry.phone));
+  if (!phone) return { skip: "no_phone" };
+  const rowMap = integration.rowMap || {};
+  const row = rowMap[phone];
+  if (!row) return { skip: "no_row" };
+  return { a1: `${integration.stageColumn}${row}`, value: enquiry.stage };
+}
+
+/**
+ * Fire-and-forget write-back for a single enquiry's stage. Never throws.
+ * Returns a result object purely for logging / tests.
+ */
+async function writeBackLeadToSheet(enquiry) {
+  try {
+    if (!sheetsConfigured()) return { skipped: "not_configured" };
+    if (!enquiry || !enquiry.venueId) return { skipped: "no_venue" };
+    const integration = await VenueSheetIntegration.findOne({ venue: enquiry.venueId }).lean();
+    const target = resolveWriteTarget(integration, enquiry);
+    if (target.skip) return { skipped: target.skip };
+    const refreshToken = decryptToken(integration.refreshToken);
+    await updateCell(refreshToken, integration.spreadsheetId, integration.sheetName, target.a1, target.value);
+    return { written: true, a1: target.a1, value: target.value };
+  } catch (err) {
+    console.error("[writeBackLeadToSheet] failed:", err.message);
+    return { error: err.message };
+  }
+}
+
+module.exports = {
+  digitsOnly,
+  columnIndexToLetter,
+  buildRowMap,
+  stageColumnLetter,
+  resolveWriteTarget,
+  writeBackLeadToSheet,
+};

--- a/utils/venueWhatsApp.js
+++ b/utils/venueWhatsApp.js
@@ -1,0 +1,61 @@
+/**
+ * utils/venueWhatsApp.js
+ *
+ * Thin Meta WhatsApp Cloud API helper for venue dashboard outbound messages.
+ * Meta Cloud API ONLY (graph.facebook.com) — never Aisensy.
+ *
+ * Env (preferred names per spec, with fallback to the existing server vars):
+ *   WHATSAPP_CLOUD_TOKEN      (fallback META_WA_ACCESS_TOKEN)
+ *   WHATSAPP_PHONE_NUMBER_ID  (fallback META_WA_PHONE_NUMBER_ID)
+ *
+ * If neither token+phoneId is present, isConfigured() === false and callers
+ * must respond 503 { configured: false } rather than attempting a send. Sends
+ * never throw to the caller — failures resolve to { ok: false, error }.
+ */
+const axios = require("axios");
+
+const GRAPH_VERSION = "v19.0";
+
+function getCreds() {
+  const token = process.env.WHATSAPP_CLOUD_TOKEN || process.env.META_WA_ACCESS_TOKEN || "";
+  const phoneNumberId = process.env.WHATSAPP_PHONE_NUMBER_ID || process.env.META_WA_PHONE_NUMBER_ID || "";
+  return { token, phoneNumberId };
+}
+
+function isConfigured() {
+  const { token, phoneNumberId } = getCreds();
+  return Boolean(token && phoneNumberId);
+}
+
+/**
+ * Send a plain text WhatsApp message via the Cloud API.
+ * Returns { ok: true, id } on success or { ok: false, error } on failure.
+ * Never throws.
+ */
+async function sendText(phone, message) {
+  const { token, phoneNumberId } = getCreds();
+  if (!token || !phoneNumberId) {
+    return { ok: false, error: "not_configured" };
+  }
+  const to = String(phone || "").replace(/\D/g, "");
+  if (!to) return { ok: false, error: "invalid_phone" };
+  try {
+    const res = await axios.post(
+      `https://graph.facebook.com/${GRAPH_VERSION}/${phoneNumberId}/messages`,
+      {
+        messaging_product: "whatsapp",
+        to,
+        type: "text",
+        text: { body: String(message || "") },
+      },
+      { headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }, timeout: 15000 }
+    );
+    const id = res.data && res.data.messages && res.data.messages[0] && res.data.messages[0].id;
+    return { ok: true, id: id || null };
+  } catch (err) {
+    const detail = err.response && err.response.data ? JSON.stringify(err.response.data) : err.message;
+    return { ok: false, error: detail };
+  }
+}
+
+module.exports = { isConfigured, sendText };


### PR DESCRIPTION
Integration branch consolidating the venue backend work across the build runs. **Do not merge** outside a coordinated deploy window.

## Summary (run reports)
- **Phase 1/2.1/2.4** baseline + **2.2** Google Sheets one-way sync (+ two-way stage write-back), **2.3** team members & role/capability matrix, **2.5** bulk actions + message templates + bulk WhatsApp (Meta Cloud only, env-gated).
- **Phase 3:** bookings, versioned quotes (+PDF), GST invoices (+PDF, atomic per-venue numbering), payments summary, lost-reason, follow-up reminder cron.
- **Phase 4.1 analytics** (volume/funnel/sources/lost/revenue) **+ couple-side traffic** (views + view→enquiry conversion).
- **Couple-side server:** public `isVerified` (detail + browse, future-proof), public no-PII view beacon, single-date availability-check, browse filters (existing model fields only), public rate limiting.
- **Capability gates** applied per the standing rulings; **member-login determinism** (multi-identity + select-identity); **deactivated-member tokens rejected per request**.
- **Hardening:** input validation, atomic invoice counter, money guards (overpayment/zero-quote/GST), IDOR/tenancy, rate-limit spoofing — permanent `scripts/e2e-hardening.js`.

## Verification
Full harness green: couple **19/19** + mutating/roles **54** + analytics **9** + rate-limit **11** + hardening **61/0/1**. Local Mongo only; WhatsApp verified with creds blanked (no real sends).

## Dependencies
- **pdfkit** — quote/invoice PDF generation.
- **googleapis** — Google Sheets sync.
(Both present in package.json.)

## Env flags
- `REMINDERS_LOG_ONLY=true` (default; follow-up reminder cron logs only, no WhatsApp sends).
- Optional: `VENUE_ENQUIRY_IP_MAX`/`_WINDOW_MS`, `VENUE_ENQUIRY_PHONE_MAX`/`_WINDOW_MS`, `VENUE_PUBLIC_READ_MAX`/`_WINDOW_MS`; Sheets `GOOGLE_SHEETS_CLIENT_ID`/`_SECRET`/`_REDIRECT_URI`, `SHEETS_TOKEN_ENC_KEY`; WhatsApp `WHATSAPP_CLOUD_TOKEN`/`WHATSAPP_PHONE_NUMBER_ID` (fallback `META_WA_*`).

**Deploy in coordinated window only** (server + both frontends ship together).

🤖 Generated with [Claude Code](https://claude.com/claude-code)