### PR TITLE
Settings Platform: permissioned settings, founder-role lock, pipeline/fields/roles editors, ad-form capture, lead journey, tags + bulk transfer + filter builder, first-login reset

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -746,6 +746,26 @@ const ResetPassword = async (req, res) => {
   }
 };
 
+
+// GET /auth/admin/permissions — the caller's resolved permission strings.
+// Drives which Settings sections the frontend renders.
+const GetPermissions = async (req, res) => {
+  try {
+    const admin = await Admin.findById(req.auth.user_id).lean();
+    if (!admin || !admin.roleId) {
+      return res.status(200).send({ permissions: [] });
+    }
+    const Role = require("../models/Role");
+    const role = await Role.findById(admin.roleId).lean();
+    res.status(200).send({
+      permissions: role && Array.isArray(role.permissions) ? role.permissions : [],
+      roleName: role ? role.name : null,
+    });
+  } catch (error) {
+    res.status(500).send({ message: "Server error" });
+  }
+};
+
 module.exports = {
   AdminLogin,
   GetAdmin,
@@ -761,4 +781,5 @@ module.exports = {
   RestoreVendorAccount,
   ForgotPassword,
   ResetPassword,
+  GetPermissions,
 };

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -523,6 +523,8 @@ const AdminLogin = (req, res) => {
             res.send({
               message: "Login Successful",
               token,
+              // Settings Suite Slice 9: client-side gate; token is still issued.
+              mustResetPassword: user.mustResetPassword === true,
             });
           } else {
             res.status(401).send({ message: "Wrong Credentials" });
@@ -574,7 +576,14 @@ const Get = async (req, res) => {
 const GetAdmin = (req, res) => {
   const { user } = req.auth;
   const { name, phone, email, roles } = user;
-  res.send({ name, phone, email, roles });
+  res.send({
+    name,
+    phone,
+    email,
+    roles,
+    // Settings Suite Slice 9: AdminContext routes flagged admins to /set-password.
+    mustResetPassword: user.mustResetPassword === true,
+  });
 };
 
 const GetVendor = (req, res) => {
@@ -747,6 +756,30 @@ const ResetPassword = async (req, res) => {
 };
 
 
+// POST /auth/admin/first-reset — the ONLY action allowed to a flagged admin.
+// Min 8 chars, must differ from the current password; clears the flag.
+const FirstResetPassword = async (req, res) => {
+  try {
+    const { newPassword } = req.body || {};
+    if (typeof newPassword !== "string" || newPassword.length < 8) {
+      return res.status(400).send({ message: "Password must be at least 8 characters" });
+    }
+    const admin = await Admin.findById(req.auth.user_id);
+    if (!admin) return res.status(401).send({ message: "invalid user" });
+    if (await CheckHash(newPassword, admin.password)) {
+      return res.status(400).send({ message: "New password cannot be the same as the current one" });
+    }
+    admin.password = await CreateHash(newPassword);
+    admin.mustResetPassword = false;
+    await admin.save();
+    console.log(`[auth] First-login password set for admin ${admin._id}`);
+    return res.status(200).send({ message: "Password updated" });
+  } catch (error) {
+    console.error("[auth] FirstResetPassword error:", error.message);
+    return res.status(500).send({ message: "Server error" });
+  }
+};
+
 // GET /auth/admin/permissions — the caller's resolved permission strings.
 // Drives which Settings sections the frontend renders.
 const GetPermissions = async (req, res) => {
@@ -782,4 +815,5 @@ module.exports = {
   ForgotPassword,
   ResetPassword,
   GetPermissions,
+  FirstResetPassword,
 };

--- a/controllers/custom-field.js
+++ b/controllers/custom-field.js
@@ -1,0 +1,43 @@
+const CustomFieldService = require("../services/CustomFieldService");
+
+const respond = (res, error) => {
+  const status = error.status || 500;
+  if (status === 500) console.error("[custom-field]", error);
+  res.status(status).json({ message: status === 500 ? "Server error" : error.message });
+};
+
+// GET /custom-field?active=true — readable by any logged-in admin (the cockpit needs defs).
+const GetAll = async (req, res) => {
+  try {
+    const defs = await CustomFieldService.listDefs({ activeOnly: req.query.active === "true" });
+    res.status(200).json(defs);
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+const Create = async (req, res) => {
+  try {
+    res.status(201).json(await CustomFieldService.createDef(req.body || {}));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+const Update = async (req, res) => {
+  try {
+    res.status(200).json(await CustomFieldService.updateDef(req.params.id, req.body || {}));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+const Delete = async (req, res) => {
+  try {
+    res.status(200).json(await CustomFieldService.deleteDef(req.params.id));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+module.exports = { GetAll, Create, Update, Delete };

--- a/controllers/enquiry-import.js
+++ b/controllers/enquiry-import.js
@@ -39,6 +39,7 @@ const Commit = async (req, res) => {
     const options = {
       mapping: parseJson(req.body.mapping, {}),
       stageMapping: parseJson(req.body.stageMapping, {}),
+      ownerMap: parseJson(req.body.ownerMap, {}),
       skipDuplicates: req.body.skipDuplicates !== "false" && req.body.skipDuplicates !== false,
       assignOnImport: req.body.assignOnImport === "true" || req.body.assignOnImport === true,
     };
@@ -51,4 +52,18 @@ const Commit = async (req, res) => {
   }
 };
 
-module.exports = { Preview, Commit };
+// GET /enquiry/import/sample — downloadable CSV in our standard shape.
+const Sample = async (req, res) => {
+  try {
+    const csv = await LeadImportService.sampleCsv();
+    res.setHeader("Content-Type", "text/csv");
+    res.setHeader("Content-Disposition", "attachment; filename=wedsy-import-sample.csv");
+    res.status(200).send(csv);
+  } catch (error) {
+    const status = error.status || 500;
+    if (status === 500) console.error("[import:sample]", error);
+    res.status(status).json({ message: status === 500 ? "Server error" : error.message });
+  }
+};
+
+module.exports = { Preview, Commit, Sample };

--- a/controllers/enquiry-lifecycle.js
+++ b/controllers/enquiry-lifecycle.js
@@ -94,4 +94,32 @@ const SetCustomFields = async (req, res) => {
   }
 };
 
-module.exports = { Dashboard, CompleteFollowUp, Recycle, Convert, Journey, SetCustomFields };
+// PUT /enquiry/:_id/tags (Slice 7a)
+const SetTags = async (req, res) => {
+  try {
+    const updated = await LeadLifecycleService.setTags(
+      req.params._id,
+      (req.body || {}).tags,
+      req.auth.user_id
+    );
+    res.status(200).json(updated);
+  } catch (error) {
+    respondError(res, error);
+  }
+};
+
+// POST /enquiry/bulk-transfer (Slice 7b) — per-document scope check inside.
+const BulkTransfer = async (req, res) => {
+  try {
+    const result = await LeadLifecycleService.bulkTransfer(
+      req.body || {},
+      req.auth.user_id,
+      req.scopeFilter || {}
+    );
+    res.status(200).json(result);
+  } catch (error) {
+    respondError(res, error);
+  }
+};
+
+module.exports = { Dashboard, CompleteFollowUp, Recycle, Convert, Journey, SetCustomFields, SetTags, BulkTransfer };

--- a/controllers/enquiry-lifecycle.js
+++ b/controllers/enquiry-lifecycle.js
@@ -1,4 +1,6 @@
 const DashboardService = require("../services/DashboardService");
+const JourneyService = require("../services/JourneyService");
+const CustomFieldService = require("../services/CustomFieldService");
 const LeadLifecycleService = require("../services/LeadLifecycleService");
 const ProjectService = require("../services/ProjectService");
 
@@ -69,4 +71,27 @@ const Convert = async (req, res) => {
   }
 };
 
-module.exports = { Dashboard, CompleteFollowUp, Recycle, Convert };
+// GET /enquiry/:_id/journey — the lead's full chronological story (Slice 5).
+const Journey = async (req, res) => {
+  try {
+    res.status(200).json(await JourneyService.buildJourney(req.params._id));
+  } catch (error) {
+    respondError(res, error);
+  }
+};
+
+// PUT /enquiry/:_id/custom-fields (Slice 3) — validated against active defs.
+const SetCustomFields = async (req, res) => {
+  try {
+    const updated = await CustomFieldService.setLeadValues(
+      req.params._id,
+      req.body,
+      req.auth.user_id
+    );
+    res.status(200).json(updated);
+  } catch (error) {
+    respondError(res, error);
+  }
+};
+
+module.exports = { Dashboard, CompleteFollowUp, Recycle, Convert, Journey, SetCustomFields };

--- a/controllers/enquiry.js
+++ b/controllers/enquiry.js
@@ -12,6 +12,7 @@ const Order = require("../models/Order");
 const { SendUpdate } = require("../utils/update");
 const { GetPaymentTransactions } = require("../utils/payment");
 const { computeLeadHealth } = require("../utils/leadHealth");
+const { buildFilterConditions } = require("../utils/leadFilterBuilder");
 const EnquiryRepository = require("../repositories/EnquiryRepository");
 const LeadIntakeService = require("../services/LeadIntakeService");
 
@@ -452,10 +453,18 @@ const GetAll = async (req, res) => {
         };
       }
     }
+    // Filter builder (Settings Suite): strict-whitelisted {field,op,value} filters.
+    // Unknown field/op → 400. ALWAYS combined under the same mandatory $and below.
+    let filterConditions = [];
+    try {
+      filterConditions = await buildFilterConditions(req.query.filters);
+    } catch (fbError) {
+      return res.status(fbError.status || 400).send({ message: fbError.message });
+    }
     // RBAC scope: combine req.scopeFilter (built by requirePermission with ownerField
     // "assignedTo") as a MANDATORY $and constraint, so caller params can only narrow
     // within scope, never widen it. For "all" scope req.scopeFilter is {} -> unchanged.
-    const scopedFilter = { $and: [query, req.scopeFilter || {}] };
+    const scopedFilter = { $and: [query, req.scopeFilter || {}, ...filterConditions] };
     if (!(status && ["Hot", "Potential", "Cold"].includes(status))) {
       Enquiry.countDocuments(scopedFilter)
         .then((total) => {
@@ -635,6 +644,7 @@ const GetAll = async (req, res) => {
                     },
                   ]),
               req.scopeFilter || {},
+              ...filterConditions,
             ],
           },
         },

--- a/controllers/role.js
+++ b/controllers/role.js
@@ -3,7 +3,7 @@ const RoleService = require("../services/RoleService");
 // GetAll — GET /role
 const GetAll = async (req, res) => {
   try {
-    const result = await RoleService.getAll();
+    const result = await RoleService.getAll(req.auth.user_id);
     res.status(200).json(result);
   } catch (error) {
     res.status(500).json({ message: error.message });
@@ -14,14 +14,36 @@ const GetAll = async (req, res) => {
 const UpdatePermissions = async (req, res) => {
   try {
     const { permissions, description } = req.body || {};
-    const updated = await RoleService.updatePermissions(req.params.id, { permissions, description });
+    const updated = await RoleService.updatePermissions(req.params.id, { permissions, description }, req.auth.user_id);
     res.status(200).json(updated);
   } catch (error) {
     res.status(error.status || 500).json({ message: error.message });
   }
 };
 
+// Create — POST /role (Settings Suite: settings_roles gate on the route)
+const Create = async (req, res) => {
+  try {
+    const created = await RoleService.createRole(req.body || {}, req.auth.user_id);
+    res.status(201).json(created);
+  } catch (error) {
+    res.status(error.status || 500).json({ message: error.status ? error.message : "Server error" });
+  }
+};
+
+// Delete — DELETE /role/:id (only when zero admins hold it)
+const Delete = async (req, res) => {
+  try {
+    const result = await RoleService.deleteRole(req.params.id, req.auth.user_id);
+    res.status(200).json(result);
+  } catch (error) {
+    res.status(error.status || 500).json({ message: error.status ? error.message : "Server error" });
+  }
+};
+
 module.exports = {
   GetAll,
   UpdatePermissions,
+  Create,
+  Delete,
 };

--- a/controllers/settings.js
+++ b/controllers/settings.js
@@ -1,0 +1,74 @@
+const SettingsService = require("../services/SettingsService");
+const AdminRepository = require("../repositories/AdminRepository");
+const RoleRepository = require("../repositories/RoleRepository");
+const { permissionSatisfies } = require("../middlewares/requirePermission");
+
+const respond = (res, error) => {
+  const status = error.status || 500;
+  if (status === 500) console.error("[settings]", error);
+  res.status(status).json({ message: status === 500 ? "Server error" : error.message });
+};
+
+// Caller's resolved permission strings (empty array when role-less).
+const callerPermissions = async (adminId) => {
+  const admin = await AdminRepository.findById(adminId);
+  if (!admin || !admin.roleId) return [];
+  const role = await RoleRepository.findById(admin.roleId);
+  return role && Array.isArray(role.permissions) ? role.permissions : [];
+};
+
+const canEditCategory = (perms, category) =>
+  permissionSatisfies(perms, `${category}:edit:all`).allowed;
+
+// GET /settings?category=settings_assignment — gated by THAT category's permission.
+const GetCategory = async (req, res) => {
+  try {
+    const category = req.query.category;
+    if (!category) return res.status(400).json({ message: "category is required" });
+    const perms = await callerPermissions(req.auth.user_id);
+    if (!canEditCategory(perms, category)) {
+      return res.status(403).json({ message: "Forbidden", required: `${category}:edit:all` });
+    }
+    const values = await SettingsService.getCategory(category);
+    res.status(200).json({ category, values, defaults: SettingsService.DEFAULTS });
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// PUT /settings { key, value } — the key's category decides the gate.
+const Put = async (req, res) => {
+  try {
+    const { key, value } = req.body || {};
+    if (typeof key !== "string") return res.status(400).json({ message: "key is required" });
+    const category = SettingsService.categoryForKey(key);
+    if (!category) return res.status(400).json({ message: `Unknown setting key: ${key}` });
+    const perms = await callerPermissions(req.auth.user_id);
+    if (!canEditCategory(perms, category)) {
+      return res.status(403).json({ message: "Forbidden", required: `${category}:edit:all` });
+    }
+    const stored = await SettingsService.set(key, value, req.auth.user_id);
+    res.status(200).json({ key, value: stored });
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// GET /settings/public — read-only operational values any logged-in admin needs
+// (cockpit templates, tag library, golden display numbers). No category gate.
+const GetPublic = async (req, res) => {
+  try {
+    const values = await SettingsService.getMany([
+      "whatsapp.templates",
+      "tags.available",
+      "golden.windowMinutes",
+      "golden.workStartHour",
+      "golden.workEndHour",
+    ]);
+    res.status(200).json(values);
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+module.exports = { GetCategory, Put, GetPublic, callerPermissions };

--- a/controllers/stage.js
+++ b/controllers/stage.js
@@ -57,8 +57,9 @@ const Reorder = async (req, res) => {
 const Delete = async (req, res) => {
   try {
     const moveTo = (req.query && req.query.moveTo) || (req.body && req.body.moveTo);
+    const migrateToStageId = req.body && req.body.migrateToStageId;
     const actorId = req.auth && req.auth.user_id;
-    const result = await StageService.deleteStage(req.params.id, moveTo, actorId);
+    const result = await StageService.deleteStage(req.params.id, moveTo, actorId, migrateToStageId);
     res.status(200).json(result);
   } catch (error) {
     res.status(error.status || 500).json({ message: error.message });

--- a/controllers/stage.js
+++ b/controllers/stage.js
@@ -28,11 +28,11 @@ const Create = async (req, res) => {
 // PUT /stages/:id
 const Update = async (req, res) => {
   try {
-    const { name, color, category, order } = req.body || {};
+    const { name, color, category, order, slaHours } = req.body || {};
     const actorId = req.auth && req.auth.user_id;
     const stage = await StageService.updateStage(
       req.params.id,
-      { name, color, category, order },
+      { name, color, category, order, slaHours },
       actorId
     );
     res.status(200).json(stage);

--- a/controllers/webhook.js
+++ b/controllers/webhook.js
@@ -1,6 +1,7 @@
 const Enquiry = require("../models/Enquiry");
 const { SendUpdate } = require("../utils/update");
 const LeadIntakeService = require("../services/LeadIntakeService");
+const AdFormService = require("../services/AdFormService");
 
 const CreateNewAdsLead = async (req, res) => {
   try {
@@ -8,25 +9,49 @@ const CreateNewAdsLead = async (req, res) => {
     if (!name || !phone) {
       return res.status(400).send({ message: "Incomplete Data" });
     }
-    // Lifecycle intake hook (additive): dedup-merge before insert. A re-enquiry
-    // from ads does NOT create a duplicate — it stamps the existing lead and
-    // appends a re_enquired event. Response contract preserved (201 empty).
+    // Ad-form capture (Settings Suite, Slice 4): every extra payload field is an
+    // answer — stored raw, size-guarded, never dropped. The adform.fieldMap
+    // setting additionally maps answers into qualificationData/customFields,
+    // never overwriting non-empty values. Contract preserved: 201 empty.
+    const answers = AdFormService.extractAnswers(req.body);
+
     const existing = await LeadIntakeService.findExistingByNormalizedPhone(phone);
     if (existing) {
+      if (answers) {
+        // Merge NEW answer keys into the lead (existing answers win) + apply mapping
+        // into still-empty fields only.
+        const mergeSets = {};
+        const existingAnswers = existing.additionalInfo?.adFormAnswers || {};
+        for (const [k, v] of Object.entries(answers)) {
+          if (!(k in existingAnswers)) mergeSets[`additionalInfo.adFormAnswers.${k}`] = v;
+        }
+        const { sets } = await AdFormService.mappedSetsFor(answers, existing);
+        Object.assign(mergeSets, sets);
+        if (Object.keys(mergeSets).length) {
+          await Enquiry.findByIdAndUpdate(existing._id, { $set: mergeSets });
+        }
+      }
       await LeadIntakeService.recordReEnquiry(existing._id, {
         source: "Ads (Landing Screen)",
         message: "",
+        adFormAnswers: answers || undefined,
       });
       return res.status(201).send();
     }
-    const result = await new Enquiry({
+
+    const { sets } = await AdFormService.mappedSetsFor(answers, null);
+    const doc = {
       name,
       phone,
       email,
       verified: false,
       source: "Ads (Landing Screen)",
-      additionalInfo: {},
-    }).save();
+      additionalInfo: answers ? { adFormAnswers: answers } : {},
+    };
+    const result = await new Enquiry(doc).save();
+    if (Object.keys(sets).length) {
+      await Enquiry.findByIdAndUpdate(result._id, { $set: sets });
+    }
     // Lifecycle intake hook (additive): auto-assign the new lead.
     LeadIntakeService.afterCreate(result._id);
     SendUpdate({

--- a/models/Admin.js
+++ b/models/Admin.js
@@ -19,6 +19,8 @@ const AdminSchema = new mongoose.Schema(
     // Password reset (additive): sha256 hash of the emailed token + its expiry.
     resetToken: { type: String, default: null },
     resetTokenExpiresAt: { type: Date, default: null },
+    // Settings Suite (additive): force a password change on first login.
+    mustResetPassword: { type: Boolean, default: false },
     meta: {
       designation: { type: String, default: "" },
       employeeId: { type: String, default: "" },

--- a/models/CustomFieldDef.js
+++ b/models/CustomFieldDef.js
@@ -1,0 +1,25 @@
+const mongoose = require("mongoose");
+
+// Custom qualification field definitions (Settings Suite, Slice 3). Values live on
+// Enquiry.customFields (Mixed). Defs are ARCHIVED, never deleted, once any lead
+// holds a value for them.
+const CustomFieldDefSchema = new mongoose.Schema(
+  {
+    key: { type: String, unique: true, required: true }, // slug
+    label: { type: String, required: true },
+    type: {
+      type: String,
+      enum: ["text", "number", "select", "date", "boolean"],
+      required: true,
+    },
+    options: { type: [String], default: [] }, // for type "select"
+    showInCockpit: { type: Boolean, default: true },
+    required: { type: Boolean, default: false },
+    order: { type: Number, default: 0 },
+    status: { type: String, enum: ["active", "archived"], default: "active" },
+  },
+  { timestamps: true }
+);
+
+module.exports =
+  mongoose.models.CustomFieldDef || mongoose.model("CustomFieldDef", CustomFieldDefSchema);

--- a/models/Enquiry.js
+++ b/models/Enquiry.js
@@ -137,6 +137,11 @@ const EnquirySchema = new mongoose.Schema(
       completedAt: { type: Date, default: null },
       completedBy: { type: ObjectId, ref: "Admin", default: null },
     },
+    // ── Settings Suite (additive only) ──────────────────────────────────────
+    // Values for CustomFieldDef-defined fields ({ defKey: value }).
+    customFields: { type: Object, default: {} },
+    // Tag labels picked from the Settings tag library (tags.available).
+    tags: { type: [String], default: [] },
     // ── Lead lifecycle (additive only) ──────────────────────────────────────
     // Intake engine: stamped when an existing lead enquires again (dedup-merge).
     reEnquiredAt: { type: Date, default: null },

--- a/models/Role.js
+++ b/models/Role.js
@@ -9,6 +9,8 @@ const RoleSchema = new mongoose.Schema(
     permissions: { type: [String], default: [] },
     isSystem: { type: Boolean, default: false },
     protected: { type: Boolean, default: false },
+    // Settings Suite (additive): stable machine key; "founder" marks the immutable role.
+    systemKey: { type: String, default: "" },
     deletedAt: { type: Date, default: null },
   },
   { timestamps: true }

--- a/models/Setting.js
+++ b/models/Setting.js
@@ -1,0 +1,15 @@
+const mongoose = require("mongoose");
+const ObjectId = mongoose.Schema.Types.ObjectId;
+
+// Key-value platform settings (Settings Suite). Every key has a hardcoded default
+// in SettingsService — an empty collection means zero behavior change.
+const SettingSchema = new mongoose.Schema(
+  {
+    key: { type: String, unique: true, required: true },
+    value: { type: mongoose.Schema.Types.Mixed },
+    updatedBy: { type: ObjectId, ref: "Admin", default: null },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.models.Setting || mongoose.model("Setting", SettingSchema);

--- a/models/Stage.js
+++ b/models/Stage.js
@@ -8,6 +8,10 @@ const StageSchema = new mongoose.Schema(
     color: { type: String, default: "#4B1528" },
     category: { type: String, enum: ["open", "won", "lost"], default: "open" },
     isSystem: { type: Boolean, default: false },     // system stages can't be deleted
+    // Settings Suite (additive): stable machine key for gate logic (≡ slug for
+    // system stages — slugs never change on rename) + per-stage SLA hours.
+    systemKey: { type: String, default: "" },
+    slaHours: { type: Number, default: null },
     deletedAt: { type: Date, default: null },         // soft delete
   },
   { timestamps: true }

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -2,13 +2,15 @@ const express = require("express");
 const router = express.Router();
 const rateLimit = require("express-rate-limit");
 
-const { CheckLogin } = require("../middlewares/auth");
+const { CheckLogin, CheckAdminLogin } = require("../middlewares/auth");
 const auth = require("../controllers/auth");
 const authInternational = require("../controllers/auth.international");
 
 // Admin Auth
 router.post("/admin", auth.AdminLogin);
 router.get("/admin", CheckLogin, auth.GetAdmin);
+// Settings Suite: resolved permissions for the caller (drives Settings UI visibility).
+router.get("/admin/permissions", CheckAdminLogin, auth.GetPermissions);
 // Password reset (Lifecycle Slice G). Forgot is rate-limited (5/hour/IP) and
 // always answers generically — no user enumeration.
 const forgotLimiter = rateLimit({

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -21,6 +21,8 @@ const forgotLimiter = rateLimit({
 });
 router.post("/admin/forgot", forgotLimiter, auth.ForgotPassword);
 router.post("/admin/reset", auth.ResetPassword);
+// Forced first-login password change (Settings Suite Slice 9).
+router.post("/admin/first-reset", CheckAdminLogin, auth.FirstResetPassword);
 
 // Vendor Auth
 router.post("/vendor", auth.VendorLogin);

--- a/routes/custom-field.js
+++ b/routes/custom-field.js
@@ -1,0 +1,15 @@
+const express = require("express");
+const router = express.Router();
+
+const customField = require("../controllers/custom-field");
+const { CheckAdminLogin } = require("../middlewares/auth");
+const { requirePermission } = require("../middlewares/requirePermission");
+
+// Reads are open to any admin (cockpit + lead detail render the defs).
+router.get("/", CheckAdminLogin, customField.GetAll);
+// Writes are part of the Fields settings category.
+router.post("/", CheckAdminLogin, requirePermission("settings_fields:edit:all"), customField.Create);
+router.put("/:id", CheckAdminLogin, requirePermission("settings_fields:edit:all"), customField.Update);
+router.delete("/:id", CheckAdminLogin, requirePermission("settings_fields:edit:all"), customField.Delete);
+
+module.exports = router;

--- a/routes/enquiry.js
+++ b/routes/enquiry.js
@@ -92,6 +92,19 @@ router.get(
   requirePermission("leads:edit:own"),
   cockpit.GetInternalEvents
 );
+// Settings Suite: journey + custom field values.
+router.get(
+  "/:_id/journey",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own"),
+  lifecycle.Journey
+);
+router.put(
+  "/:_id/custom-fields",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own"),
+  lifecycle.SetCustomFields
+);
 // Lifecycle: follow-up completion (zero-orphan gate), recycle, convert.
 router.put(
   "/:_id/follow-up/:followUpId/complete",

--- a/routes/enquiry.js
+++ b/routes/enquiry.js
@@ -24,6 +24,12 @@ router.get(
 );
 // Lifecycle (Slice F): founder CSV import (the Zoho migration tool). Literal
 // paths above /:_id; multipart handled per-route via express-fileupload.
+router.get(
+  "/import/sample",
+  CheckAdminLogin,
+  requirePermission("leads:create:department"),
+  enquiryImport.Sample
+);
 router.post(
   "/import/preview",
   CheckAdminLogin,
@@ -37,6 +43,14 @@ router.post(
   requirePermission("leads:create:department"),
   fileUpload(),
   enquiryImport.Commit
+);
+// Settings Suite (Slice 7b): bulk transfer — team-or-broader scope, verified per
+// document inside the service. Literal path above /:_id.
+router.post(
+  "/bulk-transfer",
+  CheckAdminLogin,
+  requirePermission("leads:edit:team", { ownerField: "assignedTo" }),
+  lifecycle.BulkTransfer
 );
 router.get("/:_id", CheckAdminLogin, requirePermission("leads:view:own", { ownerField: "assignedTo" }), enquiry.Get);
 router.post("/:_id/user", CheckAdminLogin, enquiry.CreateUser);
@@ -104,6 +118,12 @@ router.put(
   CheckAdminLogin,
   requirePermission("leads:edit:own"),
   lifecycle.SetCustomFields
+);
+router.put(
+  "/:_id/tags",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own"),
+  lifecycle.SetTags
 );
 // Lifecycle: follow-up completion (zero-orphan gate), recycle, convert.
 router.put(

--- a/routes/role.js
+++ b/routes/role.js
@@ -7,5 +7,8 @@ const { requirePermission } = require("../middlewares/requirePermission");
 
 router.get("/", CheckAdminLogin, requirePermission("roles:view:all"), role.GetAll);
 router.put("/:id", CheckAdminLogin, requirePermission("roles:edit:all"), role.UpdatePermissions);
+// Settings Suite: role lifecycle is part of the Roles settings category.
+router.post("/", CheckAdminLogin, requirePermission("settings_roles:edit:all"), role.Create);
+router.delete("/:id", CheckAdminLogin, requirePermission("settings_roles:edit:all"), role.Delete);
 
 module.exports = router;

--- a/routes/router.js
+++ b/routes/router.js
@@ -12,6 +12,7 @@ router.use("/auth", require("./auth"));
 router.use("/user", require("./user"));
 router.use("/enquiry", require("./enquiry"));
 router.use("/project", require("./project")); // Lifecycle Slice D
+router.use("/settings", require("./settings")); // Settings Suite
 router.use("/decor", require("./decor"));
 router.use("/decor-package", require("./decor-package"));
 router.use("/search", require("./search"));

--- a/routes/router.js
+++ b/routes/router.js
@@ -13,6 +13,7 @@ router.use("/user", require("./user"));
 router.use("/enquiry", require("./enquiry"));
 router.use("/project", require("./project")); // Lifecycle Slice D
 router.use("/settings", require("./settings")); // Settings Suite
+router.use("/custom-field", require("./custom-field")); // Settings Suite
 router.use("/decor", require("./decor"));
 router.use("/decor-package", require("./decor-package"));
 router.use("/search", require("./search"));

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -1,0 +1,13 @@
+const express = require("express");
+const router = express.Router();
+
+const settings = require("../controllers/settings");
+const { CheckAdminLogin } = require("../middlewares/auth");
+
+// Category permission gates live INSIDE the controller — the gate depends on the
+// requested category / key, which a route-level requirePermission cannot express.
+router.get("/public", CheckAdminLogin, settings.GetPublic);
+router.get("/", CheckAdminLogin, settings.GetCategory);
+router.put("/", CheckAdminLogin, settings.Put);
+
+module.exports = router;

--- a/routes/stage.js
+++ b/routes/stage.js
@@ -12,26 +12,26 @@ router.get("/", CheckAdminLogin, stage.GetAll);
 router.post(
   "/",
   CheckAdminLogin,
-  requirePermission("settings:edit:all"),
+  requirePermission("settings_pipeline:edit:all"),
   stage.Create
 );
 // "/reorder" must come BEFORE "/:id" so it isn't captured as an id param.
 router.put(
   "/reorder",
   CheckAdminLogin,
-  requirePermission("settings:edit:all"),
+  requirePermission("settings_pipeline:edit:all"),
   stage.Reorder
 );
 router.put(
   "/:id",
   CheckAdminLogin,
-  requirePermission("settings:edit:all"),
+  requirePermission("settings_pipeline:edit:all"),
   stage.Update
 );
 router.delete(
   "/:id",
   CheckAdminLogin,
-  requirePermission("settings:delete:all"),
+  requirePermission("settings_pipeline:edit:all"),
   stage.Delete
 );
 

--- a/scripts/seed-asiya.js
+++ b/scripts/seed-asiya.js
@@ -1,0 +1,54 @@
+/* Seed Asiya Tarannum (Sales Executive) — LOCAL ONLY, idempotent.
+ * On prod, Asiya is created via Settings → Users (founder) OR by running this
+ * script once — founder's call (see deploy checklist).
+ * Run: node scripts/seed-asiya.js
+ */
+require("dotenv").config();
+const mongoose = require("mongoose");
+const Admin = require("../models/Admin");
+const Role = require("../models/Role");
+const { CreateHash } = require("../utils/password");
+
+(async () => {
+  const url = process.env.DATABASE_URL || "";
+  if (!url.includes("localhost") && !url.includes("127.0.0.1")) {
+    console.error("ABORT: this seed is LOCAL ONLY (DATABASE_URL is not localhost).");
+    process.exit(1);
+  }
+  await mongoose.connect(url);
+
+  const existing = await Admin.findOne({ email: "asiya@wedsy.in" });
+  if (existing) {
+    console.log("asiya@wedsy.in already exists — nothing to do");
+    await mongoose.disconnect();
+    return;
+  }
+
+  const role = await Role.findOne({ name: "Sales Executive", deletedAt: null }).lean();
+  if (!role) {
+    console.error("ABORT: Sales Executive role not found");
+    process.exit(1);
+  }
+  // Reporting manager: Asha (Revenue Head). Department: same as the other Sales Execs.
+  const asha = await Admin.findOne({ name: /asha/i }).lean();
+  const peer = await Admin.findOne({ roleId: role._id }).lean();
+  const departmentId = peer ? peer.departmentId : role.departmentId;
+  const legacyRoles = peer ? peer.roles : ["sales"];
+
+  await Admin.create({
+    name: "Asiya Tarannum",
+    email: "asiya@wedsy.in",
+    phone: "PENDING",
+    password: await CreateHash("Wd$y-As9k2Qm"),
+    roles: legacyRoles,
+    roleId: role._id,
+    departmentId,
+    reportingManagerId: asha ? asha._id : null,
+    status: "active",
+    mustResetPassword: true,
+  });
+  console.log(
+    `created asiya@wedsy.in (Sales Executive, manager=${asha ? asha.name : "none found"}, mustResetPassword=true)`
+  );
+  await mongoose.disconnect();
+})();

--- a/scripts/settings-suite-seed.js
+++ b/scripts/settings-suite-seed.js
@@ -1,0 +1,97 @@
+/* Settings Suite one-time idempotent seed (LOCAL DEV — also a prod deploy-checklist
+ * item, run once there by a human):
+ *   1. Stamp the founder role (permissions contain *:*:all) with
+ *      systemKey:"founder" + protected:true — server-enforced immutability.
+ *   2. Stamp system stages (new|contacted|meeting_scheduled|won|lost) with
+ *      systemKey = slug (gate logic references systemKey ≡ slug; renames are safe).
+ *   3. Grant CRM Admin the new settings_* permissions (it previously held
+ *      settings:*:all — same intent under the new per-category resources).
+ *   4. Seed the first custom field def: location ("Location / Service Area", text).
+ * Run: node scripts/settings-suite-seed.js
+ */
+require("dotenv").config();
+const mongoose = require("mongoose");
+const Role = require("../models/Role");
+const Stage = require("../models/Stage");
+const CustomFieldDef = require("../models/CustomFieldDef");
+
+const SETTINGS_PERMS = [
+  "settings_pipeline:edit:all",
+  "settings_fields:edit:all",
+  "settings_assignment:edit:all",
+  "settings_sla:edit:all",
+  "settings_cadence:edit:all",
+  "settings_reasons:edit:all",
+  "settings_integrations:edit:all",
+  "settings_templates:edit:all",
+];
+
+(async () => {
+  await mongoose.connect(process.env.DATABASE_URL);
+  const log = [];
+
+  // 1. Founder stamp
+  const founder = await Role.findOne({ permissions: "*:*:all", deletedAt: null });
+  if (founder) {
+    if (founder.systemKey !== "founder" || founder.protected !== true) {
+      founder.systemKey = "founder";
+      founder.protected = true;
+      await founder.save();
+      log.push(`stamped founder role "${founder.name}" (systemKey=founder, protected)`);
+    } else {
+      log.push("founder role already stamped");
+    }
+  } else {
+    log.push("WARN: no role holds *:*:all — founder stamp skipped");
+  }
+
+  // 2. System stage stamps
+  for (const slug of ["new", "contacted", "meeting_scheduled", "won", "lost"]) {
+    const stage = await Stage.findOne({ slug, deletedAt: null });
+    if (!stage) {
+      log.push(`WARN: system stage "${slug}" not found`);
+      continue;
+    }
+    if (stage.systemKey !== slug || stage.isSystem !== true) {
+      stage.systemKey = slug;
+      stage.isSystem = true;
+      await stage.save();
+      log.push(`stamped stage ${slug}`);
+    } else {
+      log.push(`stage ${slug} already stamped`);
+    }
+  }
+
+  // 3. CRM Admin settings grants (NOT settings_roles — founder-only by policy)
+  const crmAdmin = await Role.findOne({ name: "CRM Admin", deletedAt: null });
+  if (crmAdmin) {
+    const missing = SETTINGS_PERMS.filter((p) => !crmAdmin.permissions.includes(p));
+    if (missing.length) {
+      crmAdmin.permissions.push(...missing);
+      await crmAdmin.save();
+      log.push(`granted CRM Admin: ${missing.length} settings_* permissions`);
+    } else {
+      log.push("CRM Admin already has settings_* permissions");
+    }
+  } else {
+    log.push("WARN: CRM Admin role not found");
+  }
+
+  // 4. First custom field def
+  const loc = await CustomFieldDef.findOne({ key: "location" });
+  if (!loc) {
+    await CustomFieldDef.create({
+      key: "location",
+      label: "Location / Service Area",
+      type: "text",
+      showInCockpit: true,
+      order: 0,
+    });
+    log.push("created custom field def: location");
+  } else {
+    log.push("custom field def location already present");
+  }
+
+  console.log(log.join("\n"));
+  await mongoose.disconnect();
+})();

--- a/services/AdFormService.js
+++ b/services/AdFormService.js
@@ -1,0 +1,78 @@
+const SettingsService = require("./SettingsService");
+const CustomFieldService = require("./CustomFieldService");
+
+// Whitelisted qualificationData targets for ad-form mapping (mirrors the
+// cockpit qualification whitelist).
+const QUALIFICATION_TARGETS = [
+  "groomName", "brideName", "weddingStyle", "venueStatus", "venueName",
+  "venueTypeWanted", "venueArea", "venueBudget", "venueShortlistNote",
+  "email", "whatsappNumber",
+];
+
+const MAX_ANSWERS_BYTES = 20 * 1024; // 20KB raw-answers guard
+const MAX_VALUE_CHARS = 2000;
+
+// Everything in the payload beyond the known intake fields is an ad-form answer.
+const KNOWN_INTAKE_KEYS = new Set(["name", "phone", "email"]);
+
+// Raw answers object from a webhook body: key → stringified answer, size-guarded.
+// Unknown fields are NEVER dropped — oversize values are truncated, and if the
+// total still exceeds the cap, remaining keys are noted under _truncated.
+const extractAnswers = (body = {}) => {
+  const answers = {};
+  let bytes = 2;
+  const truncatedKeys = [];
+  for (const [key, raw] of Object.entries(body)) {
+    if (KNOWN_INTAKE_KEYS.has(key)) continue;
+    if (raw === undefined || raw === null) continue;
+    let value = typeof raw === "string" ? raw : JSON.stringify(raw);
+    if (value.length > MAX_VALUE_CHARS) value = value.slice(0, MAX_VALUE_CHARS) + "…";
+    const entryBytes = key.length + value.length + 6;
+    if (bytes + entryBytes > MAX_ANSWERS_BYTES) {
+      truncatedKeys.push(key);
+      continue;
+    }
+    answers[key] = value;
+    bytes += entryBytes;
+  }
+  if (truncatedKeys.length) {
+    answers._truncated = `payload over ${MAX_ANSWERS_BYTES / 1024}KB — keys dropped: ${truncatedKeys.join(", ")}`;
+  }
+  return Object.keys(answers).length ? answers : null;
+};
+
+// Resolve adform.fieldMap into concrete $set entries for a NEW lead doc.
+// Targets: "qualificationData.<whitelisted>", "customFields.<active key>", "ignore".
+// Never overwrites a non-empty existing value (relevant on re-enquiry merges).
+const mappedSetsFor = async (answers, existingLead = null) => {
+  if (!answers) return { sets: {}, mappedKeys: [] };
+  const fieldMap = await SettingsService.get("adform.fieldMap");
+  const activeDefs = await CustomFieldService.listDefs({ activeOnly: true });
+  const activeKeys = new Set(activeDefs.map((d) => d.key));
+  const sets = {};
+  const mappedKeys = [];
+  for (const [fbKey, target] of Object.entries(fieldMap || {})) {
+    if (!(fbKey in answers) || target === "ignore" || typeof target !== "string") continue;
+    const value = answers[fbKey];
+    if (target.startsWith("qualificationData.")) {
+      const field = target.slice("qualificationData.".length);
+      if (!QUALIFICATION_TARGETS.includes(field)) continue;
+      const current = existingLead?.qualificationData?.[field];
+      if (current === undefined || current === null || current === "") {
+        sets[`qualificationData.${field}`] = value;
+        mappedKeys.push(fbKey);
+      }
+    } else if (target.startsWith("customFields.")) {
+      const key = target.slice("customFields.".length);
+      if (!activeKeys.has(key)) continue;
+      const current = existingLead?.customFields?.[key];
+      if (current === undefined || current === null || current === "") {
+        sets[`customFields.${key}`] = value;
+        mappedKeys.push(fbKey);
+      }
+    }
+  }
+  return { sets, mappedKeys };
+};
+
+module.exports = { extractAnswers, mappedSetsFor, QUALIFICATION_TARGETS, MAX_ANSWERS_BYTES };

--- a/services/CallCockpitService.js
+++ b/services/CallCockpitService.js
@@ -5,9 +5,16 @@ const LeadInternalEventService = require("./LeadInternalEventService");
 const CALL_OUTCOMES = ["", "qualified", "busy", "unknown", "disqualified"];
 const FOLLOW_UP_TYPES = ["meet", "call", "visit"];
 // Attempt cadence (Lifecycle Slice C): day offsets from the FIRST unanswered
-// attempt for attempts #1..#4. Configurable via Settings later.
+// attempt. Runtime values come from SettingsService (cadence.*) which defaults
+// to exactly these constants.
 const ATTEMPT_OFFSETS_DAYS = [0, 1, 3, 5];
 const MAX_ATTEMPTS = 4;
+const SettingsService = require("./SettingsService");
+
+const cadenceConfig = async () => {
+  const cfg = await SettingsService.getMany(["cadence.attemptOffsetsDays", "cadence.maxAttempts"]);
+  return { offsets: cfg["cadence.attemptOffsetsDays"], maxAttempts: cfg["cadence.maxAttempts"] };
+};
 const UNANSWERED_OUTCOMES = ["busy", "unknown"];
 // Whitelisted qualificationData fields a PUT may write (everything else is ignored).
 const QUALIFICATION_STRING_FIELDS = [
@@ -55,29 +62,32 @@ const hasFutureFollowUp = (enquiry, now = new Date()) =>
 // unanswered (busy/unknown) calls so far. Below MAX: suggest the next attempt per
 // the 0/1/3/5-day rhythm anchored to the first unanswered attempt (clamped to
 // tomorrow if the rhythm date already passed). At MAX: unresponsive — rep decides.
-const cadenceFor = (callLog, now = new Date()) => {
+const cadenceFor = (callLog, now = new Date(), cfg = {}) => {
+  const offsets = cfg.offsets || ATTEMPT_OFFSETS_DAYS;
+  const maxAttempts = cfg.maxAttempts || MAX_ATTEMPTS;
   const unanswered = (callLog || []).filter((e) =>
     UNANSWERED_OUTCOMES.includes(e.outcome)
   );
   const attempts = unanswered.length;
-  if (attempts === 0 || attempts >= MAX_ATTEMPTS) {
+  if (attempts === 0 || attempts >= maxAttempts) {
     return {
       attempts,
-      maxAttempts: MAX_ATTEMPTS,
+      maxAttempts,
       suggestedNextAttemptAt: null,
-      unresponsive: attempts >= MAX_ATTEMPTS,
+      unresponsive: attempts >= maxAttempts,
     };
   }
   const first = new Date(unanswered[0].startedAt);
+  const offsetIdx = Math.min(attempts, offsets.length - 1);
   let suggested = new Date(
-    first.getTime() + ATTEMPT_OFFSETS_DAYS[attempts] * 24 * 60 * 60 * 1000
+    first.getTime() + offsets[offsetIdx] * 24 * 60 * 60 * 1000
   );
   if (suggested <= now) {
     suggested = new Date(now.getTime() + 24 * 60 * 60 * 1000);
   }
   return {
     attempts,
-    maxAttempts: MAX_ATTEMPTS,
+    maxAttempts,
     suggestedNextAttemptAt: suggested,
     unresponsive: false,
   };
@@ -85,7 +95,7 @@ const cadenceFor = (callLog, now = new Date()) => {
 
 // Stamp unresponsiveFlaggedAt + event once attempts reach MAX (set-once on the flag).
 const flagUnresponsiveIfNeeded = async (enquiryId, callLog, actorId, alreadyFlaggedAt) => {
-  const cadence = cadenceFor(callLog);
+  const cadence = cadenceFor(callLog, new Date(), await cadenceConfig());
   if (!cadence.unresponsive || alreadyFlaggedAt) return false;
   await EnquiryRepository.updateFieldsById(enquiryId, {
     unresponsiveFlaggedAt: new Date(),
@@ -155,13 +165,14 @@ const logCall = async (
   const doc = stamped || updated;
   const leadObj = doc.toObject ? doc.toObject() : doc;
   if (UNANSWERED_OUTCOMES.includes(entry.outcome)) {
+    const cadCfg = await cadenceConfig();
     const flaggedNow = await flagUnresponsiveIfNeeded(
       enquiryId,
       leadObj.callLog,
       actorId,
       leadObj.unresponsiveFlaggedAt
     );
-    leadObj.cadence = cadenceFor(leadObj.callLog);
+    leadObj.cadence = cadenceFor(leadObj.callLog, new Date(), cadCfg);
     if (flaggedNow) leadObj.unresponsiveFlaggedAt = new Date();
   }
   return leadObj;
@@ -301,6 +312,7 @@ module.exports = {
   listInternalEvents,
   hasFutureFollowUp,
   cadenceFor,
+  cadenceConfig,
   flagUnresponsiveIfNeeded,
   ATTEMPT_OFFSETS_DAYS,
   MAX_ATTEMPTS,

--- a/services/CustomFieldService.js
+++ b/services/CustomFieldService.js
@@ -1,0 +1,144 @@
+const mongoose = require("mongoose");
+const CustomFieldDef = require("../models/CustomFieldDef");
+const Enquiry = require("../models/Enquiry");
+const EnquiryRepository = require("../repositories/EnquiryRepository");
+const LeadInternalEventService = require("./LeadInternalEventService");
+
+const err = (status, message) => Object.assign(new Error(message), { status });
+const TYPES = ["text", "number", "select", "date", "boolean"];
+
+const slugify = (s) =>
+  String(s).toLowerCase().trim().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+
+const listDefs = async ({ activeOnly = false } = {}) => {
+  const q = activeOnly ? { status: "active" } : {};
+  return await CustomFieldDef.find(q).sort({ order: 1, createdAt: 1 }).lean();
+};
+
+const createDef = async ({ key, label, type, options, showInCockpit, required, order } = {}) => {
+  if (typeof label !== "string" || !label.trim()) throw err(400, "label is required");
+  if (!TYPES.includes(type)) throw err(400, `type must be one of: ${TYPES.join(", ")}`);
+  const slug = slugify(key || label);
+  if (!slug) throw err(400, "key produces an empty slug");
+  const existing = await CustomFieldDef.findOne({ key: slug });
+  if (existing) throw err(409, `A field with key "${slug}" already exists`);
+  if (type === "select" && (!Array.isArray(options) || options.length === 0)) {
+    throw err(400, "select fields need a non-empty options array");
+  }
+  return await CustomFieldDef.create({
+    key: slug,
+    label: label.trim(),
+    type,
+    options: type === "select" ? options.map(String) : [],
+    showInCockpit: showInCockpit !== false,
+    required: required === true,
+    order: Number.isFinite(order) ? order : (await CustomFieldDef.countDocuments({})),
+  });
+};
+
+// Update label/options/showInCockpit/required/order/status. key+type are immutable
+// (values already stored under the key with that type).
+const updateDef = async (id, body = {}) => {
+  if (!mongoose.Types.ObjectId.isValid(id)) throw err(400, "Invalid field id");
+  const def = await CustomFieldDef.findById(id);
+  if (!def) throw err(404, "Field not found");
+  const fields = {};
+  if (typeof body.label === "string" && body.label.trim()) fields.label = body.label.trim();
+  if (Array.isArray(body.options)) {
+    if (def.type !== "select") throw err(400, "options only apply to select fields");
+    if (body.options.length === 0) throw err(400, "select fields need at least one option");
+    fields.options = body.options.map(String);
+  }
+  if (typeof body.showInCockpit === "boolean") fields.showInCockpit = body.showInCockpit;
+  if (typeof body.required === "boolean") fields.required = body.required;
+  if (Number.isFinite(body.order)) fields.order = body.order;
+  if (body.status !== undefined) {
+    if (!["active", "archived"].includes(body.status)) throw err(400, "status must be active|archived");
+    fields.status = body.status;
+  }
+  if (!Object.keys(fields).length) throw err(400, "No valid fields to update");
+  return await CustomFieldDef.findByIdAndUpdate(id, { $set: fields }, { new: true }).lean();
+};
+
+// Delete only while NO lead holds a value; otherwise the def must be archived.
+const deleteDef = async (id) => {
+  if (!mongoose.Types.ObjectId.isValid(id)) throw err(400, "Invalid field id");
+  const def = await CustomFieldDef.findById(id);
+  if (!def) throw err(404, "Field not found");
+  const holding = await Enquiry.countDocuments({
+    [`customFields.${def.key}`]: { $exists: true, $nin: [null, ""] },
+  });
+  if (holding > 0) {
+    await CustomFieldDef.findByIdAndUpdate(id, { $set: { status: "archived" } });
+    return { archived: true, holdingLeads: holding, message: `${holding} lead(s) hold a value — archived instead of deleted` };
+  }
+  await CustomFieldDef.findByIdAndDelete(id);
+  return { deleted: true };
+};
+
+// Validate a {key: value} payload against ACTIVE defs. Unknown key → 400.
+const validateValues = async (values) => {
+  if (typeof values !== "object" || values === null || Array.isArray(values)) {
+    throw err(400, "customFields must be an object of { key: value }");
+  }
+  const defs = await listDefs({ activeOnly: true });
+  const byKey = new Map(defs.map((d) => [d.key, d]));
+  const clean = {};
+  for (const [key, value] of Object.entries(values)) {
+    const def = byKey.get(key);
+    if (!def) throw err(400, `Unknown custom field: ${key}`);
+    if (value === null || value === "") {
+      clean[key] = value === null ? null : "";
+      continue;
+    }
+    switch (def.type) {
+      case "text":
+        if (typeof value !== "string" || value.length > 2000) throw err(400, `${key} must be a string ≤2000 chars`);
+        clean[key] = value;
+        break;
+      case "number": {
+        const n = Number(value);
+        if (!Number.isFinite(n)) throw err(400, `${key} must be a number`);
+        clean[key] = n;
+        break;
+      }
+      case "select":
+        if (!def.options.includes(value)) throw err(400, `${key} must be one of: ${def.options.join(", ")}`);
+        clean[key] = value;
+        break;
+      case "date": {
+        const d = new Date(value);
+        if (Number.isNaN(d.getTime())) throw err(400, `${key} must be a valid date`);
+        clean[key] = d;
+        break;
+      }
+      case "boolean":
+        if (typeof value !== "boolean") throw err(400, `${key} must be a boolean`);
+        clean[key] = value;
+        break;
+      default:
+        throw err(400, `Unknown field type for ${key}`);
+    }
+  }
+  return clean;
+};
+
+// PUT /enquiry/:_id/custom-fields — partial merge of validated values.
+const setLeadValues = async (enquiryId, values, actorId) => {
+  if (!mongoose.Types.ObjectId.isValid(enquiryId)) throw err(400, "Invalid enquiry id");
+  const clean = await validateValues(values);
+  if (Object.keys(clean).length === 0) throw err(400, "No custom field values provided");
+  const set = {};
+  for (const [k, v] of Object.entries(clean)) set[`customFields.${k}`] = v;
+  const updated = await EnquiryRepository.updateFieldsById(enquiryId, set);
+  if (!updated) throw err(404, "Enquiry not found");
+  await LeadInternalEventService.record({
+    leadId: enquiryId,
+    type: "custom_fields_updated",
+    actorId,
+    payload: { fields: Object.keys(clean) },
+  });
+  return updated;
+};
+
+module.exports = { listDefs, createDef, updateDef, deleteDef, validateValues, setLeadValues };

--- a/services/DashboardService.js
+++ b/services/DashboardService.js
@@ -11,9 +11,10 @@ const {
   toIstWallClock,
 } = require("../utils/goldenWindow");
 
-// At-risk SLAs — configurable via Settings later; constants for Phase 1.
-const NEW_LEAD_SLA_HOURS = 24; // stage New with no call in 24h
-const CONTACTED_SILENCE_SLA_HOURS = 24; // stage Contacted with no internal event in 24h
+// At-risk SLA defaults — runtime values come from SettingsService (atRisk.*).
+const NEW_LEAD_SLA_HOURS = 24;
+const CONTACTED_SILENCE_SLA_HOURS = 24;
+const SettingsService = require("./SettingsService");
 const RE_ENQUIRED_BADGE_DAYS = 7;
 
 // A lead still in play for active dashboard surfaces.
@@ -50,7 +51,21 @@ const buildDashboard = async (adminId, scope, scopeFilter = {}) => {
   const now = new Date();
   const todayStart = istDayStart(now);
   const todayEnd = istDayEnd(now);
-  const dayAgo = new Date(now.getTime() - NEW_LEAD_SLA_HOURS * 3600 * 1000);
+  const settings = await SettingsService.getMany([
+    "atRisk.newHours",
+    "atRisk.contactedHours",
+    "golden.windowMinutes",
+    "golden.workStartHour",
+    "golden.workEndHour",
+  ]);
+  const newSlaHours = settings["atRisk.newHours"];
+  const contactedSlaHours = settings["atRisk.contactedHours"];
+  const goldenCfg = {
+    windowMinutes: settings["golden.windowMinutes"],
+    workStartHour: settings["golden.workStartHour"],
+    workEndHour: settings["golden.workEndHour"],
+  };
+  const dayAgo = new Date(now.getTime() - newSlaHours * 3600 * 1000);
   const weekAgo = new Date(now.getTime() - 7 * 24 * 3600 * 1000);
 
   // Lazy resurface (Slice E): recycled leads past revisitAt come back before we read.
@@ -154,7 +169,7 @@ const buildDashboard = async (adminId, scope, scopeFilter = {}) => {
   const newUntouched = newUntouchedLeads.map((lead) => {
     // Imported leads anchor the golden window on the IMPORT time, not the
     // (historical) createdAt — a 2024 Zoho lead isn't a breached 30-min window.
-    const gw = goldenWindowFor(lead.importedAt || lead.createdAt, now);
+    const gw = goldenWindowFor(lead.importedAt || lead.createdAt, now, goldenCfg);
     return {
       ...leadRow(lead),
       source: lead.marketingSource || lead.source || "",
@@ -195,11 +210,11 @@ const buildDashboard = async (adminId, scope, scopeFilter = {}) => {
         .map((lead) => {
           const last = lastEventByLead.get(String(lead._id)) || lead.updatedAt;
           const silentHours = (now - new Date(last)) / 3600000;
-          return silentHours > CONTACTED_SILENCE_SLA_HOURS
+          return silentHours > contactedSlaHours
             ? {
                 ...leadRow(lead),
                 reason: "contacted_silent",
-                hoursOverSla: Math.floor(silentHours - CONTACTED_SILENCE_SLA_HOURS),
+                hoursOverSla: Math.floor(silentHours - contactedSlaHours),
               }
             : null;
         })
@@ -273,12 +288,12 @@ const buildDashboard = async (adminId, scope, scopeFilter = {}) => {
 
   // Manager sections only for broader-than-own scopes.
   if (["team", "department", "all"].includes(scope)) {
-    Object.assign(payload, await buildManagerSections(adminId, scope, scopeFilter, { now, todayStart, todayEnd, weekAgo }));
+    Object.assign(payload, await buildManagerSections(adminId, scope, scopeFilter, { now, todayStart, todayEnd, weekAgo, goldenCfg, newSlaHours }));
   }
   return payload;
 };
 
-const buildManagerSections = async (adminId, scope, scopeFilter, { now, todayStart, todayEnd, weekAgo }) => {
+const buildManagerSections = async (adminId, scope, scopeFilter, { now, todayStart, todayEnd, weekAgo, goldenCfg = {}, newSlaHours = NEW_LEAD_SLA_HOURS }) => {
   const { getSubordinateIds } = require("../middlewares/requirePermission");
   const caller = await Admin.findById(adminId).lean();
 
@@ -329,7 +344,7 @@ const buildManagerSections = async (adminId, scope, scopeFilter, { now, todaySta
           ...ACTIVE,
           stage: "new",
           "callLog.0": { $exists: false },
-          createdAt: { $lt: new Date(now.getTime() - NEW_LEAD_SLA_HOURS * 3600 * 1000) },
+          createdAt: { $lt: new Date(now.getTime() - newSlaHours * 3600 * 1000) },
         }),
       ]);
       const byDay = activityByActor.get(String(member._id)) || {};
@@ -393,7 +408,7 @@ const buildManagerSections = async (adminId, scope, scopeFilter, { now, todaySta
   let calledCount = 0;
   let breaches = 0;
   for (const lead of weekLeads) {
-    const deadline = goldenDeadline(lead.createdAt);
+    const deadline = goldenDeadline(lead.createdAt, goldenCfg);
     if (lead.firstCalledAt) {
       minutesSum += (new Date(lead.firstCalledAt) - new Date(lead.createdAt)) / 60000;
       calledCount += 1;

--- a/services/EnquiryService.js
+++ b/services/EnquiryService.js
@@ -4,8 +4,10 @@ const AdminRepository = require("../repositories/AdminRepository");
 const StageRepository = require("../repositories/StageRepository");
 const ActivityLogService = require("./ActivityLogService");
 
-// Fixed set of disqualification reasons. Kept as a plain constant (no enum on the field).
+// Default disqualification reasons. Runtime list comes from SettingsService
+// ("lost.reasons"), which defaults to exactly this constant.
 const LOST_REASONS = ["budget", "competitor", "not_responsive", "not_a_fit", "other"];
+const SettingsService = require("./SettingsService");
 
 const httpError = (status, message) => {
   const err = new Error(message);
@@ -84,7 +86,8 @@ const requestDisqualification = async (enquiryId, { reason, note } = {}, actorId
   if (!mongoose.Types.ObjectId.isValid(enquiryId)) {
     throw httpError(400, "Invalid enquiry id");
   }
-  if (!LOST_REASONS.includes(reason)) {
+  const lostReasons = await SettingsService.get("lost.reasons");
+  if (!lostReasons.includes(reason)) {
     throw httpError(400, "Invalid reason");
   }
   if (note !== undefined && note !== null && typeof note !== "string") {
@@ -100,6 +103,34 @@ const requestDisqualification = async (enquiryId, { reason, note } = {}, actorId
   }
   if (enquiry.lostStatus === "approved") {
     throw httpError(400, "Lead is already lost");
+  }
+
+  // Settings: when approval is switched OFF, a disqualify request is final
+  // immediately (no manager decision step). Default remains approval-required.
+  const approvalRequired = await SettingsService.get("lost.approvalRequired");
+  if (!approvalRequired) {
+    const updatedDirect = await EnquiryRepository.updateFieldsById(enquiryId, {
+      lostStatus: "approved",
+      lostReason: reason,
+      lostNote: note || "",
+      lostRequestedBy: actorId || null,
+      lostRequestedAt: new Date(),
+      lostDecidedBy: actorId || null,
+      lostDecidedAt: new Date(),
+      lostDecisionNote: "Auto-approved (approval disabled in Settings)",
+      stageBeforeLost: enquiry.stage,
+      isLost: true,
+      stage: "lost",
+    });
+    await ActivityLogService.record({
+      actorId,
+      action: "lead.disqualify_approved",
+      entityType: "lead",
+      entityId: String(enquiryId),
+      summary: `Disqualified directly (approval disabled; reason: ${reason})`,
+      meta: { reason, note: note || "", autoApproved: true },
+    });
+    return updatedDirect;
   }
 
   const updated = await EnquiryRepository.updateFieldsById(enquiryId, {

--- a/services/JourneyService.js
+++ b/services/JourneyService.js
@@ -1,0 +1,128 @@
+const mongoose = require("mongoose");
+const Enquiry = require("../models/Enquiry");
+const Admin = require("../models/Admin");
+const LeadInternalEvent = require("../models/LeadInternalEvent");
+const ActivityLog = require("../models/ActivityLog");
+
+const err = (status, message) => Object.assign(new Error(message), { status });
+
+const EVENT_TITLES = {
+  re_enquired: "Enquired again",
+  auto_assigned: "Auto-assigned",
+  assignment_failed: "Auto-assignment failed",
+  call_logged: "Call logged",
+  follow_up_scheduled: "Follow-up scheduled",
+  follow_up_completed: "Follow-up completed",
+  qualification_updated: "Qualification updated",
+  call_completed: "Call wrapped up",
+  unresponsive_flagged: "Flagged unresponsive",
+  recycled: "Recycled",
+  resurfaced: "Resurfaced",
+  resurfaced_by_reenquiry: "Resurfaced — they re-enquired",
+  converted_to_project: "Converted to project ✦",
+  transferred: "Transferred",
+  tags_changed: "Tags changed",
+  custom_fields_updated: "Custom fields updated",
+};
+
+// GET /enquiry/:_id/journey — every moment of a lead's life, one chronological
+// stream, normalized to { at, type, actor, title, detail }.
+const buildJourney = async (enquiryId) => {
+  if (!mongoose.Types.ObjectId.isValid(enquiryId)) throw err(400, "Invalid enquiry id");
+  const lead = await Enquiry.findById(enquiryId).lean();
+  if (!lead) throw err(404, "Enquiry not found");
+
+  const [internalEvents, activityRows] = await Promise.all([
+    LeadInternalEvent.find({ leadId: lead._id }).lean(),
+    // Read-only reuse of the PR #25/#26 ActivityLog stream for this lead.
+    ActivityLog.find({ entityType: "lead", entityId: String(lead._id) }).lean(),
+  ]);
+
+  // Resolve every actor name in one query.
+  const actorIds = new Set();
+  for (const e of internalEvents) if (e.actorId) actorIds.add(String(e.actorId));
+  for (const a of activityRows) if (a.actorId) actorIds.add(String(a.actorId));
+  for (const c of lead.callLog || []) if (c.loggedBy) actorIds.add(String(c.loggedBy));
+  for (const f of lead.followUps || []) {
+    if (f.createdBy) actorIds.add(String(f.createdBy));
+    if (f.completedBy) actorIds.add(String(f.completedBy));
+  }
+  const admins = actorIds.size
+    ? await Admin.find({ _id: { $in: [...actorIds] } }, { name: 1 }).lean()
+    : [];
+  const nameOf = new Map(admins.map((a) => [String(a._id), a.name]));
+  const actor = (id) => (id ? nameOf.get(String(id)) || "—" : "system");
+
+  const entries = [];
+
+  // Birth entry: creation + source + every ad-form answer.
+  entries.push({
+    at: lead.createdAt,
+    type: "created",
+    actor: "system",
+    title: lead.importedAt ? "Imported into the CRM" : "Lead captured",
+    detail: {
+      source: lead.marketingSource || lead.source || "",
+      adFormAnswers: lead.additionalInfo?.adFormAnswers || null,
+    },
+  });
+
+  for (const e of internalEvents) {
+    entries.push({
+      at: e.createdAt,
+      type: e.type,
+      actor: actor(e.actorId),
+      title: EVENT_TITLES[e.type] || e.type,
+      detail: e.payload || {},
+    });
+  }
+
+  for (const a of activityRows) {
+    entries.push({
+      at: a.createdAt,
+      type: a.action,
+      actor: actor(a.actorId),
+      title: a.summary || a.action,
+      detail: a.meta || {},
+    });
+  }
+
+  for (const c of lead.callLog || []) {
+    entries.push({
+      at: c.startedAt,
+      type: "call",
+      actor: actor(c.loggedBy),
+      title: `Call — ${c.outcome || (c.connected ? "connected" : "attempted")}`,
+      detail: {
+        durationSeconds: c.durationSeconds || 0,
+        connected: !!c.connected,
+        outcome: c.outcome || "",
+        notes: c.notes || "",
+      },
+    });
+  }
+
+  for (const f of lead.followUps || []) {
+    entries.push({
+      at: f.createdAt,
+      type: "follow_up_created",
+      actor: actor(f.createdBy),
+      title: `Next step booked — ${f.type}`,
+      detail: { followUpType: f.type, scheduledAt: f.scheduledAt, promiseNote: f.promiseNote || "" },
+    });
+    if (f.completedAt) {
+      entries.push({
+        at: f.completedAt,
+        type: "follow_up_done",
+        actor: actor(f.completedBy),
+        title: `Follow-up done — ${f.completedOutcome || "completed"}`,
+        detail: { followUpType: f.type, outcome: f.completedOutcome || "", notes: f.completedNotes || "" },
+      });
+    }
+  }
+
+  entries.sort((a, b) => new Date(a.at) - new Date(b.at));
+  return { leadId: lead._id, name: lead.name, entries };
+};
+
+module.exports = { buildJourney };

--- a/services/LeadAssignmentService.js
+++ b/services/LeadAssignmentService.js
@@ -4,9 +4,11 @@ const Enquiry = require("../models/Enquiry");
 const LeadInternalEventService = require("./LeadInternalEventService");
 const { istDayStart } = require("../utils/goldenWindow");
 
-// Configurable via Settings later — constants for Phase 1.
+const SettingsService = require("./SettingsService");
+
+// Defaults live in SettingsService (assignment.*) — these constants remain only
+// as exported legacy names; runtime reads the settings (which default to these).
 const DAILY_ASSIGNMENT_CAP = 15;
-// Primary pool first; overflow to the next pool when everyone is at cap.
 const POOL_ROLE_NAMES = ["Sales Intern", "Sales Executive"];
 
 // Least-recently-assigned ACTIVE admin in the pools with remaining daily capacity.
@@ -14,7 +16,14 @@ const POOL_ROLE_NAMES = ["Sales Intern", "Sales Executive"];
 // so brand-new pool members get the next lead).
 const pickAssignee = async () => {
   const todayStart = istDayStart();
-  for (const roleName of POOL_ROLE_NAMES) {
+  const cfg = await SettingsService.getMany([
+    "assignment.poolRoles",
+    "assignment.overflowRoles",
+    "assignment.dailyCap",
+  ]);
+  const poolRoleNames = [...cfg["assignment.poolRoles"], ...cfg["assignment.overflowRoles"]];
+  const dailyCap = cfg["assignment.dailyCap"];
+  for (const roleName of poolRoleNames) {
     const role = await Role.findOne({ name: roleName, deletedAt: null }).lean();
     if (!role) continue;
     const pool = await Admin.find({ roleId: role._id, status: "active" })
@@ -25,7 +34,7 @@ const pickAssignee = async () => {
         assignedTo: admin._id,
         createdAt: { $gte: todayStart },
       });
-      if (assignedToday < DAILY_ASSIGNMENT_CAP) return admin;
+      if (assignedToday < dailyCap) return admin;
     }
   }
   return null;
@@ -36,6 +45,9 @@ const pickAssignee = async () => {
 // Never throws (intake must not fail because assignment did).
 const doAssignLead = async (enquiryId) => {
   try {
+    if (!(await SettingsService.get("assignment.autoAssignEnabled"))) {
+      return null; // auto-assignment switched off in Settings — lead stays unassigned
+    }
     const assignee = await pickAssignee();
     if (!assignee) {
       await LeadInternalEventService.record({

--- a/services/LeadImportService.js
+++ b/services/LeadImportService.js
@@ -3,6 +3,10 @@ const Enquiry = require("../models/Enquiry");
 const Stage = require("../models/Stage");
 const LeadIntakeService = require("./LeadIntakeService");
 const LeadAssignmentService = require("./LeadAssignmentService");
+const SettingsService = require("./SettingsService");
+const CustomFieldService = require("./CustomFieldService");
+const Admin = require("../models/Admin");
+const ProjectRepository = require("../repositories/ProjectRepository");
 
 const IMPORT_SOURCE = "zoho_import";
 const BATCH_SIZE = 500;
@@ -16,6 +20,8 @@ const FIELD_ALIASES = {
   stage: ["stage", "status", "lead status", "pipeline stage", "lead stage"],
   notes: ["notes", "note", "description", "remarks", "comments"],
   createdAt: ["created", "created time", "created at", "created date", "date", "created_date", "created on"],
+  owner: ["owner", "lead owner", "owner name", "assigned to", "assignee"],
+  tags: ["tag", "tags", "rating", "labels"],
 };
 
 const httpError = (status, message) => {
@@ -82,13 +88,35 @@ const preview = async (buffer) => {
     }
   }
 
+  // Slice 8: distinct owner names (for the ownerMap step in the wizard).
+  let distinctOwners = [];
+  if (detectedMapping.owner) {
+    distinctOwners = [
+      ...new Set(
+        parsed.data.map((r) => String(r[detectedMapping.owner] || "").trim()).filter(Boolean)
+      ),
+    ].slice(0, 100);
+  }
+
   return {
     headers,
     detectedMapping,
     rowCount: parsed.data.length,
     sampleRows: parsed.data.slice(0, 10),
     duplicates,
+    distinctOwners,
   };
+};
+
+// Slice 8: a downloadable sample in OUR standard shape — static headers + every
+// ACTIVE custom field key + two filled example rows.
+const sampleCsv = async () => {
+  const defs = await CustomFieldService.listDefs({ activeOnly: true });
+  const headers = ["name", "phone", "email", "source", "stage", "notes", "createdAt", "owner", "tags", ...defs.map((d) => d.key)];
+  const ex1 = ["Priya Sharma", "9876543210", "priya@example.com", "Website", "new", "Asked about Dec wedding", "2026-01-15", "Aafiya", "Premium", ...defs.map(() => "Bengaluru")];
+  const ex2 = ["Arjun Rao", "9876500001", "", "Instagram DM", "contacted", "", "2026-02-02", "", "NRI;Destination", ...defs.map(() => "")];
+  const quote = (v) => (/[",\n]/.test(v) ? `"${String(v).replace(/"/g, '""')}"` : v);
+  return [headers, ex1, ex2].map((row) => row.map(quote).join(",")).join("\n");
 };
 
 const commit = async (buffer, options = {}, actorId) => {
@@ -97,6 +125,7 @@ const commit = async (buffer, options = {}, actorId) => {
     stageMapping = {},
     skipDuplicates = true,
     assignOnImport = false,
+    ownerMap = {},
   } = options;
   if (!mapping.phone || !mapping.name) {
     throw httpError(400, "Mapping must include at least name and phone columns");
@@ -106,6 +135,13 @@ const commit = async (buffer, options = {}, actorId) => {
   const validStages = new Set(
     (await Stage.find({ deletedAt: null }, { slug: 1 }).lean()).map((s) => s.slug)
   );
+  const tagLibrary = await SettingsService.get("tags.available");
+  // ownerMap values are adminIds (validated) or null = leave unassigned.
+  const ownerAdminIds = Object.values(ownerMap).filter(Boolean);
+  const validOwners = ownerAdminIds.length
+    ? new Set((await Admin.find({ _id: { $in: ownerAdminIds } }, { _id: 1 }).lean()).map((a) => String(a._id)))
+    : new Set();
+  const mappedHeaders = new Set(Object.values(mapping).filter(Boolean));
   const phones = await existingPhoneMap();
   const seenInFile = new Set();
   const now = new Date();
@@ -146,6 +182,9 @@ const commit = async (buffer, options = {}, actorId) => {
 
     const zohoStage = mapping.stage ? String(row[mapping.stage] || "").trim() : "";
     let stage = stageMapping[zohoStage] || "new";
+    // Slice 8: the special "convert_to_project" mapping → lead lands as won + Project.
+    const convertToProject = stage === "convert_to_project";
+    if (convertToProject) stage = "won";
     if (!validStages.has(stage)) stage = "new";
 
     let createdAt = now;
@@ -154,6 +193,38 @@ const commit = async (buffer, options = {}, actorId) => {
       if (!Number.isNaN(d.getTime())) createdAt = d;
     }
 
+    // Slice 8: owner mapping ({ name: adminId|null }).
+    let assignedTo = null;
+    if (mapping.owner && row[mapping.owner]) {
+      const ownerName = String(row[mapping.owner]).trim();
+      const mappedId = ownerMap[ownerName];
+      if (mappedId && validOwners.has(String(mappedId))) assignedTo = mappedId;
+    }
+
+    // Slice 8: tag/rating column → real tags where they exist in the library,
+    // a note in additionalInfo otherwise (nothing silently dropped).
+    let tags = [];
+    let unknownTagsNote = "";
+    if (mapping.tags && row[mapping.tags]) {
+      const rawTags = String(row[mapping.tags]).split(/[;,|]/).map((t) => t.trim()).filter(Boolean);
+      tags = rawTags.filter((t) => tagLibrary.includes(t));
+      const unknown = rawTags.filter((t) => !tagLibrary.includes(t));
+      if (unknown.length) unknownTagsNote = `Unrecognized tags from import: ${unknown.join(", ")}`;
+    }
+
+    // Slice 8: every UNMAPPED column survives in additionalInfo.importedFields.
+    const importedFields = {};
+    for (const [header, cell] of Object.entries(row)) {
+      if (mappedHeaders.has(header)) continue;
+      const v = String(cell ?? "").trim();
+      if (v) importedFields[header] = v.slice(0, 1000);
+    }
+
+    const additionalInfo = {};
+    if (mapping.notes && row[mapping.notes]) additionalInfo.importNotes = row[mapping.notes];
+    if (unknownTagsNote) additionalInfo.importTagNote = unknownTagsNote;
+    if (Object.keys(importedFields).length) additionalInfo.importedFields = importedFields;
+
     toCreate.push({
       name,
       phone,
@@ -161,26 +232,50 @@ const commit = async (buffer, options = {}, actorId) => {
       verified: false,
       source: IMPORT_SOURCE,
       stage,
-      additionalInfo: mapping.notes && row[mapping.notes] ? { importNotes: row[mapping.notes] } : {},
+      tags,
+      assignedTo,
+      additionalInfo,
       importedAt: now,
       createdAt,
       updatedAt: createdAt,
-      _assign: assignOnImport && stage === "new",
+      _assign: assignOnImport && stage === "new" && !assignedTo,
+      _convert: convertToProject,
+      _origStage: zohoStage,
     });
   });
 
   let created = 0;
+  let projectsCreated = 0;
   const createdForAssignment = [];
+  const ProjectServiceLazy = require("./ProjectService");
   for (let i = 0; i < toCreate.length; i += BATCH_SIZE) {
     const batch = toCreate.slice(i, i + BATCH_SIZE);
-    const docs = batch.map(({ _assign, ...doc }) => doc);
+    const docs = batch.map(({ _assign, _convert, _origStage, ...doc }) => doc);
     try {
       // timestamps:false → the provided historical createdAt/updatedAt are kept.
       const inserted = await Enquiry.insertMany(docs, { ordered: false, timestamps: false });
       created += inserted.length;
-      inserted.forEach((doc, j) => {
-        if (batch[j] && batch[j]._assign) createdForAssignment.push(doc._id);
-      });
+      for (let j = 0; j < inserted.length; j++) {
+        if (batch[j] && batch[j]._assign) createdForAssignment.push(inserted[j]._id);
+        if (batch[j] && batch[j]._convert) {
+          // "Convert to Project (active)": lead is already won; create the Project.
+          try {
+            const csOwner = await ProjectServiceLazy.defaultCsOwner();
+            await ProjectRepository.create({
+              leadId: inserted[j]._id,
+              coupleNames: inserted[j].name,
+              eventIds: [],
+              csOwnerId: csOwner ? csOwner._id : null,
+              convertedBy: actorId || null,
+              value: 0,
+              handoffNote: `Imported from Bigin – ${batch[j]._origStage || "active"}`,
+            });
+            projectsCreated += 1;
+          } catch (pe) {
+            errors.push({ row: "project", error: `Project create failed for ${inserted[j].name}: ${pe.message}` });
+          }
+        }
+      }
     } catch (e) {
       // ordered:false → successful docs in the batch were still written.
       const okCount = e.insertedDocs ? e.insertedDocs.length : 0;
@@ -197,7 +292,7 @@ const commit = async (buffer, options = {}, actorId) => {
     await LeadAssignmentService.assignLead(id);
   }
 
-  return { created, skippedDuplicates, errors };
+  return { created, skippedDuplicates, errors, projectsCreated };
 };
 
-module.exports = { preview, commit, detectMapping, FIELD_ALIASES, IMPORT_SOURCE };
+module.exports = { preview, commit, sampleCsv, detectMapping, FIELD_ALIASES, IMPORT_SOURCE };

--- a/services/LeadIntakeService.js
+++ b/services/LeadIntakeService.js
@@ -30,7 +30,7 @@ const findExistingByNormalizedPhone = async (phone) => {
 //   lost     → keep the stage; reEnquiredAt feeds the dashboard's
 //              "Returned — they came back" card (last 14 days) with a manager Reopen.
 //   won      → already a client; event only, no badge.
-const recordReEnquiry = async (enquiryId, { source, message } = {}) => {
+const recordReEnquiry = async (enquiryId, { source, message, adFormAnswers } = {}) => {
   try {
     const lead = await Enquiry.findById(enquiryId).lean();
     if (!lead) return;
@@ -39,7 +39,12 @@ const recordReEnquiry = async (enquiryId, { source, message } = {}) => {
       leadId: enquiryId,
       type: "re_enquired",
       actorId: null,
-      payload: { source: source || "", message: message || "" },
+      payload: {
+        source: source || "",
+        message: message || "",
+        // Slice 4: a re-enquiry from an ad form carries its new answers.
+        ...(adFormAnswers ? { adFormAnswers } : {}),
+      },
     });
 
     if (lead.stage === "won") {

--- a/services/LeadLifecycleService.js
+++ b/services/LeadLifecycleService.js
@@ -306,11 +306,89 @@ const completeFollowUp = async (enquiryId, followUpId, body = {}, actorId) => {
   return obj;
 };
 
+// ── Tags (Settings Suite, Slice 7a) ─────────────────────────────────────────
+// Replace the lead's tag set. Every tag must come from the Settings library
+// (tags.available) — free-text additions happen only on the settings page.
+const setTags = async (enquiryId, tags, actorId) => {
+  assertValidId(enquiryId);
+  if (!Array.isArray(tags) || tags.some((t) => typeof t !== "string")) {
+    throw httpError(400, "tags must be an array of strings");
+  }
+  const library = await SettingsService.get("tags.available");
+  const unknown = tags.filter((t) => !library.includes(t));
+  if (unknown.length) {
+    throw httpError(400, `Unknown tag(s): ${unknown.join(", ")} — add them to the library in Settings first`);
+  }
+  const lead = await EnquiryRepository.findById(enquiryId);
+  if (!lead) throw httpError(404, "Enquiry not found");
+  const before = lead.tags || [];
+  const next = [...new Set(tags)];
+  const updated = await EnquiryRepository.updateFieldsById(enquiryId, { tags: next });
+  const added = next.filter((t) => !before.includes(t));
+  const removed = before.filter((t) => !next.includes(t));
+  if (added.length || removed.length) {
+    await LeadInternalEventService.record({
+      leadId: enquiryId,
+      type: "tags_changed",
+      actorId,
+      payload: { added, removed, tags: next },
+    });
+  }
+  return updated;
+};
+
+// ── Bulk transfer (Settings Suite, Slice 7b) ────────────────────────────────
+// Scope is verified PER DOCUMENT: every lead must match the caller's scope filter
+// or the WHOLE batch is rejected (403) listing the out-of-scope ids.
+const bulkTransfer = async ({ leadIds, toAdminId } = {}, actorId, scopeFilter = {}) => {
+  if (!Array.isArray(leadIds) || leadIds.length === 0) {
+    throw httpError(400, "leadIds must be a non-empty array");
+  }
+  if (leadIds.length > 200) throw httpError(400, "Max 200 leads per transfer");
+  for (const id of leadIds) assertValidId(id, "lead id");
+  if (!mongoose.Types.ObjectId.isValid(toAdminId)) throw httpError(400, "Invalid toAdminId");
+
+  const target = await Admin.findById(toAdminId).lean();
+  if (!target) throw httpError(400, "Target admin not found");
+  if (target.status !== "active") throw httpError(422, "Target admin is not active");
+
+  const inScope = await Enquiry.find(
+    { $and: [{ _id: { $in: leadIds } }, scopeFilter] },
+    { _id: 1, assignedTo: 1 }
+  ).lean();
+  const inScopeIds = new Set(inScope.map((l) => String(l._id)));
+  const outOfScope = leadIds.filter((id) => !inScopeIds.has(String(id)));
+  if (outOfScope.length) {
+    throw httpError(403, `Out of your scope: ${outOfScope.join(", ")} — batch rejected`);
+  }
+
+  const fromById = new Map(inScope.map((l) => [String(l._id), l.assignedTo]));
+  await Enquiry.updateMany(
+    { _id: { $in: leadIds } },
+    { $set: { assignedTo: target._id, updatedBy: actorId || null } }
+  );
+  for (const id of leadIds) {
+    await LeadInternalEventService.record({
+      leadId: id,
+      type: "transferred",
+      actorId,
+      payload: {
+        from: fromById.get(String(id)) ? String(fromById.get(String(id))) : null,
+        to: String(target._id),
+        toName: target.name,
+      },
+    });
+  }
+  return { transferred: leadIds.length, to: String(target._id), toName: target.name };
+};
+
 module.exports = {
   recycleLead,
   resurfaceDueLeads,
   completeFollowUp,
   isOpenLead,
+  setTags,
+  bulkTransfer,
   RECYCLE_REASONS,
   COMPLETION_OUTCOMES,
 };

--- a/services/LeadLifecycleService.js
+++ b/services/LeadLifecycleService.js
@@ -7,12 +7,14 @@ const CallCockpitService = require("./CallCockpitService");
 const LeadAssignmentService = require("./LeadAssignmentService");
 const LeadInternalEventService = require("./LeadInternalEventService");
 
+// Default recycle reasons. Runtime list comes from SettingsService ("recycle.reasons").
 const RECYCLE_REASONS = [
   "wedding_next_year",
   "budget_mismatch_now",
   "venue_not_booked",
   "other",
 ];
+const SettingsService = require("./SettingsService");
 const COMPLETION_OUTCOMES = ["connected", "busy", "no_answer", "done"];
 
 const httpError = (status, message) => {
@@ -36,8 +38,9 @@ const isOpenLead = (lead) =>
 // ── Recycle: the third terminal state ──────────────────────────────────────
 const recycleLead = async (enquiryId, { reason, reasonNote, revisitAt } = {}, actorId) => {
   assertValidId(enquiryId);
-  if (!RECYCLE_REASONS.includes(reason)) {
-    throw httpError(400, `Invalid reason (expected one of: ${RECYCLE_REASONS.join(", ")})`);
+  const recycleReasons = await SettingsService.get("recycle.reasons");
+  if (!recycleReasons.includes(reason)) {
+    throw httpError(400, `Invalid reason (expected one of: ${recycleReasons.join(", ")})`);
   }
   if (reasonNote !== undefined && typeof reasonNote !== "string") {
     throw httpError(400, "Invalid reasonNote");
@@ -225,8 +228,9 @@ const completeFollowUp = async (enquiryId, followUpId, body = {}, actorId) => {
       }
     } else if (name === "recycle") {
       const d = new Date(value && value.revisitAt);
-      if (!value || !RECYCLE_REASONS.includes(value.reason)) {
-        throw httpError(400, `recycle needs a valid reason (${RECYCLE_REASONS.join(", ")})`);
+      const recycleReasons = await SettingsService.get("recycle.reasons");
+      if (!value || !recycleReasons.includes(value.reason)) {
+        throw httpError(400, `recycle needs a valid reason (${recycleReasons.join(", ")})`);
       }
       if (!value.revisitAt || Number.isNaN(d.getTime()) || d <= new Date()) {
         throw httpError(422, "recycle.revisitAt is required and must be in the future");

--- a/services/RoleService.js
+++ b/services/RoleService.js
@@ -1,16 +1,42 @@
 const mongoose = require("mongoose");
 const RoleRepository = require("../repositories/RoleRepository");
+const Role = require("../models/Role");
+const Admin = require("../models/Admin");
 const { validatePermissions } = require("../utils/rbacPermissions");
+const { permissionSatisfies } = require("../middlewares/requirePermission");
 
 const err = (status, message) => Object.assign(new Error(message), { status });
 
-const getAll = async () => {
-  return await RoleRepository.findAllActive();
+// ─── Founder-protection helpers (Settings Suite — hard requirement) ───────────
+// The founder role is identified by systemKey "founder" (stamped by the seed) or,
+// defensively, by holding *:*:all.
+const isFounderRole = (role) =>
+  role && (role.systemKey === "founder" || (role.permissions || []).includes("*:*:all"));
+
+const callerContext = async (callerId) => {
+  if (!callerId) return { admin: null, role: null, isFounder: false };
+  const admin = await Admin.findById(callerId).lean();
+  const role = admin && admin.roleId ? await Role.findById(admin.roleId).lean() : null;
+  return { admin, role, isFounder: isFounderRole(role) };
 };
 
-// Update a role's permissions (and optionally description). Permissions-only:
-// name / departmentId / isSystem are never changed here. Protected roles cannot be edited.
-const updatePermissions = async (_id, { permissions, description } = {}) => {
+// Roles list: the founder role (and therefore its matrix row) is INVISIBLE to any
+// caller who does not themselves hold it; for the founder it carries locked:true.
+const getAll = async (callerId) => {
+  const roles = await RoleRepository.findAllActive();
+  const { isFounder } = await callerContext(callerId);
+  return roles
+    .filter((r) => isFounder || !isFounderRole(r))
+    .map((r) => (isFounderRole(r) ? { ...r, locked: true } : r));
+};
+
+// Update a role's permissions (and optionally description).
+// Server-enforced, NO exceptions (not even founder callers):
+//   - the founder role is immutable (422)
+//   - protected roles cannot be edited (403)
+//   - callers cannot edit the role they themselves hold (403, self-elevation block)
+//   - only the founder may grant *:*:all or any settings_roles permission (403)
+const updatePermissions = async (_id, { permissions, description } = {}, callerId) => {
   if (!mongoose.Types.ObjectId.isValid(_id)) {
     throw err(400, "Invalid role id.");
   }
@@ -18,12 +44,27 @@ const updatePermissions = async (_id, { permissions, description } = {}) => {
   if (!role || role.deletedAt) {
     throw err(404, "Role not found.");
   }
+  if (isFounderRole(role)) {
+    throw err(422, "Founder role is immutable");
+  }
   if (role.protected === true) {
     throw err(403, "This role is protected and cannot be edited.");
+  }
+  const { admin, isFounder } = await callerContext(callerId);
+  if (admin && admin.roleId && String(admin.roleId) === String(_id)) {
+    throw err(403, "You cannot edit the role you yourself hold.");
   }
   const { valid, errors } = validatePermissions(permissions);
   if (!valid) {
     throw err(400, `Invalid permissions: ${errors.join("; ")}`);
+  }
+  if (!isFounder) {
+    const grantsForbidden = (permissions || []).some(
+      (p) => p === "*:*:all" || p.startsWith("settings_roles:")
+    );
+    if (grantsForbidden) {
+      throw err(403, "Only the founder can grant *:*:all or settings_roles permissions.");
+    }
   }
   const fields = { permissions: [...new Set(permissions)] };
   if (typeof description === "string") {
@@ -32,7 +73,63 @@ const updatePermissions = async (_id, { permissions, description } = {}) => {
   return await RoleRepository.updateById(_id, fields);
 };
 
+// Create a role: name (+ optional departmentId) cloning permissions from an
+// existing role. Founder-role permissions can never be cloned.
+const createRole = async ({ name, departmentId, cloneFromRoleId, description } = {}, callerId) => {
+  if (typeof name !== "string" || !name.trim()) throw err(400, "name is required");
+  const existing = await Role.findOne({ name: name.trim(), deletedAt: null }).lean();
+  if (existing) throw err(409, "A role with this name already exists");
+
+  let permissions = [];
+  let dept = departmentId;
+  if (cloneFromRoleId) {
+    if (!mongoose.Types.ObjectId.isValid(cloneFromRoleId)) throw err(400, "Invalid cloneFromRoleId");
+    const source = await Role.findById(cloneFromRoleId).lean();
+    if (!source || source.deletedAt) throw err(404, "Clone-source role not found");
+    if (isFounderRole(source)) throw err(422, "Founder role is immutable");
+    permissions = [...source.permissions];
+    dept = dept || source.departmentId;
+  }
+  if (!dept || !mongoose.Types.ObjectId.isValid(String(dept))) {
+    throw err(400, "departmentId is required (or clone from a role that has one)");
+  }
+  const { isFounder } = await callerContext(callerId);
+  if (!isFounder) {
+    permissions = permissions.filter(
+      (p) => p !== "*:*:all" && !p.startsWith("settings_roles:")
+    );
+  }
+  return await Role.create({
+    name: name.trim(),
+    departmentId: dept,
+    description: description || "",
+    permissions,
+    isSystem: false,
+  });
+};
+
+// Delete (soft) a role — only when zero admins hold it; 422 listing holders otherwise.
+const deleteRole = async (_id, callerId) => {
+  if (!mongoose.Types.ObjectId.isValid(_id)) throw err(400, "Invalid role id.");
+  const role = await RoleRepository.findById(_id);
+  if (!role || role.deletedAt) throw err(404, "Role not found.");
+  if (isFounderRole(role)) throw err(422, "Founder role is immutable");
+  if (role.protected === true) throw err(403, "This role is protected and cannot be deleted.");
+  const holders = await Admin.find({ roleId: _id }, { name: 1 }).lean();
+  if (holders.length > 0) {
+    throw err(
+      422,
+      `Cannot delete: ${holders.length} admin(s) hold this role (${holders.map((h) => h.name).join(", ")}). Reassign them first.`
+    );
+  }
+  await Role.findByIdAndUpdate(_id, { $set: { deletedAt: new Date() } });
+  return { deleted: String(_id) };
+};
+
 module.exports = {
   getAll,
   updatePermissions,
+  createRole,
+  deleteRole,
+  isFounderRole,
 };

--- a/services/SettingsService.js
+++ b/services/SettingsService.js
@@ -1,0 +1,201 @@
+const Setting = require("../models/Setting");
+
+// ─── Defaults: the EXACT current hardcoded values. Empty collection ⇒ identical
+// behavior to before this service existed. WhatsApp strings lifted verbatim from
+// the cockpit frontend with {{name}}/{{caller}}/{{time}} placeholders. ───────────
+const DEFAULTS = {
+  "assignment.poolRoles": ["Sales Intern"],
+  "assignment.overflowRoles": ["Sales Executive"],
+  "assignment.dailyCap": 15,
+  "assignment.autoAssignEnabled": true,
+  "golden.windowMinutes": 30,
+  "golden.workStartHour": 10,
+  "golden.workEndHour": 19,
+  "cadence.attemptOffsetsDays": [0, 1, 3, 5],
+  "cadence.maxAttempts": 4,
+  "lost.reasons": ["budget", "competitor", "not_responsive", "not_a_fit", "other"],
+  "lost.approvalRequired": true,
+  "recycle.reasons": ["wedding_next_year", "budget_mismatch_now", "venue_not_booked", "other"],
+  "whatsapp.templates": {
+    busy: "Hi {{name}}! This is {{caller}} from Wedsy. We just connected over a call but unfortunately couldn't get to speak — so I've rescheduled our call for {{time}}. Talk to you then!",
+    unknown:
+      "Hi {{name}}! This is {{caller}} from Wedsy, a wedding planning company. You'd dropped in an enquiry with us and I tried giving you a call, but we couldn't connect. Whenever you have a moment, do let me know a good time to chat — I'd love to help plan your big day!",
+    reschedule:
+      "Hi {{name}}! This is {{caller}} from Wedsy. We just connected over a call but unfortunately couldn't get to speak. I'll reschedule our call and be in touch shortly. Talk to you soon!",
+  },
+  "atRisk.newHours": 24,
+  "atRisk.contactedHours": 24,
+  "tags.available": ["Premium", "NRI", "Destination"],
+  "adform.fieldMap": {},
+};
+
+// key → settings permission category. Every write is gated by ITS category.
+const KEY_CATEGORY = {
+  "assignment.poolRoles": "settings_assignment",
+  "assignment.overflowRoles": "settings_assignment",
+  "assignment.dailyCap": "settings_assignment",
+  "assignment.autoAssignEnabled": "settings_assignment",
+  "golden.windowMinutes": "settings_sla",
+  "golden.workStartHour": "settings_sla",
+  "golden.workEndHour": "settings_sla",
+  "atRisk.newHours": "settings_sla",
+  "atRisk.contactedHours": "settings_sla",
+  "cadence.attemptOffsetsDays": "settings_cadence",
+  "cadence.maxAttempts": "settings_cadence",
+  "lost.reasons": "settings_reasons",
+  "lost.approvalRequired": "settings_reasons",
+  "recycle.reasons": "settings_reasons",
+  "whatsapp.templates": "settings_templates",
+  "tags.available": "settings_templates",
+  "adform.fieldMap": "settings_integrations",
+};
+
+const err = (status, message) => Object.assign(new Error(message), { status });
+
+const isStringArray = (v) =>
+  Array.isArray(v) && v.length > 0 && v.every((s) => typeof s === "string" && s.trim().length > 0);
+const isIntInRange = (v, min, max) => Number.isInteger(v) && v >= min && v <= max;
+
+// Strict per-key validation. Throws 400 on anything off.
+const validateValue = (key, value) => {
+  switch (key) {
+    case "assignment.poolRoles":
+    case "assignment.overflowRoles":
+    case "lost.reasons":
+    case "recycle.reasons":
+    case "tags.available":
+      if (!isStringArray(value)) throw err(400, `${key} must be a non-empty array of non-empty strings`);
+      return value.map((s) => s.trim());
+    case "assignment.dailyCap":
+      if (!isIntInRange(value, 1, 100)) throw err(400, "assignment.dailyCap must be an integer 1–100");
+      return value;
+    case "assignment.autoAssignEnabled":
+    case "lost.approvalRequired":
+      if (typeof value !== "boolean") throw err(400, `${key} must be a boolean`);
+      return value;
+    case "golden.windowMinutes":
+      if (!isIntInRange(value, 5, 480)) throw err(400, "golden.windowMinutes must be an integer 5–480");
+      return value;
+    case "golden.workStartHour":
+      if (!isIntInRange(value, 0, 23)) throw err(400, "golden.workStartHour must be an hour 0–23");
+      return value;
+    case "golden.workEndHour":
+      if (!isIntInRange(value, 1, 24)) throw err(400, "golden.workEndHour must be an hour 1–24");
+      return value;
+    case "atRisk.newHours":
+    case "atRisk.contactedHours":
+      if (!isIntInRange(value, 1, 720)) throw err(400, `${key} must be an integer 1–720`);
+      return value;
+    case "cadence.maxAttempts":
+      if (!isIntInRange(value, 1, 20)) throw err(400, "cadence.maxAttempts must be an integer 1–20");
+      return value;
+    case "cadence.attemptOffsetsDays": {
+      const ok =
+        Array.isArray(value) &&
+        value.length > 0 &&
+        value.every((n) => Number.isInteger(n) && n >= 0) &&
+        value.every((n, i) => i === 0 || n > value[i - 1]);
+      if (!ok) throw err(400, "cadence.attemptOffsetsDays must be a strictly ascending array of non-negative integers");
+      return value;
+    }
+    case "whatsapp.templates": {
+      if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        throw err(400, "whatsapp.templates must be an object of template strings");
+      }
+      const allowed = ["busy", "unknown", "reschedule"];
+      const out = {};
+      for (const k of allowed) {
+        const t = value[k];
+        if (typeof t !== "string" || t.length === 0 || t.length > 1000) {
+          throw err(400, `whatsapp.templates.${k} must be a string of 1–1000 chars`);
+        }
+        out[k] = t;
+      }
+      return out;
+    }
+    case "adform.fieldMap": {
+      if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        throw err(400, "adform.fieldMap must be an object of { fbKey: target }");
+      }
+      for (const [k, v] of Object.entries(value)) {
+        if (typeof k !== "string" || typeof v !== "string") {
+          throw err(400, "adform.fieldMap entries must be string → string");
+        }
+      }
+      return value;
+    }
+    default:
+      throw err(400, `Unknown setting key: ${key}`);
+  }
+};
+
+// ─── 60s read cache ──────────────────────────────────────────────────────────
+const CACHE_TTL_MS = 60 * 1000;
+let cache = { values: null, expires: 0 };
+
+const loadAll = async () => {
+  if (cache.values && cache.expires > Date.now()) return cache.values;
+  const docs = await Setting.find({}).lean();
+  const values = {};
+  for (const d of docs) values[d.key] = d.value;
+  cache = { values, expires: Date.now() + CACHE_TTL_MS };
+  return values;
+};
+
+const invalidate = () => {
+  cache = { values: null, expires: 0 };
+};
+
+// Read one key — stored value if present, else the hardcoded default.
+const get = async (key) => {
+  if (!(key in DEFAULTS)) throw err(400, `Unknown setting key: ${key}`);
+  const values = await loadAll();
+  return key in values ? values[key] : DEFAULTS[key];
+};
+
+const getMany = async (keys) => {
+  const values = await loadAll();
+  const out = {};
+  for (const key of keys) {
+    if (!(key in DEFAULTS)) throw err(400, `Unknown setting key: ${key}`);
+    out[key] = key in values ? values[key] : DEFAULTS[key];
+  }
+  return out;
+};
+
+// Write one key (validated). Returns the stored value.
+const set = async (key, value, updatedBy) => {
+  const clean = validateValue(key, value);
+  await Setting.findOneAndUpdate(
+    { key },
+    { $set: { value: clean, updatedBy: updatedBy || null } },
+    { upsert: true, new: true }
+  );
+  invalidate();
+  return clean;
+};
+
+// All keys of one category with effective values (for GET /settings?category=).
+const getCategory = async (category) => {
+  const keys = Object.entries(KEY_CATEGORY)
+    .filter(([, cat]) => cat === category)
+    .map(([k]) => k);
+  if (keys.length === 0) throw err(400, `Unknown settings category: ${category}`);
+  return await getMany(keys);
+};
+
+const categoryForKey = (key) => KEY_CATEGORY[key] || null;
+const CATEGORIES = [...new Set(Object.values(KEY_CATEGORY))];
+
+module.exports = {
+  DEFAULTS,
+  KEY_CATEGORY,
+  CATEGORIES,
+  get,
+  getMany,
+  set,
+  getCategory,
+  categoryForKey,
+  validateValue,
+  invalidate, // exported for tests
+};

--- a/services/StageService.js
+++ b/services/StageService.js
@@ -60,7 +60,7 @@ const createStage = async ({ name, color, category } = {}, actorId) => {
 
 // Rename / recolor / reorder a single stage. NEVER changes slug — leads store the slug,
 // so renaming is display-only to keep existing leads valid.
-const updateStage = async (id, { name, color, category, order } = {}, actorId) => {
+const updateStage = async (id, { name, color, category, order, slaHours } = {}, actorId) => {
   if (!mongoose.Types.ObjectId.isValid(id)) throw err(400, "Invalid stage id");
   const existing = await StageRepository.findById(id);
   if (!existing) throw err(404, "Stage not found");
@@ -83,6 +83,12 @@ const updateStage = async (id, { name, color, category, order } = {}, actorId) =
   }
   if (typeof order === "number" && Number.isFinite(order)) {
     fields.order = order;
+  }
+  if (slaHours !== undefined) {
+    if (slaHours !== null && (!Number.isFinite(slaHours) || slaHours < 0 || slaHours > 8760)) {
+      throw err(400, "slaHours must be null or a number 0–8760");
+    }
+    fields.slaHours = slaHours;
   }
 
   if (Object.keys(fields).length === 0) return existing;
@@ -130,12 +136,21 @@ const reorderStages = async (orderedIds, actorId) => {
   return { stages };
 };
 
-const deleteStage = async (id, moveToSlug, actorId) => {
+const deleteStage = async (id, moveToSlug, actorId, migrateToStageId) => {
   if (!mongoose.Types.ObjectId.isValid(id)) throw err(400, "Invalid stage id");
   const existing = await StageRepository.findById(id);
   if (!existing) throw err(404, "Stage not found");
-  if (existing.isSystem === true) {
-    throw err(400, "Cannot delete a system stage");
+  // Settings Suite: accept migrateToStageId (preferred) — resolve it to a slug.
+  if (!moveToSlug && migrateToStageId) {
+    if (!mongoose.Types.ObjectId.isValid(migrateToStageId)) {
+      throw err(400, "Invalid migrateToStageId");
+    }
+    const target = await StageRepository.findById(migrateToStageId);
+    if (!target) throw err(400, "migrateToStageId not found");
+    moveToSlug = target.slug;
+  }
+  if (existing.isSystem === true || existing.systemKey) {
+    throw err(422, "Cannot delete a system stage");
   }
   const total = await StageRepository.countAll();
   if (total <= 1) throw err(400, "Cannot delete the only stage");

--- a/utils/goldenWindow.js
+++ b/utils/goldenWindow.js
@@ -21,29 +21,33 @@ const istDayStart = (now = new Date()) => {
 const istDayEnd = (now = new Date()) =>
   new Date(istDayStart(now).getTime() + 24 * 60 * 60 * 1000 - 1);
 
-// First-call deadline for a lead created at `createdAt`.
-const goldenDeadline = (createdAt) => {
+// First-call deadline for a lead created at `createdAt`. cfg overrides come from
+// SettingsService (golden.*); omitted ⇒ the original constants.
+const goldenDeadline = (createdAt, cfg = {}) => {
+  const windowMinutes = cfg.windowMinutes ?? GOLDEN_WINDOW_MINUTES;
+  const workStart = cfg.workStartHour ?? WORK_START_HOUR;
+  const workEnd = cfg.workEndHour ?? WORK_END_HOUR;
   const created = new Date(createdAt);
   const ist = toIstWallClock(created);
   const hour = ist.getUTCHours();
-  if (hour >= WORK_START_HOUR && hour < WORK_END_HOUR) {
-    return new Date(created.getTime() + GOLDEN_WINDOW_MINUTES * 60 * 1000);
+  if (hour >= workStart && hour < workEnd) {
+    return new Date(created.getTime() + windowMinutes * 60 * 1000);
   }
-  // Out of hours: due 10:30 IST the same morning (created 00:00–09:59)
-  // or the next morning (created 19:00–23:59).
-  const dayShift = hour < WORK_START_HOUR ? 0 : 1;
+  // Out of hours: due workStart:30 IST the same morning (created before work)
+  // or the next morning (created after work).
+  const dayShift = hour < workStart ? 0 : 1;
   return fromIstParts(
     ist.getUTCFullYear(),
     ist.getUTCMonth(),
     ist.getUTCDate() + dayShift,
-    WORK_START_HOUR,
+    workStart,
     OUT_OF_HOURS_DUE_MINUTE
   );
 };
 
 // { deadline, inWindow, minutesLeft, minutesOver } for an uncalled lead.
-const goldenWindowFor = (createdAt, now = new Date()) => {
-  const deadline = goldenDeadline(createdAt);
+const goldenWindowFor = (createdAt, now = new Date(), cfg = {}) => {
+  const deadline = goldenDeadline(createdAt, cfg);
   const msLeft = deadline.getTime() - now.getTime();
   return {
     deadline,

--- a/utils/leadFilterBuilder.js
+++ b/utils/leadFilterBuilder.js
@@ -1,0 +1,137 @@
+// Filter builder (Settings Suite, Slice 7c). Parses a `filters` query param —
+// JSON array of { field, op, value } — into Mongo conditions with STRICT
+// whitelists. Unknown field or op → 400. The caller's scope filter is ALWAYS
+// ANDed separately; nothing here can widen scope.
+const CustomFieldService = require("../services/CustomFieldService");
+
+const err = (status, message) => Object.assign(new Error(message), { status });
+
+const QUALIFICATION_KEYS = [
+  "groomName", "brideName", "weddingStyle", "venueStatus", "venueName",
+  "venueTypeWanted", "venueArea", "venueBudget", "venueShortlistNote",
+  "email", "whatsappNumber",
+];
+
+// field → allowed ops + value kind
+const STATIC_FIELDS = {
+  stage: { ops: ["eq", "in"], kind: "string" },
+  source: { ops: ["eq", "in", "contains"], kind: "string" },
+  assignedTo: { ops: ["eq", "in", "exists"], kind: "string" },
+  tags: { ops: ["eq", "in", "contains"], kind: "string" }, // array field: eq/in match elements
+  createdAt: { ops: ["gte", "lte"], kind: "date" },
+  reEnquiredAt: { ops: ["gte", "lte", "exists"], kind: "date" },
+  qualified: { ops: ["eq"], kind: "boolean" },
+  "recycled.isRecycled": { ops: ["eq"], kind: "boolean" },
+  importedAt: { ops: ["exists"], kind: "date" },
+};
+
+const escapeRegExp = (s) => String(s).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const castValue = (kind, value, field) => {
+  if (kind === "date") {
+    const d = new Date(value);
+    if (Number.isNaN(d.getTime())) throw err(400, `Invalid date for ${field}`);
+    return d;
+  }
+  if (kind === "boolean") {
+    if (typeof value === "boolean") return value;
+    if (value === "true") return true;
+    if (value === "false") return false;
+    throw err(400, `Invalid boolean for ${field}`);
+  }
+  if (typeof value !== "string" && typeof value !== "number") {
+    throw err(400, `Invalid value for ${field}`);
+  }
+  return value;
+};
+
+const conditionFor = (field, op, value, kind) => {
+  switch (op) {
+    case "eq":
+      return { [field]: castValue(kind, value, field) };
+    case "in": {
+      if (!Array.isArray(value) || value.length === 0) {
+        throw err(400, `"in" needs a non-empty array for ${field}`);
+      }
+      return { [field]: { $in: value.map((v) => castValue(kind, v, field)) } };
+    }
+    case "contains": {
+      if (typeof value !== "string" || !value.trim()) {
+        throw err(400, `"contains" needs a string for ${field}`);
+      }
+      return { [field]: { $regex: new RegExp(escapeRegExp(value.trim()), "i") } };
+    }
+    case "gte":
+      return { [field]: { $gte: castValue(kind, value, field) } };
+    case "lte":
+      return { [field]: { $lte: castValue(kind, value, field) } };
+    case "exists": {
+      const wants = value === true || value === "true" || value === undefined;
+      // exists ⇒ present AND non-null (an unset importedAt is stored as null).
+      return wants
+        ? { [field]: { $exists: true, $nin: [null, ""] } }
+        : { $or: [{ [field]: { $exists: false } }, { [field]: null }] };
+    }
+    default:
+      throw err(400, `Unknown op: ${op}`);
+  }
+};
+
+// Parse + validate, returning an array of Mongo conditions to AND in.
+const buildFilterConditions = async (filtersRaw) => {
+  if (filtersRaw === undefined || filtersRaw === null || filtersRaw === "") return [];
+  let filters;
+  try {
+    filters = typeof filtersRaw === "string" ? JSON.parse(filtersRaw) : filtersRaw;
+  } catch {
+    throw err(400, "filters must be valid JSON");
+  }
+  if (!Array.isArray(filters)) throw err(400, "filters must be an array");
+  if (filters.length > 20) throw err(400, "Too many filters (max 20)");
+
+  const activeDefs = await CustomFieldService.listDefs({ activeOnly: true });
+  const customKinds = new Map(
+    activeDefs.map((d) => [
+      d.key,
+      d.type === "number" ? "number" : d.type === "date" ? "date" : d.type === "boolean" ? "boolean" : "string",
+    ])
+  );
+
+  const conditions = [];
+  for (const f of filters) {
+    if (!f || typeof f.field !== "string" || typeof f.op !== "string") {
+      throw err(400, "Each filter needs { field, op, value }");
+    }
+    const { field, op, value } = f;
+
+    if (field in STATIC_FIELDS) {
+      const spec = STATIC_FIELDS[field];
+      if (!spec.ops.includes(op)) throw err(400, `Op "${op}" not allowed for ${field}`);
+      conditions.push(conditionFor(field, op, value, spec.kind));
+      continue;
+    }
+    if (field.startsWith("qualificationData.")) {
+      const key = field.slice("qualificationData.".length);
+      if (!QUALIFICATION_KEYS.includes(key)) throw err(400, `Unknown field: ${field}`);
+      if (!["eq", "in", "contains", "exists"].includes(op)) {
+        throw err(400, `Op "${op}" not allowed for ${field}`);
+      }
+      conditions.push(conditionFor(field, op, value, "string"));
+      continue;
+    }
+    if (field.startsWith("customFields.")) {
+      const key = field.slice("customFields.".length);
+      if (!customKinds.has(key)) throw err(400, `Unknown field: ${field}`);
+      const kind = customKinds.get(key);
+      const allowed =
+        kind === "number" || kind === "date" ? ["eq", "gte", "lte", "exists"] : ["eq", "in", "contains", "exists"];
+      if (!allowed.includes(op)) throw err(400, `Op "${op}" not allowed for ${field}`);
+      conditions.push(conditionFor(field, op, value, kind));
+      continue;
+    }
+    throw err(400, `Unknown field: ${field}`);
+  }
+  return conditions;
+};
+
+module.exports = { buildFilterConditions, STATIC_FIELDS, QUALIFICATION_KEYS };

--- a/utils/rbacPermissions.js
+++ b/utils/rbacPermissions.js
@@ -9,6 +9,10 @@
 const RESOURCES = [
   "leads", "projects", "tasks", "content", "internal_ops",
   "attendance", "incentives", "users", "roles", "reports", "settings",
+  // Settings Suite — per-category settings permissions (action "edit", scope "all").
+  "settings_pipeline", "settings_fields", "settings_assignment", "settings_sla",
+  "settings_cadence", "settings_reasons", "settings_integrations",
+  "settings_templates", "settings_roles",
 ];
 const ACTIONS = ["view", "create", "edit", "delete", "assign", "export", "approve"];
 const SCOPES = ["own", "team", "department", "all"];


### PR DESCRIPTION
## Summary

The permissioned Settings Platform (MEGA-BUILD 2). Every operational constant becomes a permission-gated setting with hardcoded defaults — an empty Setting collection means zero behavior change.

### Slices
1. **SettingsService config takeover**: Setting model + 60s-cached service; GET/PUT /settings gated per category; GET /settings/public; GET /auth/admin/permissions (drives Settings UI visibility). Rewired consumers: assignment pools/cap/toggle, golden window, cadence rhythm, lost + recycle reasons, lost.approvalRequired (off = instant final disqualify, audited), at-risk SLA hours. Strict per-key validation (cap 1–100, window 5–480, ascending offsets, template ≤1000 chars).
2. **Pipeline editor**: additive Stage systemKey/slaHours; system stages rename/color/order/SLA but delete → 422; custom stages delete with {migrateToStageId} migrating all leads; gates key on immutable slugs (≡ systemKey) — proven by running the 422 invariant against a renamed Meeting Scheduled.
3. **Custom fields builder**: CustomFieldDef CRUD (archive, never delete, once any lead holds a value); Enquiry.customFields + PUT /enquiry/:_id/custom-fields with strict type/options/unknown-key validation; cockpit renders a "Custom" qualification group.
4. **Ad-form capture**: webhook stores ALL extra payload fields raw in additionalInfo.adFormAnswers (20KB guard, truncation annotated, nothing silently dropped); adform.fieldMap maps answers into qualificationData/customFields without overwriting; re-enquiries merge new answers + carry them on the event. 201-empty contract and validation preserved exactly.
5. **Lead Journey**: GET /enquiry/:_id/journey — creation (+source +ad answers), internal events, ActivityLog reuse, calls, follow-ups (booked + done), normalized and chronological; Journey tab on lead detail.
6. **Roles & users platform**: matrix grid with the new settings_* resources, role create (clone) + delete (only with zero holders, 422 listing them), plain-words permission-diff confirm dialog; Users deactivate flow with open-lead transfer.
7. **Tags + bulk transfer + filter builder**: library-validated lead tags with events; POST /enquiry/bulk-transfer (leads:edit:team) with PER-DOCUMENT scope verification — one out-of-scope id rejects the whole batch (403, ids listed), inactive target 422; GET /enquiry filters= with strict field/op whitelists (static + qualificationData.* + active customFields.*), unknown field/op 400, caller scope ALWAYS ANDed.
8. **Import polish**: sample CSV endpoint (standard headers + active custom field keys), unmapped columns preserved in additionalInfo.importedFields, owner mapping (preview distinctOwners → commit ownerMap), tag/rating column → library tags (unknowns noted), stage mapping "convert_to_project" → lead lands won + Project ("Imported from Bigin – <orig stage>").
9. **First-login reset**: additive Admin.mustResetPassword surfaced in login + profile; POST /auth/admin/first-reset (min 8, must differ); client-enforced blocking /set-password screen.
10. **Asiya seed**: scripts/seed-asiya.js (LOCAL-ONLY guard) — on prod create her via Settings → Users instead.

### Founder-role immutability (server-enforced, no exceptions)
The founder role (systemKey "founder", stamped by the seed) cannot be renamed, edited, permission-changed, or deleted — 422 "Founder role is immutable" even for founder callers. It is invisible in role lists to anyone not holding it (locked read-only row for the founder). Non-founders cannot grant *:*:all or any settings_roles permission (403) and cannot edit their own role (self-elevation block).

### New permission resources
settings_pipeline, settings_fields, settings_assignment, settings_sla, settings_cadence, settings_reasons, settings_integrations, settings_templates, settings_roles — all action "edit", scope "all". Founder *:*:all satisfies all (verified against permissionSatisfies). **settings_roles stays founder-only** — the seed grants CRM Admin every other settings_* permission (it previously held settings:*:all).

### Prerequisites
- Run `node scripts/settings-suite-seed.js` **once on prod** (idempotent): founder-role stamp, stage systemKeys, CRM Admin settings grants, `location` custom field def.
- (If not already run from the lifecycle PR: `scripts/lifecycle-role-patch.js`.)
- **No new dependencies.**

### Verification
Settings suite 58/58 (incl. empty-collection ≡ constants proof and the renamed-stage gate proof), Puppeteer UI 19/19 (visibility per role, founder lock, first-reset gate), regressions intact: lifecycle 72/72, cockpit 41/42 known-quirk + UI 25/25, tsc clean. Frontend counterpart: `claude/crm-settings-suite-ui` on wedsy-os.

🤖 Generated with [Claude Code](https://claude.com/claude-code)