### PR TITLE
Quick-note endpoint: POST /enquiry/:_id/note (commented journey event + legacy notes append)

### DIFF
--- a/controllers/enquiry-lifecycle.js
+++ b/controllers/enquiry-lifecycle.js
@@ -94,6 +94,20 @@ const SetCustomFields = async (req, res) => {
   }
 };
 
+// POST /enquiry/:_id/note (Redesign) — quick note: commented event + legacy blob.
+const AddNote = async (req, res) => {
+  try {
+    const updated = await LeadLifecycleService.addNote(
+      req.params._id,
+      (req.body || {}).text,
+      req.auth.user_id
+    );
+    res.status(201).json(updated);
+  } catch (error) {
+    respondError(res, error);
+  }
+};
+
 // PUT /enquiry/:_id/tags (Slice 7a)
 const SetTags = async (req, res) => {
   try {
@@ -122,4 +136,4 @@ const BulkTransfer = async (req, res) => {
   }
 };
 
-module.exports = { Dashboard, CompleteFollowUp, Recycle, Convert, Journey, SetCustomFields, SetTags, BulkTransfer };
+module.exports = { Dashboard, CompleteFollowUp, Recycle, Convert, Journey, SetCustomFields, SetTags, BulkTransfer, AddNote };

--- a/routes/enquiry.js
+++ b/routes/enquiry.js
@@ -119,6 +119,12 @@ router.put(
   requirePermission("leads:edit:own"),
   lifecycle.SetCustomFields
 );
+router.post(
+  "/:_id/note",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own"),
+  lifecycle.AddNote
+);
 router.put(
   "/:_id/tags",
   CheckAdminLogin,

--- a/services/LeadLifecycleService.js
+++ b/services/LeadLifecycleService.js
@@ -306,6 +306,27 @@ const completeFollowUp = async (enquiryId, followUpId, body = {}, actorId) => {
   return obj;
 };
 
+// ── Quick notes (Redesign) ───────────────────────────────────────────────────
+// One note = one "commented" internal event (shows in the journey) + an append
+// to the legacy updates.notes blob so the old surfaces keep seeing it.
+const addNote = async (enquiryId, text, actorId) => {
+  assertValidId(enquiryId);
+  if (typeof text !== "string" || !text.trim()) throw httpError(400, "Note text is required");
+  if (text.length > 2000) throw httpError(400, "Notes are capped at 2000 characters");
+  const lead = await EnquiryRepository.findById(enquiryId);
+  if (!lead) throw httpError(404, "Enquiry not found");
+  const clean = text.trim();
+  await LeadInternalEventService.record({
+    leadId: enquiryId,
+    type: "commented",
+    actorId,
+    payload: { text: clean },
+  });
+  const stamp = new Date().toLocaleDateString("en-IN", { day: "numeric", month: "short", year: "numeric" });
+  const legacy = lead.updates?.notes ? `${lead.updates.notes}\n\n[${stamp}] ${clean}` : `[${stamp}] ${clean}`;
+  return await EnquiryRepository.updateFieldsById(enquiryId, { "updates.notes": legacy });
+};
+
 // ── Tags (Settings Suite, Slice 7a) ─────────────────────────────────────────
 // Replace the lead's tag set. Every tag must come from the Settings library
 // (tags.available) — free-text additions happen only on the settings page.
@@ -389,6 +410,7 @@ module.exports = {
   isOpenLead,
   setTags,
   bulkTransfer,
+  addNote,
   RECYCLE_REASONS,
   COMPLETION_OUTCOMES,
 };


### PR DESCRIPTION
## Summary

Adds **`POST /enquiry/:_id/note`** — a quick-note endpoint backing the Client File in the MB3 redesign. This is the **only backend change required for the MB3 redesign**.

### What it does
- Records a `commented` `LeadInternalEvent` with `{text}`, which the lead journey timeline picks up automatically.
- Also appends a dated line to the legacy `updates.notes` blob so the old notes view stays in sync (back-compat).

### Auth
- `CheckAdminLogin` middleware
- RBAC permission: `leads:edit:own`

### Validation
- Note text must be non-empty and ≤ 2000 characters; otherwise responds `400`.

### Files changed
- `routes/enquiry.js` — route registration
- `controllers/enquiry-lifecycle.js` — request handling + validation
- `services/LeadLifecycleService.js` — event write + legacy notes append

🤖 Generated with [Claude Code](https://claude.com/claude-code)