### PR TITLE
Kiara ↔ Wedsy OS: conversation layer, CRM intake on first message, takeover/escalation, Kiara settings, admin chat API, agent crash fix

### DIFF
--- a/controllers/waConversation.js
+++ b/controllers/waConversation.js
@@ -1,0 +1,103 @@
+const WAConversationService = require("../services/WAConversationService");
+
+// Admin chat API over the Kiara WhatsApp line (Slice 4). RBAC-scoped through
+// the linked enquiry: requirePermission builds req.scopeFilter on assignedTo
+// with the same semantics as every lead route.
+const respond = (res, error) => {
+  const status = error.status || 500;
+  if (status === 500) console.error("[waConversation]", error);
+  const body = { message: status === 500 ? "Server error" : error.message };
+  if (error.windowClosed) {
+    body.windowClosed = true;
+    body.windowClosesAt = error.windowClosesAt || null;
+  }
+  res.status(status).json(body);
+};
+
+// GET /wa/conversations?mode=&needsHuman=&status=&page=&limit=
+const List = async (req, res) => {
+  try {
+    const { mode, needsHuman, status, page, limit } = req.query;
+    const result = await WAConversationService.listInbox(
+      { mode, needsHuman, status, page, limit },
+      req.scopeFilter || {}
+    );
+    res.status(200).json(result);
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// GET /wa/conversations/:id/messages?page=&limit= — marks the thread read.
+const Messages = async (req, res) => {
+  try {
+    const { page, limit } = req.query;
+    const result = await WAConversationService.getMessages(
+      req.params.id,
+      { page, limit },
+      req.scopeFilter || {}
+    );
+    res.status(200).json(result);
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// POST /wa/conversations/:id/takeover — mode='human', STICKY until handback.
+const Takeover = async (req, res) => {
+  try {
+    const conversation = await WAConversationService.takeover(
+      req.params.id,
+      req.auth.user_id,
+      req.scopeFilter || {}
+    );
+    res.status(200).json(conversation);
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// POST /wa/conversations/:id/handback — Kiara resumes.
+const Handback = async (req, res) => {
+  try {
+    const conversation = await WAConversationService.handback(
+      req.params.id,
+      req.auth.user_id,
+      req.scopeFilter || {}
+    );
+    res.status(200).json(conversation);
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// POST /wa/conversations/:id/send {text} — human mode + open 24h window only.
+const Send = async (req, res) => {
+  try {
+    const result = await WAConversationService.sendText(
+      req.params.id,
+      (req.body || {}).text,
+      req.auth.user_id,
+      req.scopeFilter || {}
+    );
+    res.status(200).json(result);
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// POST /wa/conversations/:id/send-template — re-engage template, window-proof.
+const SendTemplate = async (req, res) => {
+  try {
+    const result = await WAConversationService.sendTemplate(
+      req.params.id,
+      req.auth.user_id,
+      req.scopeFilter || {}
+    );
+    res.status(200).json(result);
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+module.exports = { List, Messages, Takeover, Handback, Send, SendTemplate };

--- a/controllers/waConversation.js
+++ b/controllers/waConversation.js
@@ -17,9 +17,9 @@ const respond = (res, error) => {
 // GET /wa/conversations?mode=&needsHuman=&status=&page=&limit=
 const List = async (req, res) => {
   try {
-    const { mode, needsHuman, status, page, limit } = req.query;
+    const { mode, needsHuman, status, enquiryId, page, limit } = req.query;
     const result = await WAConversationService.listInbox(
-      { mode, needsHuman, status, page, limit },
+      { mode, needsHuman, status, enquiryId, page, limit },
       req.scopeFilter || {}
     );
     res.status(200).json(result);

--- a/controllers/whatsappAgent.js
+++ b/controllers/whatsappAgent.js
@@ -1,5 +1,5 @@
 const crypto = require('crypto');
-const { receiveMessage } = require('../services/WhatsAppAgentService');
+const { receiveMessage, receiveMedia } = require('../services/WhatsAppAgentService');
 
 const VerifyWebhook = (req, res) => {
   const mode = req.query['hub.mode'];
@@ -44,12 +44,20 @@ const ReceiveMessage = (req, res) => {
     const entry = req.body?.entry?.[0];
     const change = entry?.changes?.[0];
     const message = change?.value?.messages?.[0];
-    if (!message || message.type !== 'text') return;
+    if (!message) return;
     const phone = message.from;
-    const text = message.text.body;
-    receiveMessage(phone, text).catch(err =>
-      console.error('[WhatsAppAgent] Unhandled error:', err.message)
-    );
+    // WhatsApp display name travels with the message — used to name the CRM lead.
+    const profileName = change?.value?.contacts?.[0]?.profile?.name || '';
+    if (message.type === 'text') {
+      receiveMessage(phone, message.text.body, { profileName }).catch(err =>
+        console.error('[WhatsAppAgent] Unhandled error:', err.message)
+      );
+    } else {
+      // Non-text (image/audio/…): placeholder + conversation bump, no AI reply.
+      receiveMedia(phone, message.type, { profileName }).catch(err =>
+        console.error('[WhatsAppAgent] Unhandled error:', err.message)
+      );
+    }
   } catch (error) {
     console.error('[WhatsAppAgent] Webhook parse error:', error.message);
   }

--- a/models/QualifiedLead.js
+++ b/models/QualifiedLead.js
@@ -15,7 +15,10 @@ const QualifiedLeadSchema = new mongoose.Schema({
   weddingStyle: { type: String, default: '' },
   source: { type: String, default: 'WhatsApp' },
   qualifiedAt: { type: Date, default: Date.now },
-  googleSheetSynced: { type: Boolean, default: false }
+  googleSheetSynced: { type: Boolean, default: false },
+  // Additive (Kiara ↔ Wedsy OS): mirrors googleSheetSynced for the CRM sync —
+  // the two flags are independent, either side may land first.
+  crmSynced: { type: Boolean, default: false }
 });
 
 module.exports = mongoose.model('QualifiedLead', QualifiedLeadSchema);

--- a/models/VendorContact.js
+++ b/models/VendorContact.js
@@ -1,0 +1,23 @@
+const mongoose = require("mongoose");
+const ObjectId = mongoose.Schema.Types.ObjectId;
+
+// Quiet capture of vendors/suppliers who message the Kiara WhatsApp line.
+// No UI yet (a Vendors section comes later) — founder-approved collection so
+// "I'll pass your details to our vendor team" is actually true.
+const VendorContactSchema = new mongoose.Schema(
+  {
+    phone: { type: String, required: true },
+    name: { type: String, default: "" },
+    offering: { type: String, default: "" },
+    firstMessage: { type: String, default: "" },
+    source: { type: String, default: "whatsapp" },
+    conversationId: { type: ObjectId, ref: "WAConversation", default: null },
+  },
+  { timestamps: true }
+);
+
+VendorContactSchema.index({ phone: 1 });
+
+module.exports =
+  mongoose.models.VendorContact ||
+  mongoose.model("VendorContact", VendorContactSchema);

--- a/models/WAAgentMessage.js
+++ b/models/WAAgentMessage.js
@@ -4,6 +4,9 @@ const WAAgentMessageSchema = new mongoose.Schema({
   phone: { type: String, required: true },
   role: { type: String, enum: ['user', 'assistant'], required: true },
   message: { type: String, required: true },
+  // Additive (Kiara ↔ Wedsy OS): set when a human admin sends from the CRM,
+  // null for Kiara's own replies and customer messages.
+  sentBy: { type: mongoose.Schema.Types.ObjectId, ref: 'Admin', default: null },
   createdAt: { type: Date, default: Date.now }
 });
 

--- a/models/WAConversation.js
+++ b/models/WAConversation.js
@@ -1,0 +1,42 @@
+const mongoose = require("mongoose");
+const ObjectId = mongoose.Schema.Types.ObjectId;
+
+// One row per WhatsApp number talking to the Kiara agent line. The message
+// stream stays in WAAgentMessage (keyed by the same raw webhook phone); this
+// is the conversation STATE: who owns it (Kiara or a human), whether it's
+// screaming for attention, and which CRM lead it belongs to.
+//
+// phone        — raw Meta webhook phone (message.from, e.g. "91XXXXXXXXXX").
+//                Unique: Meta sends a stable form per user, and it's the key
+//                WAAgentMessage + the send APIs already use.
+// normalizedPhone — last-10-digit form (LeadIntakeService.normalizePhone) for
+//                Enquiry cross-referencing/dedup, mirroring the intake engine.
+const WAConversationSchema = new mongoose.Schema(
+  {
+    phone: { type: String, required: true, unique: true },
+    normalizedPhone: { type: String, default: "", index: true },
+    enquiryId: { type: ObjectId, ref: "Enquiry", default: null },
+    mode: { type: String, enum: ["ai", "human"], default: "ai" },
+    needsHuman: { type: Boolean, default: false },
+    needsHumanReason: { type: String, default: "" },
+    needsHumanAt: { type: Date, default: null },
+    classification: {
+      type: String,
+      enum: ["lead", "vendor", "birthday", "corporate", "destination", null],
+      default: null,
+    },
+    lastInboundAt: { type: Date, default: null },
+    lastMessageAt: { type: Date, default: null },
+    lastMessagePreview: { type: String, default: "" },
+    unreadCount: { type: Number, default: 0 },
+    status: { type: String, enum: ["active", "closed"], default: "active" },
+  },
+  { timestamps: true }
+);
+
+WAConversationSchema.index({ needsHuman: -1, lastMessageAt: -1 });
+WAConversationSchema.index({ enquiryId: 1 });
+
+module.exports =
+  mongoose.models.WAConversation ||
+  mongoose.model("WAConversation", WAConversationSchema);

--- a/repositories/WAConversationRepository.js
+++ b/repositories/WAConversationRepository.js
@@ -1,0 +1,70 @@
+const WAConversation = require("../models/WAConversation");
+
+const findByPhone = async (phone) => WAConversation.findOne({ phone });
+
+const findById = async (id) => WAConversation.findById(id);
+
+// Inbound message touch: create the conversation on first contact, bump the
+// freshness fields and the unread counter on every one after. Atomic upsert —
+// concurrent webhook deliveries can't double-create.
+const upsertOnInbound = async (phone, normalizedPhone, preview, at = new Date()) =>
+  WAConversation.findOneAndUpdate(
+    { phone },
+    {
+      $set: {
+        normalizedPhone,
+        lastInboundAt: at,
+        lastMessageAt: at,
+        lastMessagePreview: preview,
+      },
+      $inc: { unreadCount: 1 },
+    },
+    { upsert: true, new: true, setDefaultsOnInsert: true }
+  );
+
+// Outbound (Kiara or human) touch: freshness + preview, unread untouched.
+const touchOutbound = async (id, preview, at = new Date()) =>
+  WAConversation.findByIdAndUpdate(
+    id,
+    { $set: { lastMessageAt: at, lastMessagePreview: preview } },
+    { new: true }
+  );
+
+const updateFieldsById = async (id, fields) =>
+  WAConversation.findByIdAndUpdate(id, { $set: fields }, { new: true });
+
+// Inbox listing: needs-attention first, then by recency.
+const list = async (filter = {}, { skip = 0, limit = 20 } = {}) =>
+  WAConversation.find(filter)
+    .sort({ needsHuman: -1, lastMessageAt: -1 })
+    .skip(skip)
+    .limit(limit)
+    .lean();
+
+const count = async (filter = {}) => WAConversation.countDocuments(filter);
+
+// Mission-quiet support: enquiry ids whose conversation is actively handled by
+// Kiara (mode ai, open, not escalated) — these leads stay off call-now pressure.
+const findQuietEnquiryIds = async () =>
+  WAConversation.distinct("enquiryId", {
+    mode: "ai",
+    status: "active",
+    needsHuman: false,
+    enquiryId: { $ne: null },
+  });
+
+// Escalated conversations (for the dashboard mission card).
+const findNeedsHuman = async () =>
+  WAConversation.find({ needsHuman: true, status: "active" }).lean();
+
+module.exports = {
+  findByPhone,
+  findById,
+  upsertOnInbound,
+  touchOutbound,
+  updateFieldsById,
+  list,
+  count,
+  findQuietEnquiryIds,
+  findNeedsHuman,
+};

--- a/routes/router.js
+++ b/routes/router.js
@@ -80,5 +80,6 @@ router.use("/venues", require("./venue"));
 router.use("/places", require("./places"));
 router.use("/venue-owner", require("./venueOwner"));
 router.use("/conversations", require("./conversation"));
+router.use("/wa", require("./waConversation")); // Kiara admin chat API
 
 module.exports = router;

--- a/routes/waConversation.js
+++ b/routes/waConversation.js
@@ -1,0 +1,48 @@
+const express = require("express");
+const router = express.Router();
+
+const controller = require("../controllers/waConversation");
+const { CheckAdminLogin } = require("../middlewares/auth");
+const { requirePermission } = require("../middlewares/requirePermission");
+
+// Conversations are lead surfaces: viewing follows leads:view scope, acting
+// (takeover / handback / sending) follows leads:edit scope — both resolved
+// through the linked enquiry's assignedTo, exactly like /enquiry routes.
+router.get(
+  "/conversations",
+  CheckAdminLogin,
+  requirePermission("leads:view:own", { ownerField: "assignedTo" }),
+  controller.List
+);
+router.get(
+  "/conversations/:id/messages",
+  CheckAdminLogin,
+  requirePermission("leads:view:own", { ownerField: "assignedTo" }),
+  controller.Messages
+);
+router.post(
+  "/conversations/:id/takeover",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own", { ownerField: "assignedTo" }),
+  controller.Takeover
+);
+router.post(
+  "/conversations/:id/handback",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own", { ownerField: "assignedTo" }),
+  controller.Handback
+);
+router.post(
+  "/conversations/:id/send",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own", { ownerField: "assignedTo" }),
+  controller.Send
+);
+router.post(
+  "/conversations/:id/send-template",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own", { ownerField: "assignedTo" }),
+  controller.SendTemplate
+);
+
+module.exports = router;

--- a/scripts/e2e-kiara.js
+++ b/scripts/e2e-kiara.js
@@ -1,0 +1,661 @@
+/* Kiara ↔ Wedsy OS — end-to-end suite (MEGA-BUILD 4 verify).
+ *
+ * Boots the real server on a TEST port with the Anthropic + Meta Graph calls
+ * pointed at an in-process mock (ANTHROPIC_API_URL / META_GRAPH_BASE_URL) and
+ * Google Sheets creds forced bogus, then drives it with HMAC-SIGNED webhook
+ * payloads and the admin chat API. Never touches a live API. Local DB only.
+ * Cleans every fixture it creates.
+ *
+ * Run: node scripts/e2e-kiara.js
+ */
+require("dotenv").config();
+const http = require("http");
+const crypto = require("crypto");
+const { spawn } = require("child_process");
+const mongoose = require("mongoose");
+const jwt = require("jsonwebtoken");
+
+const APP_PORT = 8097;
+const MOCK_PORT = 8098;
+const BASE = `http://localhost:${APP_PORT}`;
+const APP_SECRET = process.env.WHATSAPP_AGENT_APP_SECRET || "kiara-e2e-secret";
+const AGENT_PHONE_ID = "KIARA_E2E_AGENT_ID";
+const PHONE_PREFIX = "9190000"; // every test phone starts with this
+const startedAt = new Date();
+
+// ── Tiny test harness ─────────────────────────────────────────────────────────
+let passed = 0;
+let failed = 0;
+const failures = [];
+const ok = (cond, label) => {
+  if (cond) {
+    passed++;
+    console.log(`  ✓ ${label}`);
+  } else {
+    failed++;
+    failures.push(label);
+    console.error(`  ✗ ${label}`);
+  }
+};
+const section = (t) => console.log(`\n── ${t} ──`);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const waitFor = async (fn, label, timeoutMs = 20000, everyMs = 300) => {
+  const until = Date.now() + timeoutMs;
+  while (Date.now() < until) {
+    try {
+      const v = await fn();
+      if (v) return v;
+    } catch (_) {}
+    await sleep(everyMs);
+  }
+  throw new Error(`waitFor timed out: ${label}`);
+};
+
+// ── Mock Anthropic + Meta Graph server ────────────────────────────────────────
+const mock = {
+  anthropicCalls: [], // { system, messages }
+  metaCalls: [], // { phoneNumberId, body }
+  replyText: "Lovely! Tell me a little more 😊",
+  extractor: { qualified: false, escalate: false, escalateReason: "", classification: "lead", data: {} },
+  anthropicMode: "normal", // normal | empty | toolFirst
+};
+const mockServer = http.createServer((req, res) => {
+  let raw = "";
+  req.on("data", (c) => (raw += c));
+  req.on("end", () => {
+    const body = raw ? JSON.parse(raw) : {};
+    if (req.url === "/v1/messages") {
+      mock.anthropicCalls.push({ system: body.system, messages: body.messages });
+      let content;
+      if (mock.anthropicMode === "empty") {
+        content = [];
+      } else if (mock.anthropicMode === "toolFirst") {
+        content = [
+          { type: "tool_use", id: "tu_1", name: "x", input: {} },
+          { type: "text", text: "Reply after a tool block 🛠" },
+        ];
+      } else if (String(body.system || "").startsWith("You are a data extractor")) {
+        content = [{ type: "text", text: JSON.stringify(mock.extractor) }];
+      } else {
+        content = [{ type: "text", text: mock.replyText }];
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ id: "msg_e2e", content, stop_reason: "end_turn" }));
+      return;
+    }
+    const graph = req.url.match(/^\/graph\/([^/]+)\/messages$/);
+    if (graph) {
+      mock.metaCalls.push({ phoneNumberId: graph[1], body });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ messaging_product: "whatsapp", messages: [{ id: "wamid.e2e" }] }));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+});
+
+// ── HTTP helpers ──────────────────────────────────────────────────────────────
+const api = async (method, path, { token, body } = {}) => {
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(body ? { "Content-Type": "application/json" } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  let data = null;
+  try {
+    data = await res.json();
+  } catch (_) {}
+  return { status: res.status, data };
+};
+
+const signedWebhook = async (payload) => {
+  const raw = JSON.stringify(payload);
+  const sig = "sha256=" + crypto.createHmac("sha256", APP_SECRET).update(raw).digest("hex");
+  const res = await fetch(`${BASE}/webhook/whatsapp-agent`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-hub-signature-256": sig },
+    body: raw,
+  });
+  return res.status;
+};
+
+const inboundText = (phone, text, profileName = "E2E Customer") => ({
+  entry: [
+    {
+      changes: [
+        {
+          value: {
+            contacts: [{ profile: { name: profileName }, wa_id: phone }],
+            messages: [{ from: phone, id: `wamid.in.${Date.now()}`, type: "text", text: { body: text } }],
+          },
+        },
+      ],
+    },
+  ],
+});
+
+const inboundMedia = (phone, type = "image", profileName = "E2E Customer") => ({
+  entry: [
+    {
+      changes: [
+        {
+          value: {
+            contacts: [{ profile: { name: profileName }, wa_id: phone }],
+            messages: [{ from: phone, id: `wamid.in.${Date.now()}`, type, [type]: { id: "media-1" } }],
+          },
+        },
+      ],
+    },
+  ],
+});
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+(async () => {
+  if (!process.env.DATABASE_URL || !process.env.JWT_SECRET) {
+    console.error("DATABASE_URL / JWT_SECRET missing — run from the repo root with .env present.");
+    process.exit(1);
+  }
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Enquiry = require("../models/Enquiry");
+  const WAConversation = require("../models/WAConversation");
+  const WAAgentMessage = require("../models/WAAgentMessage");
+  const QualifiedLead = require("../models/QualifiedLead");
+  const VendorContact = require("../models/VendorContact");
+  const LeadInternalEvent = require("../models/LeadInternalEvent");
+  const NotificationFailureLog = require("../models/NotificationFailureLog");
+  const ActivityLog = require("../models/ActivityLog");
+  const Setting = require("../models/Setting");
+  const Admin = require("../models/Admin");
+  const Role = require("../models/Role");
+  const User = require("../models/User");
+  const Event = require("../models/Event");
+
+  // Fixtures: department + roles + admins + assignment pool routed at the intern.
+  const Department = require("../models/Department");
+  const dept = await Department.create({ name: "KIARA-E2E Dept" });
+  const founderRole = await Role.create({
+    name: "KIARA-E2E Founder",
+    departmentId: dept._id,
+    permissions: ["*:*:all"],
+  });
+  const internRole = await Role.create({
+    name: "KIARA-E2E Intern",
+    departmentId: dept._id,
+    permissions: ["leads:view:own", "leads:edit:own"],
+  });
+  const founder = await Admin.create({
+    name: "Kiara E2E Founder",
+    email: `kiara-e2e-founder-${Date.now()}@test.local`,
+    phone: "919000090001",
+    password: "kiara-e2e-not-a-real-password",
+    roles: ["crm"],
+    roleId: founderRole._id,
+    departmentId: dept._id,
+    status: "active",
+  });
+  const intern = await Admin.create({
+    name: "Kiara E2E Intern",
+    email: `kiara-e2e-intern-${Date.now()}@test.local`,
+    phone: "919000090002",
+    password: "kiara-e2e-not-a-real-password",
+    roles: ["sales"],
+    roleId: internRole._id,
+    departmentId: dept._id,
+    status: "active",
+  });
+  const founderToken = jwt.sign({ _id: String(founder._id), isAdmin: true }, process.env.JWT_SECRET);
+  const internToken = jwt.sign({ _id: String(intern._id), isAdmin: true }, process.env.JWT_SECRET);
+
+  // Snapshot any pre-existing settings we touch so cleanup restores them.
+  const touchedKeys = ["assignment.poolRoles", "kiara.systemPrompt", "kiara.reengageTemplateName"];
+  const settingsBefore = await Setting.find({ key: { $in: touchedKeys } }).lean();
+
+  // Boot mock + server.
+  await new Promise((r) => mockServer.listen(MOCK_PORT, r));
+  const child = spawn("node", ["server.js"], {
+    cwd: `${__dirname}/..`,
+    env: {
+      ...process.env,
+      PORT: String(APP_PORT),
+      ANTHROPIC_API_URL: `http://localhost:${MOCK_PORT}/v1/messages`,
+      META_GRAPH_BASE_URL: `http://localhost:${MOCK_PORT}/graph`,
+      WHATSAPP_AGENT_PHONE_NUMBER_ID: AGENT_PHONE_ID,
+      WHATSAPP_AGENT_APP_SECRET: APP_SECRET,
+      META_WA_AGENT_ACCESS_TOKEN: "e2e-agent-token",
+      GOOGLE_SHEETS_KEY_PATH: "/nonexistent/kiara-e2e-keyfile.json",
+      GOOGLE_SHEETS_ID: "kiara-e2e-sheet",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let serverLog = "";
+  child.stdout.on("data", (d) => (serverLog += d));
+  child.stderr.on("data", (d) => (serverLog += d));
+
+  const phones = [];
+  const phone = (n) => {
+    const p = `${PHONE_PREFIX}${String(n).padStart(5, "0")}`;
+    if (!phones.includes(p)) phones.push(p);
+    return p;
+  };
+
+  try {
+    await waitFor(
+      () => fetch(`${BASE}/`).then((r) => r.ok).catch(() => false),
+      "server boot",
+      30000
+    );
+
+    // Route auto-assignment at the e2e intern only.
+    const poolPut = await api("PUT", "/settings", {
+      token: founderToken,
+      body: { key: "assignment.poolRoles", value: ["KIARA-E2E Intern"] },
+    });
+    ok(poolPut.status === 200, "settings: assignment pool routed at e2e intern");
+
+    // ── (1) First inbound from an unknown number ────────────────────────────
+    section("1. First inbound → conversation + lead + mission-quiet");
+    const p1 = phone(1);
+    ok((await signedWebhook(inboundText(p1, "Hi! Planning my wedding"))) === 200, "webhook accepts signed payload");
+    const conv1 = await waitFor(async () => {
+      const c = await WAConversation.findOne({ phone: p1 }).lean();
+      return c && c.enquiryId ? c : null;
+    }, "conversation + lead link");
+    const lead1 = await Enquiry.findById(conv1.enquiryId).lean();
+    ok(!!lead1, "Enquiry created");
+    ok(lead1.source === "whatsapp", "lead source is 'whatsapp'");
+    ok(lead1.name === "E2E Customer", "lead named from webhook profile.name");
+    ok(String(lead1.assignedTo) === String(intern._id), "lead auto-assigned (round-robin pool)");
+    ok(conv1.mode === "ai" && conv1.status === "active", "conversation defaults: ai/active");
+    ok(conv1.unreadCount >= 1, "unread bumped");
+    const ev1 = await LeadInternalEvent.findOne({ leadId: lead1._id, type: "wa_conversation_started" }).lean();
+    ok(!!ev1, "journey event wa_conversation_started");
+    await waitFor(async () => WAAgentMessage.findOne({ phone: p1, role: "assistant" }).lean(), "Kiara replied");
+    ok(
+      mock.metaCalls.some((m) => m.phoneNumberId === AGENT_PHONE_ID && m.body.to === p1 && m.body.type === "text"),
+      "reply sent via the AGENT phone number id"
+    );
+    // Unsigned payload is rejected.
+    const badSig = await fetch(`${BASE}/webhook/whatsapp-agent`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-hub-signature-256": "sha256=deadbeef" },
+      body: JSON.stringify(inboundText(p1, "spoof")),
+    });
+    ok(badSig.status === 403, "tampered signature rejected (403)");
+
+    const dash1 = await api("GET", "/enquiry/dashboard", { token: founderToken });
+    ok(dash1.status === 200, "dashboard loads");
+    ok(
+      !(dash1.data.newUntouched || []).some((r) => String(r.leadId) === String(lead1._id)),
+      "mission-quiet: Kiara-handled lead absent from new-untouched call pressure"
+    );
+
+    // ── (2) Takeover silences Kiara; handback resumes ───────────────────────
+    section("2. Takeover → no AI call; handback → resumes");
+    const take = await api("POST", `/wa/conversations/${conv1._id}/takeover`, { token: founderToken });
+    ok(take.status === 200 && take.data.mode === "human", "takeover → mode human");
+    const callsBefore = mock.anthropicCalls.length;
+    const msgsBefore = await WAAgentMessage.countDocuments({ phone: p1, role: "assistant" });
+    await signedWebhook(inboundText(p1, "are you a real person?"));
+    await waitFor(async () => WAAgentMessage.findOne({ phone: p1, message: "are you a real person?" }).lean(), "human-mode inbound stored");
+    await sleep(1500);
+    ok(mock.anthropicCalls.length === callsBefore, "NO Anthropic call in human mode (spy)");
+    ok(
+      (await WAAgentMessage.countDocuments({ phone: p1, role: "assistant" })) === msgsBefore,
+      "NO auto-reply in human mode"
+    );
+    ok(
+      !!(await LeadInternalEvent.findOne({ leadId: lead1._id, type: "wa_human_takeover" }).lean()),
+      "journey event wa_human_takeover"
+    );
+    const back = await api("POST", `/wa/conversations/${conv1._id}/handback`, { token: founderToken });
+    ok(back.status === 200 && back.data.mode === "ai", "handback → mode ai");
+    await signedWebhook(inboundText(p1, "ok continuing"));
+    await waitFor(
+      async () => (await WAAgentMessage.countDocuments({ phone: p1, role: "assistant" })) > msgsBefore,
+      "Kiara resumes after handback"
+    );
+    ok(true, "Kiara resumed after handback");
+
+    // ── (3) Escalation ───────────────────────────────────────────────────────
+    section("3. Escalation JSON → needsHuman + mission card + journey");
+    const p3 = phone(3);
+    mock.extractor = { qualified: false, escalate: true, escalateReason: "Customer is frustrated", classification: "lead", data: {} };
+    await signedWebhook(inboundText(p3, "This is taking forever. Get me a human!"));
+    const conv3 = await waitFor(async () => {
+      const c = await WAConversation.findOne({ phone: p3 }).lean();
+      return c && c.needsHuman ? c : null;
+    }, "escalation flag");
+    ok(conv3.needsHuman === true, "needsHuman set");
+    ok(conv3.needsHumanReason === "Customer is frustrated", "needsHumanReason carried");
+    ok(
+      !!(await LeadInternalEvent.findOne({ leadId: conv3.enquiryId, type: "wa_escalated" }).lean()),
+      "journey event wa_escalated"
+    );
+    const dash3 = await api("GET", "/enquiry/dashboard", { token: founderToken });
+    ok(
+      (dash3.data.waNeedsHuman || []).some((r) => String(r.conversationId) === String(conv3._id)),
+      "dashboard mission card (waNeedsHuman) present"
+    );
+    ok(
+      (dash3.data.waNeedsHuman || []).some((r) => r.reason === "Customer is frustrated"),
+      "mission card carries the reason"
+    );
+    ok(
+      (dash3.data.newUntouched || []).some((r) => String(r.leadId) === String(conv3.enquiryId)),
+      "escalated lead re-enters call-now pressure (no longer quiet)"
+    );
+
+    // ── (4) Qualification → CRM sync (Sheets failing → independence) ────────
+    section("4. Qualified JSON → CRM sync independent of Sheets");
+    const p4 = phone(4);
+    mock.extractor = {
+      qualified: true,
+      escalate: true,
+      escalateReason: "Qualified — ready for your call",
+      classification: "lead",
+      data: {
+        name: "Asha Rao",
+        eventType: "wedding",
+        city: "Bengaluru",
+        eventDate: "2026-11-20",
+        numberOfEvents: "3",
+        venueStatus: "booked",
+        venueName: "Taj West End",
+        servicesRequired: "decor only",
+        budget: "5L",
+        weddingStyle: "South Indian",
+      },
+    };
+    await signedWebhook(inboundText(p4, "Thanks! All details shared.", "Asha Rao"));
+    const ql4 = await waitFor(async () => {
+      const q = await QualifiedLead.findOne({ phone: p4 }).lean();
+      return q && q.crmSynced ? q : null;
+    }, "QualifiedLead crmSynced", 30000);
+    ok(ql4.crmSynced === true, "crmSynced true");
+    ok(ql4.googleSheetSynced === false, "googleSheetSynced false (Sheets mock-failed) → INDEPENDENCE proven");
+    ok(
+      !!(await NotificationFailureLog.findOne({ service: "GoogleSheets", phone: p4 }).lean()),
+      "Sheets failure logged through the existing FailureLog path"
+    );
+    const conv4 = await WAConversation.findOne({ phone: p4 }).lean();
+    const lead4 = await Enquiry.findById(conv4.enquiryId).lean();
+    ok(lead4.qualified === true, "lead qualified flag set (Roadmap shows Qualified ✓ — derived from this flag)");
+    ok(lead4.qualificationData.venueName === "Taj West End", "qualificationData.venueName mapped");
+    ok(lead4.qualificationData.venueStatus === "booked", "qualificationData.venueStatus normalized to 'booked'");
+    ok(lead4.qualificationData.weddingStyle === "South Indian", "qualificationData.weddingStyle mapped");
+    ok(lead4.qualificationData.groomName === "Asha Rao", "name surfaced as couple fact (both names were empty)");
+    const ka = lead4.additionalInfo && lead4.additionalInfo.kiaraAnswers;
+    ok(!!ka && Object.keys(ka).length === 10, "ALL ten raw answers under additionalInfo.kiaraAnswers");
+    ok(ka && ka.budget === "5L" && ka.servicesRequired === "decor only", "kiaraAnswers carry budget + services raw");
+    const user4 = await User.findOne({ phone: p4 }).lean();
+    ok(!!user4, "Event Store user created");
+    const event4 = user4 ? await Event.findOne({ user: user4._id }).lean() : null;
+    ok(!!event4 && event4.eventDays.length === 3, "Event created with 3 eventDays");
+    ok(event4 && event4.eventDays[0].date === "2026-11-20" && event4.eventDays[2].date === "2026-11-22", "eventDays anchored on parsed date");
+    ok(
+      !!(await LeadInternalEvent.findOne({ leadId: lead4._id, type: "wa_qualified_by_kiara" }).lean()),
+      "journey event wa_qualified_by_kiara"
+    );
+    ok(conv4.needsHuman && conv4.needsHumanReason === "Qualified — ready for your call", "qualified ⇒ ALWAYS escalates with the canonical reason");
+    const journey4 = await api("GET", `/enquiry/${lead4._id}/journey`, { token: founderToken });
+    ok(
+      (journey4.data.entries || []).some((e) => e.type === "wa_qualified_by_kiara" && e.title === "Qualified by Kiara ✦"),
+      "journey API titles the Kiara qualification"
+    );
+
+    // ── (5) Vendor classification ────────────────────────────────────────────
+    section("5. Vendor JSON → VendorContact + conversation closed + lead lost");
+    const p5 = phone(5);
+    mock.extractor = {
+      qualified: false,
+      escalate: false,
+      escalateReason: "",
+      classification: "vendor",
+      data: { name: "Studio Lumière", servicesRequired: "wedding photography" },
+    };
+    await signedWebhook(inboundText(p5, "Hi, I'm a photographer — can I work with Wedsy?", "Studio Lumiere"));
+    const conv5 = await waitFor(async () => {
+      const c = await WAConversation.findOne({ phone: p5 }).lean();
+      return c && c.status === "closed" ? c : null;
+    }, "vendor conversation closed");
+    ok(conv5.classification === "vendor", "classification stored");
+    const vc = await VendorContact.findOne({ phone: p5 }).lean();
+    ok(!!vc, "VendorContact captured");
+    ok(vc && vc.offering === "wedding photography", "VendorContact offering");
+    ok(vc && /photographer/.test(vc.firstMessage), "VendorContact firstMessage = first user message");
+    const lead5 = await Enquiry.findById(conv5.enquiryId).lean();
+    ok(lead5.stage === "lost" && lead5.isLost === true, "lead closed via lost flow");
+    ok(lead5.lostReason === "Not a lead — vendor", "lost reason 'Not a lead — vendor'");
+    ok(lead5.lostStatus === "approved", "approval bypassed as system action");
+    // Stored-but-silent: another inbound on the closed conversation.
+    const calls5 = mock.anthropicCalls.length;
+    await signedWebhook(inboundText(p5, "any update?"));
+    await waitFor(async () => WAAgentMessage.findOne({ phone: p5, message: "any update?" }).lean(), "closed-conv inbound stored");
+    await sleep(1000);
+    ok(mock.anthropicCalls.length === calls5, "closed conversation → zero Anthropic spend");
+
+    // ── (6) Non-text inbound ─────────────────────────────────────────────────
+    section("6. Non-text inbound → placeholder, no AI");
+    const p6 = phone(6);
+    mock.extractor = { qualified: false, escalate: false, escalateReason: "", classification: "lead", data: {} };
+    const calls6 = mock.anthropicCalls.length;
+    await signedWebhook(inboundMedia(p6, "image"));
+    const m6 = await waitFor(async () => WAAgentMessage.findOne({ phone: p6 }).lean(), "media placeholder stored");
+    ok(m6.message === "[media: image]", "placeholder message '[media: image]'");
+    const conv6 = await WAConversation.findOne({ phone: p6 }).lean();
+    ok(!!conv6 && conv6.unreadCount === 1, "conversation upserted + unread++");
+    ok(!!conv6.enquiryId, "lead ensured for media-first contact");
+    await sleep(1200);
+    ok(mock.anthropicCalls.length === calls6, "NO AI call for media");
+    ok((await WAAgentMessage.countDocuments({ phone: p6, role: "assistant" })) === 0, "NO reply for media");
+
+    // ── (7) 24h window: send / 422 / send-template ──────────────────────────
+    section("7. 24h window enforcement + re-engage template");
+    // 409 while AI-owned:
+    const send409 = await api("POST", `/wa/conversations/${conv1._id}/send`, { token: founderToken, body: { text: "hi" } });
+    ok(send409.status === 409, "send in AI mode → 409 (take over first)");
+    await api("POST", `/wa/conversations/${conv1._id}/takeover`, { token: founderToken });
+    const sendOk = await api("POST", `/wa/conversations/${conv1._id}/send`, { token: founderToken, body: { text: "Hello from the team!" } });
+    ok(sendOk.status === 200, "send inside the window → 200");
+    const sentMsg = await WAAgentMessage.findOne({ phone: p1, message: "Hello from the team!" }).lean();
+    ok(!!sentMsg && sentMsg.role === "assistant" && String(sentMsg.sentBy) === String(founder._id), "saved as assistant + sentBy admin ref");
+    ok(
+      mock.metaCalls.some((m) => m.phoneNumberId === AGENT_PHONE_ID && m.body.text && m.body.text.body === "Hello from the team!"),
+      "sent via agent number (Meta mocked)"
+    );
+    // Stale the window.
+    await WAConversation.updateOne({ _id: conv1._id }, { $set: { lastInboundAt: new Date(Date.now() - 25 * 3600 * 1000) } });
+    const send422 = await api("POST", `/wa/conversations/${conv1._id}/send`, { token: founderToken, body: { text: "too late" } });
+    ok(send422.status === 422 && send422.data.windowClosed === true, "send after 24h → 422 {windowClosed:true}");
+    // Template not configured yet → 422.
+    const tpl422 = await api("POST", `/wa/conversations/${conv1._id}/send-template`, { token: founderToken });
+    ok(tpl422.status === 422, "send-template without a configured template → 422");
+    const tplSet = await api("PUT", "/settings", { token: founderToken, body: { key: "kiara.reengageTemplateName", value: "kiara_reengage_e2e" } });
+    ok(tplSet.status === 200, "founder sets kiara.reengageTemplateName");
+    const tplOk = await api("POST", `/wa/conversations/${conv1._id}/send-template`, { token: founderToken });
+    ok(tplOk.status === 200, "send-template with window closed → 200");
+    ok(
+      mock.metaCalls.some(
+        (m) =>
+          m.phoneNumberId === AGENT_PHONE_ID &&
+          m.body.type === "template" &&
+          m.body.template &&
+          m.body.template.name === "kiara_reengage_e2e"
+      ),
+      "template sent via agent number with the configured name"
+    );
+
+    // ── (8) Crash-fix: empty content + tool-block-first ──────────────────────
+    section("8. Crash fix (content[0].text guard)");
+    const p8 = phone(8);
+    mock.anthropicMode = "empty";
+    const failLogsBefore = await NotificationFailureLog.countDocuments({ service: "Anthropic", createdAt: { $gte: startedAt } });
+    await signedWebhook(inboundText(p8, "hello?"));
+    await waitFor(
+      async () =>
+        (await NotificationFailureLog.countDocuments({ service: "Anthropic", createdAt: { $gte: startedAt } })) > failLogsBefore,
+      "empty-content lands in the FailureLog retry path",
+      30000
+    );
+    ok(true, "empty content array → graceful failure (no crash, FailureLog written)");
+    ok((await WAAgentMessage.countDocuments({ phone: p8, role: "assistant" })) === 0, "no reply on empty content");
+    ok((await fetch(`${BASE}/`).then((r) => r.ok)), "server alive after empty-content responses");
+    mock.anthropicMode = "toolFirst";
+    await signedWebhook(inboundText(p8, "you there?"));
+    await waitFor(
+      async () => WAAgentMessage.findOne({ phone: p8, role: "assistant", message: "Reply after a tool block 🛠" }).lean(),
+      "tool-block-first reply extracted"
+    );
+    ok(true, "tool-block-first response → first TEXT block used");
+    mock.anthropicMode = "normal";
+
+    // ── (9) Settings prompt edit reaches the next call ───────────────────────
+    section("9. kiara.systemPrompt edit → next call uses it");
+    const NEW_PROMPT = "You are KIARA-E2E-TEST persona. Reply tersely.";
+    const promptPut = await api("PUT", "/settings", { token: founderToken, body: { key: "kiara.systemPrompt", value: NEW_PROMPT } });
+    ok(promptPut.status === 200, "founder saves a new persona");
+    const p9 = phone(9);
+    await signedWebhook(inboundText(p9, "hi kiara"));
+    await waitFor(async () => WAAgentMessage.findOne({ phone: p9, role: "assistant" }).lean(), "reply under new persona");
+    const personaCalls = mock.anthropicCalls.filter((c) => !String(c.system || "").startsWith("You are a data extractor"));
+    ok(personaCalls[personaCalls.length - 1].system === NEW_PROMPT, "Anthropic call used the EDITED system prompt");
+    // RBAC on the settings category: intern may not read or write kiara.*
+    const internRead = await api("GET", "/settings?category=settings_kiara", { token: internToken });
+    const internWrite = await api("PUT", "/settings", { token: internToken, body: { key: "kiara.systemPrompt", value: "hacked" } });
+    ok(internRead.status === 403 && internWrite.status === 403, "settings_kiara is founder-gated (intern 403)");
+
+    // ── (10) RBAC scope on conversations ─────────────────────────────────────
+    section("10. RBAC: intern sees only own-lead conversations");
+    // Move lead3 to the founder so it leaves the intern's scope.
+    await Enquiry.updateOne({ _id: conv3.enquiryId }, { $set: { assignedTo: founder._id } });
+    const internInbox = await api("GET", "/wa/conversations", { token: internToken });
+    ok(internInbox.status === 200, "intern can open the inbox");
+    const internIds = (internInbox.data.list || []).map((c) => String(c._id));
+    ok(internIds.includes(String(conv1._id)), "intern sees their own lead's conversation");
+    ok(!internIds.includes(String(conv3._id)), "intern does NOT see another owner's conversation");
+    const internForeign = await api("GET", `/wa/conversations/${conv3._id}/messages`, { token: internToken });
+    ok(internForeign.status === 403, "intern blocked from a foreign thread (403)");
+    const founderInbox = await api("GET", "/wa/conversations", { token: founderToken });
+    ok(
+      (founderInbox.data.list || []).some((c) => String(c._id) === String(conv3._id)),
+      "all-scope caller sees everything"
+    );
+    ok(
+      (founderInbox.data.list || []).findIndex((c) => c.needsHuman) <
+        (founderInbox.data.list || []).findIndex((c) => !c.needsHuman),
+      "inbox sorts needsHuman first"
+    );
+
+    // ── (11) Regression: lifecycle + cockpit + dashboard refresh ────────────
+    section("11. Regression — cockpit, lifecycle, dashboard, journey");
+    const regLead = await Enquiry.create({
+      name: "Kiara E2E Regression",
+      phone: phone(11),
+      source: "Default",
+      verified: false,
+      assignedTo: intern._id,
+    });
+    const callLog = await api("POST", `/enquiry/${regLead._id}/call-log`, {
+      token: internToken,
+      body: { startedAt: new Date().toISOString(), durationSeconds: 60, connected: true, outcome: "qualified", notes: "good call" },
+    });
+    ok(callLog.status === 200, "cockpit: call-log accepted");
+    ok((await Enquiry.findById(regLead._id).lean()).qualified === true, "cockpit: qualified flag flips");
+    const qualPut = await api("PUT", `/enquiry/${regLead._id}/qualification`, {
+      token: internToken,
+      body: { groomName: "R", brideName: "S" },
+    });
+    ok(qualPut.status === 200, "cockpit: qualification PUT works");
+    const fu = await api("POST", `/enquiry/${regLead._id}/follow-up`, {
+      token: internToken,
+      body: { type: "call", scheduledAt: new Date(Date.now() + 3600e3).toISOString(), promiseNote: "callback" },
+    });
+    ok(fu.status === 200, "lifecycle: follow-up booked");
+    const fuId = (await Enquiry.findById(regLead._id).lean()).followUps[0]._id;
+    const badComplete = await api("PUT", `/enquiry/${regLead._id}/follow-up/${fuId}/complete`, {
+      token: internToken,
+      body: { outcome: "connected" },
+    });
+    ok(badComplete.status === 422, "lifecycle: zero-orphan gate still enforced (422)");
+    const goodComplete = await api("PUT", `/enquiry/${regLead._id}/follow-up/${fuId}/complete`, {
+      token: internToken,
+      body: {
+        outcome: "connected",
+        nextFollowUp: { type: "call", scheduledAt: new Date(Date.now() + 7200e3).toISOString() },
+      },
+    });
+    ok(goodComplete.status === 200, "lifecycle: completion with next step works");
+    const regJourney = await api("GET", `/enquiry/${regLead._id}/journey`, { token: internToken });
+    ok(
+      regJourney.status === 200 && (regJourney.data.entries || []).some((e) => e.type === "call_logged"),
+      "journey: stream intact"
+    );
+    const dashFinal = await api("GET", "/enquiry/dashboard", { token: internToken });
+    ok(
+      dashFinal.status === 200 &&
+        Array.isArray(dashFinal.data.todaysMission) &&
+        dashFinal.data.counts !== undefined,
+      "dashboard refresh: payload shape intact (own scope)"
+    );
+    const enquiryList = await api("GET", "/enquiry?page=1&limit=20", { token: founderToken });
+    ok(enquiryList.status === 200, "lead list loads");
+  } catch (e) {
+    failed++;
+    failures.push(`FATAL: ${e.message}`);
+    console.error("FATAL:", e);
+    console.error(serverLog.split("\n").slice(-25).join("\n"));
+  } finally {
+    // ── Cleanup: every fixture this suite created ───────────────────────────
+    section("Cleanup");
+    try {
+      child.kill();
+      await new Promise((r) => mockServer.close(r));
+      const leadIds = (await Enquiry.find({ phone: { $regex: `^${PHONE_PREFIX}` } }, { _id: 1 }).lean()).map((l) => l._id);
+      const userIds = (await User.find({ phone: { $regex: `^${PHONE_PREFIX}` } }, { _id: 1 }).lean()).map((u) => u._id);
+      await Promise.all([
+        Event.deleteMany({ user: { $in: userIds } }),
+        User.deleteMany({ phone: { $regex: `^${PHONE_PREFIX}` } }),
+        LeadInternalEvent.deleteMany({ leadId: { $in: leadIds } }),
+        ActivityLog.deleteMany({ entityType: "lead", entityId: { $in: leadIds.map(String) } }),
+        WAAgentMessage.deleteMany({ phone: { $regex: `^${PHONE_PREFIX}` } }),
+        WAConversation.deleteMany({ phone: { $regex: `^${PHONE_PREFIX}` } }),
+        QualifiedLead.deleteMany({ phone: { $regex: `^${PHONE_PREFIX}` } }),
+        VendorContact.deleteMany({ phone: { $regex: `^${PHONE_PREFIX}` } }),
+        NotificationFailureLog.deleteMany({
+          createdAt: { $gte: startedAt },
+          service: { $in: ["Anthropic", "GoogleSheets", "KiaraCrmSync", "WhatsApp", "QualifiedLeadDB"] },
+        }),
+        Enquiry.deleteMany({ phone: { $regex: `^${PHONE_PREFIX}` } }),
+        Admin.deleteMany({ _id: { $in: [founder._id, intern._id] } }),
+        Role.deleteMany({ _id: { $in: [founderRole._id, internRole._id] } }),
+        require("../models/Department").deleteMany({ _id: dept._id }),
+      ]);
+      // Restore settings exactly as found.
+      await Setting.deleteMany({ key: { $in: touchedKeys } });
+      for (const s of settingsBefore) {
+        await Setting.create({ key: s.key, value: s.value, updatedBy: s.updatedBy || null });
+      }
+      const leftovers = await Promise.all([
+        Enquiry.countDocuments({ phone: { $regex: `^${PHONE_PREFIX}` } }),
+        WAConversation.countDocuments({ phone: { $regex: `^${PHONE_PREFIX}` } }),
+        WAAgentMessage.countDocuments({ phone: { $regex: `^${PHONE_PREFIX}` } }),
+        Admin.countDocuments({ name: /Kiara E2E/ }),
+      ]);
+      console.log(`  cleanup leftovers (should be all 0): ${leftovers.join(", ")}`);
+    } catch (e) {
+      console.error("  cleanup error:", e.message);
+    }
+    await mongoose.disconnect();
+  }
+
+  console.log(`\n══ RESULT: ${passed} passed, ${failed} failed ══`);
+  if (failures.length) {
+    console.log("Failures:");
+    for (const f of failures) console.log(`  - ${f}`);
+  }
+  process.exit(failed ? 1 : 0);
+})();

--- a/services/DashboardService.js
+++ b/services/DashboardService.js
@@ -2,6 +2,7 @@ const Enquiry = require("../models/Enquiry");
 const Admin = require("../models/Admin");
 const LeadInternalEvent = require("../models/LeadInternalEvent");
 const LeadLifecycleService = require("./LeadLifecycleService");
+const WAConversationRepository = require("../repositories/WAConversationRepository");
 const { computeLeadHealth } = require("../utils/leadHealth");
 const {
   goldenWindowFor,
@@ -75,6 +76,25 @@ const buildDashboard = async (adminId, scope, scopeFilter = {}) => {
   // Lazy resurface (Slice E): recycled leads past revisitAt come back before we read.
   await LeadLifecycleService.resurfaceDueLeads(scopeFilter);
 
+  // MISSION-QUIET (Kiara): WhatsApp leads actively handled by the AI agent
+  // (mode ai, open, not escalated) carry no call-now pressure — Kiara is
+  // already talking to them. They re-enter missions the moment the
+  // conversation escalates or qualifies (needsHuman flips / qualified path).
+  let kiaraQuietIds = [];
+  try {
+    const quietConvIds = await WAConversationRepository.findQuietEnquiryIds();
+    if (quietConvIds.length) {
+      const quietLeads = await Enquiry.find(
+        { _id: { $in: quietConvIds }, source: "whatsapp" },
+        { _id: 1 }
+      ).lean();
+      kiaraQuietIds = quietLeads.map((l) => l._id);
+    }
+  } catch (e) {
+    console.error("[Dashboard] kiara mission-quiet lookup failed:", e.message);
+  }
+  const kiaraQuiet = kiaraQuietIds.length ? { _id: { $nin: kiaraQuietIds } } : {};
+
   // Hardening: admins who can no longer work leads — their open leads are orphans.
   const inactiveAdminIds = (
     await Admin.find({ status: { $ne: "active" } }, { _id: 1 }).lean()
@@ -102,15 +122,17 @@ const buildDashboard = async (adminId, scope, scopeFilter = {}) => {
     }).lean(),
     // Unresponsive — decide rows.
     Enquiry.find({ $and: [{ ...scopeFilter, ...ACTIVE, unresponsiveFlaggedAt: { $ne: null } }, visibility] }).lean(),
-    // New & untouched (no call yet), oldest first.
-    Enquiry.find({ $and: [{ ...scopeFilter, ...ACTIVE, stage: "new", "callLog.0": { $exists: false } }, visibility] })
+    // New & untouched (no call yet), oldest first. Kiara-quiet leads excluded —
+    // the AI agent is mid-conversation with them.
+    Enquiry.find({ $and: [{ ...scopeFilter, ...ACTIVE, ...kiaraQuiet, stage: "new", "callLog.0": { $exists: false } }, visibility] })
       .sort({ createdAt: 1 })
       .lean(),
     // At-risk A: New, no call, older than the SLA. Imported historical leads are
-    // excluded — a Zoho migration must never read as an SLA storm.
+    // excluded — a Zoho migration must never read as an SLA storm. Kiara-quiet
+    // leads excluded too (no call pressure while the agent is handling them).
     Enquiry.find({
       $and: [
-        { ...scopeFilter, ...ACTIVE, stage: "new", "callLog.0": { $exists: false }, createdAt: { $lt: dayAgo }, importedAt: null },
+        { ...scopeFilter, ...ACTIVE, ...kiaraQuiet, stage: "new", "callLog.0": { $exists: false }, createdAt: { $lt: dayAgo }, importedAt: null },
         visibility,
       ],
     }).lean(),
@@ -259,6 +281,39 @@ const buildDashboard = async (adminId, scope, scopeFilter = {}) => {
   const counts = {};
   for (const c of stageCounts) counts[c._id || "unknown"] = c.count;
 
+  // Kiara escalations: needsHuman conversations surface as mission cards for
+  // the lead's owner ("WhatsApp: <name> needs you — <reason>"), same scope
+  // rules as every other lead surface.
+  let waNeedsHuman = [];
+  try {
+    const escalated = await WAConversationRepository.findNeedsHuman();
+    const escalatedLeadIds = escalated.map((c) => c.enquiryId).filter(Boolean);
+    if (escalatedLeadIds.length) {
+      const inScope = await Enquiry.find({
+        $and: [{ _id: { $in: escalatedLeadIds } }, scopeFilter, visibility],
+      }).lean();
+      const byId = new Map(inScope.map((l) => [String(l._id), l]));
+      waNeedsHuman = escalated
+        .filter((c) => c.enquiryId && byId.has(String(c.enquiryId)))
+        .map((c) => {
+          const lead = byId.get(String(c.enquiryId));
+          return {
+            conversationId: c._id,
+            leadId: lead._id,
+            name: lead.name,
+            maskedPhone: maskPhone(lead.phone),
+            stage: lead.stage,
+            reason: c.needsHumanReason || "Needs a human",
+            needsHumanAt: c.needsHumanAt,
+            unreadCount: c.unreadCount || 0,
+          };
+        })
+        .sort((a, b) => new Date(a.needsHumanAt || 0) - new Date(b.needsHumanAt || 0));
+    }
+  } catch (e) {
+    console.error("[Dashboard] kiara needs-human lookup failed:", e.message);
+  }
+
   // Mission progress: follow-ups completed today in scope ("X of Y done").
   const completedTodayDocs = await Enquiry.aggregate([
     { $match: { $and: [{ ...scopeFilter }, visibility] } },
@@ -282,6 +337,7 @@ const buildDashboard = async (adminId, scope, scopeFilter = {}) => {
     scope,
     todaysMission,
     unresponsiveDecide,
+    waNeedsHuman,
     newUntouched,
     atRisk,
     hotLeads,

--- a/services/JourneyService.js
+++ b/services/JourneyService.js
@@ -23,6 +23,15 @@ const EVENT_TITLES = {
   transferred: "Transferred",
   tags_changed: "Tags changed",
   custom_fields_updated: "Custom fields updated",
+  // Kiara (WhatsApp AI agent) moments.
+  wa_conversation_started: "WhatsApp conversation started",
+  wa_escalated: "Kiara asked for a human",
+  wa_human_takeover: "Human took over the chat",
+  wa_handed_back: "Handed back to Kiara",
+  wa_qualified_by_kiara: "Qualified by Kiara ✦",
+  wa_classified: "Classified by Kiara",
+  wa_admin_message_sent: "WhatsApp message sent",
+  wa_template_sent: "Re-engage template sent",
 };
 
 // GET /enquiry/:_id/journey — every moment of a lead's life, one chronological

--- a/services/KiaraCrmSyncService.js
+++ b/services/KiaraCrmSyncService.js
@@ -1,0 +1,301 @@
+const Enquiry = require("../models/Enquiry");
+const WAAgentMessage = require("../models/WAAgentMessage");
+const User = require("../models/User");
+const Event = require("../models/Event");
+const VendorContact = require("../models/VendorContact");
+const EnquiryRepository = require("../repositories/EnquiryRepository");
+const WAConversationRepository = require("../repositories/WAConversationRepository");
+const LeadInternalEventService = require("./LeadInternalEventService");
+const ActivityLogService = require("./ActivityLogService");
+
+// Kiara → CRM bridge. Hook 2 outcomes (escalation + classification) and the
+// Hook 3 qualification sync live here so the surgical edits inside
+// WhatsAppAgentService stay one-line call-outs.
+
+const CLASSIFICATIONS = ["lead", "vendor", "birthday", "corporate", "destination"];
+const NOT_A_LEAD = { vendor: "vendor", birthday: "birthday", corporate: "corporate" };
+
+// All ten extractor answers, stored raw under additionalInfo.kiaraAnswers
+// (the adFormAnswers idiom).
+const ANSWER_KEYS = [
+  "name", "eventType", "city", "eventDate", "numberOfEvents",
+  "venueStatus", "venueName", "servicesRequired", "budget", "weddingStyle",
+];
+
+// ── System lead close (vendor/birthday/corporate) ────────────────────────────
+// Mirrors EnquiryService's direct-approve write shape. Bypasses both the
+// lost.reasons validation and the approval queue — founder-approved system
+// action: a vendor pitch is not a sales decision anyone needs to sign off on.
+// Won/already-lost leads are never touched.
+const closeLeadAsSystem = async (enquiryId, reason) => {
+  const lead = await EnquiryRepository.findById(enquiryId);
+  if (!lead) return null;
+  if (lead.stage === "won" || lead.stage === "lost" || lead.lostStatus === "approved") {
+    return lead;
+  }
+  const updated = await EnquiryRepository.updateFieldsById(enquiryId, {
+    lostStatus: "approved",
+    lostReason: reason,
+    lostNote: "",
+    lostRequestedBy: null,
+    lostRequestedAt: new Date(),
+    lostDecidedBy: null,
+    lostDecidedAt: new Date(),
+    lostDecisionNote: "Kiara system action (approval bypassed)",
+    stageBeforeLost: lead.stage,
+    isLost: true,
+    stage: "lost",
+  });
+  await ActivityLogService.record({
+    actorId: null,
+    action: "lead.disqualify_approved",
+    entityType: "lead",
+    entityId: String(enquiryId),
+    summary: `Closed by Kiara (${reason})`,
+    meta: { reason, system: true },
+  });
+  return updated;
+};
+
+// ── Escalation ────────────────────────────────────────────────────────────────
+const escalate = async (conversation, reason) => {
+  const updated = await WAConversationRepository.updateFieldsById(conversation._id, {
+    needsHuman: true,
+    needsHumanReason: reason || "Needs a human",
+    needsHumanAt: new Date(),
+  });
+  if (conversation.enquiryId) {
+    await LeadInternalEventService.record({
+      leadId: conversation.enquiryId,
+      type: "wa_escalated",
+      actorId: null,
+      payload: { reason: reason || "" },
+    });
+  }
+  return updated;
+};
+
+// ── Hook 2: apply the extractor's escalate/classification verdicts ───────────
+// vendor      → VendorContact capture, conversation closed, lead lost
+// birthday /
+// corporate   → conversation closed, lead lost
+// destination → escalate (specialist), conversation stays open
+// qualified   → ALWAYS escalates ("Qualified — ready for your call")
+const applyExtraction = async (conversation, extraction) => {
+  if (!conversation || !extraction) return conversation;
+  try {
+    const classification = CLASSIFICATIONS.includes(extraction.classification)
+      ? extraction.classification
+      : null;
+
+    if (classification && conversation.classification !== classification) {
+      conversation = await WAConversationRepository.updateFieldsById(conversation._id, {
+        classification,
+      });
+    }
+
+    if (classification && NOT_A_LEAD[classification] && conversation.status !== "closed") {
+      if (classification === "vendor") {
+        const firstMsg = await WAAgentMessage.findOne({
+          phone: conversation.phone,
+          role: "user",
+        })
+          .sort({ createdAt: 1 })
+          .lean();
+        await VendorContact.create({
+          phone: conversation.phone,
+          name: (extraction.data && extraction.data.name) || "",
+          offering: (extraction.data && extraction.data.servicesRequired) || "",
+          firstMessage: firstMsg ? firstMsg.message : "",
+          source: "whatsapp",
+          conversationId: conversation._id,
+        });
+      }
+      conversation = await WAConversationRepository.updateFieldsById(conversation._id, {
+        status: "closed",
+        needsHuman: false,
+        needsHumanReason: "",
+        needsHumanAt: null,
+      });
+      if (conversation.enquiryId) {
+        const reason = `Not a lead — ${NOT_A_LEAD[classification]}`;
+        await closeLeadAsSystem(conversation.enquiryId, reason);
+        await LeadInternalEventService.record({
+          leadId: conversation.enquiryId,
+          type: "wa_classified",
+          actorId: null,
+          payload: { classification, action: "conversation_closed_lead_lost", reason },
+        });
+      }
+      return conversation;
+    }
+
+    if (classification === "destination" && !conversation.needsHuman) {
+      return await escalate(conversation, "Destination wedding — specialist needed");
+    }
+
+    if (extraction.qualified && !conversation.needsHuman) {
+      return await escalate(conversation, "Qualified — ready for your call");
+    }
+
+    if (extraction.escalate && !conversation.needsHuman) {
+      return await escalate(
+        conversation,
+        (extraction.escalateReason || "").trim() || "Needs a human"
+      );
+    }
+    return conversation;
+  } catch (e) {
+    console.error("[KiaraCrmSync] applyExtraction failed:", e.message);
+    return conversation;
+  }
+};
+
+// ── Hook 3 helpers ────────────────────────────────────────────────────────────
+
+// Best-effort date parse → Date at the start of the day, or null.
+const parseEventDate = (raw) => {
+  const str = String(raw || "").trim();
+  if (!str) return null;
+  const d = new Date(str);
+  if (!Number.isNaN(d.getTime()) && d.getFullYear() > 2000) return d;
+  return null;
+};
+
+const parseCount = (raw, fallback = 1) => {
+  const m = String(raw || "").match(/\d+/);
+  if (!m) return fallback;
+  return Math.min(10, Math.max(1, parseInt(m[0], 10)));
+};
+
+const normalizeVenueStatus = (raw) => {
+  const s = String(raw || "").toLowerCase();
+  if (!s) return "";
+  if (/(not|n't|no |looking|search|need|help)/.test(s)) return "looking";
+  if (/book|confirm|final|done|yes/.test(s)) return "booked";
+  return "";
+};
+
+const isoDay = (d) => d.toISOString().slice(0, 10);
+
+// Event Store sync: User by phone (created if absent) → Event with
+// numberOfEvents eventDays anchored on the parsed date. Unparseable dates →
+// caller keeps the raw answer in kiaraAnswers only.
+const ensureEventDays = async (lead, data) => {
+  const baseDate = parseEventDate(data.eventDate);
+  if (!baseDate) return false;
+
+  let user = await User.findOne({ phone: lead.phone });
+  if (!user) {
+    user = await new User({ name: data.name || lead.name, phone: lead.phone }).save();
+  }
+
+  // Idempotent: an event already on file for this user means days exist — the
+  // sales team curates from there, Kiara never overwrites.
+  const existing = await Event.findOne({ user: user._id });
+  if (existing) return true;
+
+  const count = parseCount(data.numberOfEvents, 1);
+  const eventDays = Array.from({ length: count }, (_, i) => ({
+    name: count === 1 ? "Wedding" : `Day ${i + 1}`,
+    date: isoDay(new Date(baseDate.getTime() + i * 24 * 3600 * 1000)),
+    time: "TBD",
+    venue: data.venueName || "TBD",
+  }));
+
+  await new Event({
+    user: user._id,
+    name: data.name || lead.name,
+    community: "",
+    eventType: data.eventType || "",
+    eventDate: isoDay(baseDate),
+    eventDays,
+  }).save();
+  return true;
+};
+
+// ── Hook 3: qualification → the linked CRM lead ───────────────────────────────
+// Writes qualificationData (never clobbering non-empty values), stores ALL ten
+// raw answers under additionalInfo.kiaraAnswers, creates the Event Store days
+// (best-effort), flips the lead's qualified flag (Roadmap ✓), and records
+// wa_qualified_by_kiara. Throws on failure so the caller's retry idiom
+// (crmSynced, mirroring googleSheetSynced) can re-run it.
+const syncQualifiedToCrm = async (phone, data = {}, conversation = null) => {
+  let enquiryId = conversation && conversation.enquiryId;
+  if (!enquiryId) {
+    const LeadIntakeService = require("./LeadIntakeService");
+    const existing = await LeadIntakeService.findExistingByNormalizedPhone(phone);
+    enquiryId = existing && existing._id;
+  }
+  if (!enquiryId) throw new Error("No linked CRM lead for qualified conversation");
+
+  const lead = await EnquiryRepository.findById(enquiryId);
+  if (!lead) throw new Error("Linked enquiry not found");
+
+  const set = {};
+
+  // Raw answers — the adFormAnswers idiom (all ten, non-empty only).
+  for (const key of ANSWER_KEYS) {
+    const value = data[key];
+    if (value !== undefined && value !== null && String(value).trim() !== "") {
+      set[`additionalInfo.kiaraAnswers.${key}`] = String(value).slice(0, 2000);
+    }
+  }
+
+  // qualificationData mapping — fill only what's empty.
+  const qd = lead.qualificationData || {};
+  const fillQd = (field, value) => {
+    if (value && !qd[field]) set[`qualificationData.${field}`] = String(value);
+  };
+  // Single extractor "name": surfaced as the couple fact only when neither
+  // name is on file (no gender guess to make — it's just "the name we have").
+  if (data.name && !qd.groomName && !qd.brideName) {
+    set["qualificationData.groomName"] = String(data.name);
+  }
+  fillQd("venueStatus", normalizeVenueStatus(data.venueStatus));
+  fillQd("venueName", data.venueName);
+  fillQd("weddingStyle", data.weddingStyle);
+
+  // Placeholder lead names ("WhatsApp 1234") upgrade to the real one.
+  if (data.name && /^WhatsApp \d{4}$/.test(lead.name || "")) {
+    set.name = String(data.name);
+  }
+
+  // Qualified flag — same write the cockpit's qualified-call outcome makes.
+  set.qualified = true;
+
+  await EnquiryRepository.updateFieldsById(enquiryId, set);
+
+  // Event Store days (best-effort: an unparseable date stays answers-only).
+  let eventCreated = false;
+  try {
+    eventCreated = await ensureEventDays(lead, data);
+  } catch (e) {
+    console.error("[KiaraCrmSync] event-day sync failed:", e.message);
+  }
+
+  await LeadInternalEventService.record({
+    leadId: enquiryId,
+    type: "wa_qualified_by_kiara",
+    actorId: null,
+    payload: {
+      answers: ANSWER_KEYS.reduce((acc, k) => {
+        if (data[k]) acc[k] = String(data[k]).slice(0, 500);
+        return acc;
+      }, {}),
+      eventCreated,
+    },
+  });
+
+  return true;
+};
+
+module.exports = {
+  applyExtraction,
+  syncQualifiedToCrm,
+  closeLeadAsSystem,
+  escalate,
+  parseEventDate,
+  parseCount,
+  normalizeVenueStatus,
+};

--- a/services/SettingsService.js
+++ b/services/SettingsService.js
@@ -1,4 +1,5 @@
 const Setting = require("../models/Setting");
+const { KIARA_DEFAULT_SYSTEM_PROMPT } = require("./kiaraDefaultPrompt");
 
 // ─── Defaults: the EXACT current hardcoded values. Empty collection ⇒ identical
 // behavior to before this service existed. WhatsApp strings lifted verbatim from
@@ -30,6 +31,11 @@ const DEFAULTS = {
   // Lead visibility cutoff: hide leads created before this date from lists and
   // dashboards (imported + recently re-enquired leads always show). null = off.
   "leads.visibilityCutoff": null,
+  // Kiara (the WhatsApp AI agent). systemPrompt seeds VERBATIM from the former
+  // hardcoded text — empty settings ⇒ zero behavior change. Qualification
+  // FIELDS stay code-defined (extractor + QualifiedLead + Sheets coupling).
+  "kiara.systemPrompt": KIARA_DEFAULT_SYSTEM_PROMPT,
+  "kiara.reengageTemplateName": "",
 };
 
 // key → settings permission category. Every write is gated by ITS category.
@@ -53,6 +59,9 @@ const KEY_CATEGORY = {
   "adform.fieldMap": "settings_integrations",
   // Visibility cutoff governs what the working pipeline shows → pipeline category.
   "leads.visibilityCutoff": "settings_pipeline",
+  // Kiara's brain — founder-gated category.
+  "kiara.systemPrompt": "settings_kiara",
+  "kiara.reengageTemplateName": "settings_kiara",
 };
 
 const err = (status, message) => Object.assign(new Error(message), { status });
@@ -124,6 +133,22 @@ const validateValue = (key, value) => {
         throw err(400, "leads.visibilityCutoff must be null or a parseable ISO date string");
       }
       return new Date(value).toISOString();
+    }
+    case "kiara.systemPrompt": {
+      if (typeof value !== "string" || value.trim().length === 0 || value.length > 20000) {
+        throw err(400, "kiara.systemPrompt must be a non-empty string of at most 20000 chars");
+      }
+      return value;
+    }
+    case "kiara.reengageTemplateName": {
+      if (typeof value !== "string" || value.length > 200) {
+        throw err(400, "kiara.reengageTemplateName must be a string of at most 200 chars");
+      }
+      // Meta template names: lowercase/digits/underscores. Empty = unset.
+      if (value && !/^[a-z0-9_]+$/.test(value)) {
+        throw err(400, "kiara.reengageTemplateName must match Meta's template-name format (lowercase letters, digits, underscores)");
+      }
+      return value;
     }
     case "adform.fieldMap": {
       if (typeof value !== "object" || value === null || Array.isArray(value)) {

--- a/services/WAConversationService.js
+++ b/services/WAConversationService.js
@@ -1,0 +1,340 @@
+const mongoose = require("mongoose");
+const WAConversationRepository = require("../repositories/WAConversationRepository");
+const WAAgentMessageRepository = require("../repositories/WAAgentMessageRepository");
+const WAAgentMessage = require("../models/WAAgentMessage");
+const Enquiry = require("../models/Enquiry");
+const Admin = require("../models/Admin");
+const LeadIntakeService = require("./LeadIntakeService");
+const LeadInternalEventService = require("./LeadInternalEventService");
+const SettingsService = require("./SettingsService");
+const { sendWhatsApp, sendWhatsAppText } = require("../utils/whatsapp");
+
+// Meta's customer-service window: free-form messages are allowed only within
+// 24 hours of the customer's last inbound message. Outside it, only approved
+// templates go through.
+const WINDOW_MS = 24 * 60 * 60 * 1000;
+const PREVIEW_LEN = 120;
+
+const httpError = (status, message, extra = {}) =>
+  Object.assign(new Error(message), { status, ...extra });
+
+const assertValidId = (id) => {
+  if (!mongoose.Types.ObjectId.isValid(id)) {
+    throw httpError(400, "Invalid conversation id");
+  }
+};
+
+const preview = (text) => String(text || "").slice(0, PREVIEW_LEN);
+
+// 24h-window helper: open while lastInboundAt is within 24h.
+const windowInfo = (conversation, now = new Date()) => {
+  const last = conversation && conversation.lastInboundAt
+    ? new Date(conversation.lastInboundAt)
+    : null;
+  if (!last || Number.isNaN(last.getTime())) {
+    return { windowOpen: false, windowClosesAt: null };
+  }
+  const closesAt = new Date(last.getTime() + WINDOW_MS);
+  return { windowOpen: closesAt > now, windowClosesAt: closesAt };
+};
+
+// ── Hook 1 support: inbound touch + CRM lead linkage ─────────────────────────
+
+// Upsert the conversation row for an inbound message (creates it on first
+// contact) and bump freshness/unread.
+const recordInbound = async (phone, text) => {
+  const normalized = LeadIntakeService.normalizePhone(phone);
+  return await WAConversationRepository.upsertOnInbound(phone, normalized, preview(text));
+};
+
+// Ensure the conversation is linked to a CRM lead — full intake semantics:
+// normalized-phone dedup, re-enquiry on terminal leads, round-robin auto-assign.
+// Idempotent: a linked conversation returns untouched.
+const ensureLeadLinked = async (conversation, { profileName, firstMessage } = {}) => {
+  if (!conversation) return conversation;
+  if (conversation.enquiryId) return conversation;
+
+  let enquiryId = null;
+  const existing = await LeadIntakeService.findExistingByNormalizedPhone(conversation.phone);
+  if (existing) {
+    enquiryId = existing._id;
+    // Dedup-merge: same person, new channel — re-enquiry semantics (badge,
+    // resurfacing of recycled leads, Returned card for lost ones).
+    await LeadIntakeService.recordReEnquiry(existing._id, {
+      source: "whatsapp",
+      message: firstMessage || "",
+    });
+  } else {
+    const name = (profileName || "").trim() || `WhatsApp ${String(conversation.phone).slice(-4)}`;
+    try {
+      const created = await new Enquiry({
+        name,
+        phone: conversation.phone,
+        verified: false,
+        source: "whatsapp",
+        additionalInfo: {},
+      }).save();
+      enquiryId = created._id;
+      // Round-robin auto-assign (never throws).
+      await LeadIntakeService.afterCreate(created._id);
+    } catch (e) {
+      // Unique-phone race (duplicate webhook delivery): fall back to the winner.
+      const winner = await LeadIntakeService.findExistingByNormalizedPhone(conversation.phone);
+      if (!winner) throw e;
+      enquiryId = winner._id;
+    }
+  }
+
+  const updated = await WAConversationRepository.updateFieldsById(conversation._id, {
+    enquiryId,
+  });
+  await LeadInternalEventService.record({
+    leadId: enquiryId,
+    type: "wa_conversation_started",
+    actorId: null,
+    payload: { phone: conversation.phone, firstMessage: preview(firstMessage) },
+  });
+  return updated;
+};
+
+// ── Admin chat API (Slice 4) ──────────────────────────────────────────────────
+
+// Conversations visible to the caller: scoped through the LINKED LEAD using the
+// same scope filter the lead routes build (ownerField assignedTo). Conversations
+// without a lead link surface only for all-scope callers.
+const listInbox = async ({ mode, needsHuman, status, page = 1, limit = 20 } = {}, scopeFilter = {}) => {
+  const filter = {};
+  if (mode === "ai" || mode === "human") filter.mode = mode;
+  if (needsHuman === "true" || needsHuman === true) filter.needsHuman = true;
+  if (status === "active" || status === "closed") filter.status = status;
+
+  const unscoped = Object.keys(scopeFilter).length === 0;
+  if (!unscoped) {
+    const inScope = await Enquiry.find(scopeFilter, { _id: 1 }).lean();
+    filter.enquiryId = { $in: inScope.map((l) => l._id) };
+  }
+
+  const pageNum = Math.max(1, parseInt(page, 10) || 1);
+  const lim = Math.min(100, Math.max(1, parseInt(limit, 10) || 20));
+  const [rows, total] = await Promise.all([
+    WAConversationRepository.list(filter, { skip: (pageNum - 1) * lim, limit: lim }),
+    WAConversationRepository.count(filter),
+  ]);
+
+  // Join the lead summary (name, stage, owner) in two queries.
+  const leadIds = rows.map((r) => r.enquiryId).filter(Boolean);
+  const leads = leadIds.length
+    ? await Enquiry.find(
+        { _id: { $in: leadIds } },
+        { name: 1, stage: 1, assignedTo: 1, qualified: 1 }
+      ).lean()
+    : [];
+  const ownerIds = [...new Set(leads.map((l) => l.assignedTo).filter(Boolean).map(String))];
+  const owners = ownerIds.length
+    ? await Admin.find({ _id: { $in: ownerIds } }, { name: 1 }).lean()
+    : [];
+  const leadById = new Map(leads.map((l) => [String(l._id), l]));
+  const ownerById = new Map(owners.map((o) => [String(o._id), o.name]));
+
+  const now = new Date();
+  const list = rows.map((c) => {
+    const lead = c.enquiryId ? leadById.get(String(c.enquiryId)) : null;
+    return {
+      ...c,
+      ...windowInfo(c, now),
+      lead: lead
+        ? {
+            _id: lead._id,
+            name: lead.name,
+            stage: lead.stage,
+            qualified: !!lead.qualified,
+            ownerId: lead.assignedTo || null,
+            ownerName: lead.assignedTo ? ownerById.get(String(lead.assignedTo)) || null : null,
+          }
+        : null,
+    };
+  });
+
+  return { list, total, page: pageNum, totalPages: Math.max(1, Math.ceil(total / lim)) };
+};
+
+// Load + scope-check one conversation (404 unknown, 403 out of scope).
+const getScoped = async (conversationId, scopeFilter = {}) => {
+  assertValidId(conversationId);
+  const conversation = await WAConversationRepository.findById(conversationId);
+  if (!conversation) throw httpError(404, "Conversation not found");
+  const unscoped = Object.keys(scopeFilter).length === 0;
+  if (!unscoped) {
+    if (!conversation.enquiryId) throw httpError(403, "Out of your scope");
+    const lead = await Enquiry.findOne({
+      $and: [{ _id: conversation.enquiryId }, scopeFilter],
+    }).lean();
+    if (!lead) throw httpError(403, "Out of your scope");
+  }
+  return conversation;
+};
+
+// Paginated thread, newest page first by createdAt asc within the page. Marks read.
+const getMessages = async (conversationId, { page = 1, limit = 50 } = {}, scopeFilter = {}) => {
+  const conversation = await getScoped(conversationId, scopeFilter);
+  const pageNum = Math.max(1, parseInt(page, 10) || 1);
+  const lim = Math.min(200, Math.max(1, parseInt(limit, 10) || 50));
+  const [total, docs] = await Promise.all([
+    WAAgentMessage.countDocuments({ phone: conversation.phone }),
+    WAAgentMessage.find({ phone: conversation.phone })
+      .sort({ createdAt: -1 })
+      .skip((pageNum - 1) * lim)
+      .limit(lim)
+      .populate("sentBy", "name")
+      .lean(),
+  ]);
+  if (conversation.unreadCount > 0) {
+    await WAConversationRepository.updateFieldsById(conversation._id, { unreadCount: 0 });
+  }
+  return {
+    conversation: { ...conversation.toObject(), ...windowInfo(conversation), unreadCount: 0 },
+    messages: docs.reverse(),
+    total,
+    page: pageNum,
+    totalPages: Math.max(1, Math.ceil(total / lim)),
+  };
+};
+
+// Sticky human takeover: Kiara stops replying until an explicit hand-back.
+const takeover = async (conversationId, actorId, scopeFilter = {}) => {
+  const conversation = await getScoped(conversationId, scopeFilter);
+  const updated = await WAConversationRepository.updateFieldsById(conversation._id, {
+    mode: "human",
+    needsHuman: false,
+    needsHumanReason: "",
+    needsHumanAt: null,
+  });
+  if (conversation.enquiryId) {
+    await LeadInternalEventService.record({
+      leadId: conversation.enquiryId,
+      type: "wa_human_takeover",
+      actorId,
+      payload: {},
+    });
+  }
+  return { ...updated.toObject(), ...windowInfo(updated) };
+};
+
+const handback = async (conversationId, actorId, scopeFilter = {}) => {
+  const conversation = await getScoped(conversationId, scopeFilter);
+  const updated = await WAConversationRepository.updateFieldsById(conversation._id, {
+    mode: "ai",
+    needsHuman: false,
+    needsHumanReason: "",
+    needsHumanAt: null,
+  });
+  if (conversation.enquiryId) {
+    await LeadInternalEventService.record({
+      leadId: conversation.enquiryId,
+      type: "wa_handed_back",
+      actorId,
+      payload: {},
+    });
+  }
+  return { ...updated.toObject(), ...windowInfo(updated) };
+};
+
+// Free-form send: human mode only (409 tells the UI to take over first) and
+// only inside the 24h window (422 {windowClosed:true} → re-engage template).
+const sendText = async (conversationId, text, actorId, scopeFilter = {}) => {
+  if (typeof text !== "string" || !text.trim()) throw httpError(400, "text is required");
+  if (text.length > 4096) throw httpError(400, "Message is too long (max 4096 chars)");
+  const conversation = await getScoped(conversationId, scopeFilter);
+  if (conversation.mode !== "human") {
+    throw httpError(409, "Kiara is handling this conversation — take over before sending");
+  }
+  const { windowOpen, windowClosesAt } = windowInfo(conversation);
+  if (!windowOpen) {
+    throw httpError(
+      422,
+      "The 24-hour WhatsApp window has closed — use the re-engage template",
+      { windowClosed: true, windowClosesAt }
+    );
+  }
+  const clean = text.trim();
+  const sent = await sendWhatsAppText(
+    conversation.phone,
+    clean,
+    process.env.WHATSAPP_AGENT_PHONE_NUMBER_ID
+  );
+  if (!sent) throw httpError(502, "WhatsApp send failed — try again");
+
+  const saved = await new WAAgentMessage({
+    phone: conversation.phone,
+    role: "assistant",
+    message: clean,
+    sentBy: actorId || null,
+  }).save();
+  const updated = await WAConversationRepository.touchOutbound(conversation._id, preview(clean));
+  if (conversation.enquiryId) {
+    await LeadInternalEventService.record({
+      leadId: conversation.enquiryId,
+      type: "wa_admin_message_sent",
+      actorId,
+      payload: { preview: preview(clean) },
+    });
+  }
+  return { message: saved, conversation: { ...updated.toObject(), ...windowInfo(updated) } };
+};
+
+// Template send (re-engage): allowed with the window closed, still human-mode-only.
+const sendTemplate = async (conversationId, actorId, scopeFilter = {}) => {
+  const conversation = await getScoped(conversationId, scopeFilter);
+  if (conversation.mode !== "human") {
+    throw httpError(409, "Kiara is handling this conversation — take over before sending");
+  }
+  const templateName = await SettingsService.get("kiara.reengageTemplateName");
+  if (!templateName) {
+    throw httpError(422, "No re-engage template configured — set kiara.reengageTemplateName in Settings");
+  }
+  let name = "";
+  if (conversation.enquiryId) {
+    const lead = await Enquiry.findById(conversation.enquiryId, { name: 1 }).lean();
+    name = lead ? (lead.name || "").split(/\s+/)[0] : "";
+  }
+  const sent = await sendWhatsApp(
+    conversation.phone,
+    templateName,
+    [name || "there"],
+    null,
+    process.env.WHATSAPP_AGENT_PHONE_NUMBER_ID
+  );
+  if (!sent) throw httpError(502, "WhatsApp template send failed — try again");
+
+  const body = `[template: ${templateName}]`;
+  const saved = await new WAAgentMessage({
+    phone: conversation.phone,
+    role: "assistant",
+    message: body,
+    sentBy: actorId || null,
+  }).save();
+  const updated = await WAConversationRepository.touchOutbound(conversation._id, body);
+  if (conversation.enquiryId) {
+    await LeadInternalEventService.record({
+      leadId: conversation.enquiryId,
+      type: "wa_template_sent",
+      actorId,
+      payload: { template: templateName },
+    });
+  }
+  return { message: saved, conversation: { ...updated.toObject(), ...windowInfo(updated) } };
+};
+
+module.exports = {
+  WINDOW_MS,
+  windowInfo,
+  recordInbound,
+  ensureLeadLinked,
+  listInbox,
+  getScoped,
+  getMessages,
+  takeover,
+  handback,
+  sendText,
+  sendTemplate,
+};

--- a/services/WAConversationService.js
+++ b/services/WAConversationService.js
@@ -192,8 +192,19 @@ const getMessages = async (conversationId, { page = 1, limit = 50 } = {}, scopeF
   if (conversation.unreadCount > 0) {
     await WAConversationRepository.updateFieldsById(conversation._id, { unreadCount: 0 });
   }
+  // Whether the re-engage template is configured (the UI disables its send
+  // button with an explanatory tooltip when it isn't).
+  let reengageTemplateSet = false;
+  try {
+    reengageTemplateSet = !!(await SettingsService.get("kiara.reengageTemplateName"));
+  } catch (_) { /* settings read is advisory here */ }
   return {
-    conversation: { ...conversation.toObject(), ...windowInfo(conversation), unreadCount: 0 },
+    conversation: {
+      ...conversation.toObject(),
+      ...windowInfo(conversation),
+      unreadCount: 0,
+      reengageTemplateSet,
+    },
     messages: docs.reverse(),
     total,
     page: pageNum,

--- a/services/WAConversationService.js
+++ b/services/WAConversationService.js
@@ -102,11 +102,12 @@ const ensureLeadLinked = async (conversation, { profileName, firstMessage } = {}
 // Conversations visible to the caller: scoped through the LINKED LEAD using the
 // same scope filter the lead routes build (ownerField assignedTo). Conversations
 // without a lead link surface only for all-scope callers.
-const listInbox = async ({ mode, needsHuman, status, page = 1, limit = 20 } = {}, scopeFilter = {}) => {
+const listInbox = async ({ mode, needsHuman, status, enquiryId, page = 1, limit = 20 } = {}, scopeFilter = {}) => {
   const filter = {};
   if (mode === "ai" || mode === "human") filter.mode = mode;
   if (needsHuman === "true" || needsHuman === true) filter.needsHuman = true;
   if (status === "active" || status === "closed") filter.status = status;
+  if (enquiryId && mongoose.Types.ObjectId.isValid(enquiryId)) filter.enquiryId = enquiryId;
 
   const unscoped = Object.keys(scopeFilter).length === 0;
   if (!unscoped) {

--- a/services/WhatsAppAgentService.js
+++ b/services/WhatsAppAgentService.js
@@ -10,6 +10,10 @@ const QualifiedLead = require('../models/QualifiedLead');
 const axios = require('axios');
 const { google } = require('googleapis');
 
+// Test seam: e2e suites point this at a local mock so no test ever touches
+// the live API. Unset (production) ⇒ the real endpoint, unchanged.
+const ANTHROPIC_API_URL = process.env.ANTHROPIC_API_URL || 'https://api.anthropic.com/v1/messages';
+
 // Kiara's persona now lives in Settings (kiara.systemPrompt, founder-gated,
 // 60s cache) and defaults to the verbatim former hardcoded text — an empty
 // settings collection is byte-identical behavior.
@@ -47,7 +51,7 @@ const sendToClaude = async (history) => {
   while (attempt <= MAX_RETRIES) {
     try {
       const response = await axios.post(
-        'https://api.anthropic.com/v1/messages',
+        ANTHROPIC_API_URL,
         {
           model: 'claude-sonnet-4-5',
           max_tokens: 500,
@@ -89,7 +93,7 @@ const checkQualified = async (history) => {
   while (attempt <= MAX_RETRIES) {
     try {
       const response = await axios.post(
-        'https://api.anthropic.com/v1/messages',
+        ANTHROPIC_API_URL,
         {
           model: 'claude-sonnet-4-5',
           max_tokens: 400,

--- a/services/WhatsAppAgentService.js
+++ b/services/WhatsAppAgentService.js
@@ -1,55 +1,48 @@
 const { sendWhatsAppText } = require('../utils/whatsapp');
 const WAAgentMessageRepository = require('../repositories/WAAgentMessageRepository');
+const WAConversationRepository = require('../repositories/WAConversationRepository');
+const WAConversationService = require('./WAConversationService');
+const KiaraCrmSyncService = require('./KiaraCrmSyncService');
+const SettingsService = require('./SettingsService');
+const { KIARA_DEFAULT_SYSTEM_PROMPT } = require('./kiaraDefaultPrompt');
 const NotificationFailureLog = require('../models/NotificationFailureLog');
 const QualifiedLead = require('../models/QualifiedLead');
 const axios = require('axios');
 const { google } = require('googleapis');
 
-const SYSTEM_PROMPT = `You are Kiara, a wedding planner at Wedsy in Bengaluru. You're texting a potential client on WhatsApp.
+// Kiara's persona now lives in Settings (kiara.systemPrompt, founder-gated,
+// 60s cache) and defaults to the verbatim former hardcoded text — an empty
+// settings collection is byte-identical behavior.
+const getSystemPrompt = async () => {
+  try {
+    return await SettingsService.get('kiara.systemPrompt');
+  } catch (error) {
+    console.error('[WhatsAppAgent] settings prompt read failed, using default:', error.message);
+    return KIARA_DEFAULT_SYSTEM_PROMPT;
+  }
+};
 
-Your personality:
-- You text like a real human — short, warm, casual but professional
-- Max 1-2 sentences per reply. Never write paragraphs.
-- Use natural language. Contractions, light punctuation, occasional emoji (not every message)
-- You sound like a knowledgeable friend who happens to plan weddings — not a bot, not a formal agent
-- If someone asks about anything wedding related (venues, decor, catering, budget, trends, mehendi artists, photographers etc.) — answer naturally and helpfully, then gently steer back to understanding their needs
-- Never use bullet points, numbered lists, or formal language
-- Never say things like "Certainly!", "Absolutely!", "Of course!" — too robotic
-- If they say something funny or casual, match their energy
+// CRASH FIX: response.data.content[0].text threw on empty content arrays and
+// tool/thinking-first responses. Find the first text block; null means the
+// caller treats it as a failure (existing retry → FailureLog path).
+const firstTextBlock = (response) => {
+  const content = response && response.data && Array.isArray(response.data.content)
+    ? response.data.content
+    : [];
+  const block = content.find((b) => b && b.type === 'text' && typeof b.text === 'string');
+  return block ? block.text : null;
+};
 
-About Wedsy:
-- Bengaluru-based wedding planning and decor company
-- Full-service: planning, decor design, vendor coordination, catering, photography, makeup, logistics, entertainment
-- Primary city is Bengaluru. Outside Bengaluru = destination wedding (handled by a specialist)
-- Only weddings and engagements. No birthdays. Corporate events handled separately.
-
-Your goal is to naturally collect these details through conversation — don't make it feel like a form:
-- Type of event (wedding or engagement)
-- City
-- Date or approximate month
-- For weddings: how many days/functions (weddings can be 2-5 days — ask naturally like "how many days is the wedding going to be?")
-- Wedding style/theme preference — South Indian, North Indian, fusion, destination, etc. If they're unsure, suggest a few options casually and help them think through it. This is important for decor and planning style.
-- Venue (booked or need help finding one)
-- Services needed (full planning, decor only, specific things)
-- Budget (ask softly, totally fine if they skip it)
-
-How to handle edge cases:
-- Vendor/photographer/supplier reaching out → "Oh nice! I'll pass your details to our vendor team, they'll reach out if there's a good fit 😊" then end politely
-- Birthday inquiry → "Ah we actually specialise only in weddings and engagements! But if you ever need a wedding planner, you know where to find us 😄"
-- Corporate inquiry → "Corporate events aren't our space, but we have a team that handles that — I'll connect you!"
-- Outside Bengaluru → "Oh that's a destination wedding for us! We have a specialist for those — are you okay working with a Bengaluru-based planner?"
-- Destination confirmed → "Perfect, I'll have our destination wedding team reach out to you shortly 😊" then end
-
-When you have all the details:
-- Thank them warmly in 1-2 casual sentences
-- Tell them the team will be in touch within 24 hours
-- End the conversation naturally, like a human would
-
-Remember: you're texting, not writing an email. Keep it short, keep it real.`;
+const EXTRACTOR_SYSTEM_PROMPT = 'You are a data extractor. Based on the conversation, check if the qualification is complete — meaning the assistant has thanked the user and said the team will connect within 24 hours. Extract whatever details were collected. ' +
+  'Also decide two routing signals. (1) "escalate": set true when the customer explicitly asks for a human, shows frustration or anger, pushes pricing/negotiation beyond rapport, or the conversation is stuck (3+ exchanges without progress) — and ALWAYS when qualified is true (use escalateReason "Qualified — ready for your call"). Give a short escalateReason whenever escalate is true. ' +
+  '(2) "classification": classify the contact as one of "lead" (a genuine wedding/engagement customer), "vendor" (a vendor/photographer/supplier pitching their services), "birthday" (a birthday inquiry), "corporate" (a corporate-event inquiry), or "destination" (a confirmed destination wedding outside Bengaluru). ' +
+  'Respond ONLY with valid JSON, no markdown, no explanation. Format: {"qualified": true/false, "escalate": true/false, "escalateReason": "", "classification": "lead", "data": {"name": "", "eventType": "", "city": "", "eventDate": "", "numberOfEvents": "", "venueStatus": "", "venueName": "", "servicesRequired": "", "budget": "", "weddingStyle": ""}}';
 
 const sendToClaude = async (history) => {
   const MAX_RETRIES = 2;
   let attempt = 0;
+
+  const systemPrompt = await getSystemPrompt();
 
   while (attempt <= MAX_RETRIES) {
     try {
@@ -58,7 +51,7 @@ const sendToClaude = async (history) => {
         {
           model: 'claude-sonnet-4-5',
           max_tokens: 500,
-          system: SYSTEM_PROMPT,
+          system: systemPrompt,
           messages: history
         },
         {
@@ -69,7 +62,9 @@ const sendToClaude = async (history) => {
           }
         }
       );
-      return response.data.content[0].text;
+      const text = firstTextBlock(response);
+      if (text === null) throw new Error('Anthropic response had no text block');
+      return text;
     } catch (error) {
       attempt++;
       if (attempt > MAX_RETRIES) {
@@ -98,7 +93,7 @@ const checkQualified = async (history) => {
         {
           model: 'claude-sonnet-4-5',
           max_tokens: 400,
-          system: 'You are a data extractor. Based on the conversation, check if the qualification is complete — meaning the assistant has thanked the user and said the team will connect within 24 hours. Extract whatever details were collected. Respond ONLY with valid JSON, no markdown, no explanation. Format: {"qualified": true/false, "data": {"name": "", "eventType": "", "city": "", "eventDate": "", "numberOfEvents": "", "venueStatus": "", "venueName": "", "servicesRequired": "", "budget": "", "weddingStyle": ""}}',
+          system: EXTRACTOR_SYSTEM_PROMPT,
           messages: history
         },
         {
@@ -109,10 +104,12 @@ const checkQualified = async (history) => {
           }
         }
       );
-      const text = response.data.content[0].text;
+      const text = firstTextBlock(response);
+      if (text === null) throw new Error('Anthropic response had no text block');
       try {
         return JSON.parse(text);
       } catch {
+        // JSON parse failure keeps the pre-Kiara fallback: not qualified, no routing.
         return { qualified: false };
       }
     } catch (error) {
@@ -132,9 +129,12 @@ const checkQualified = async (history) => {
   }
 };
 
-const saveQualifiedLead = async (phone, data) => {
+const saveQualifiedLead = async (phone, data, conversation = null) => {
   const existing = await QualifiedLead.findOne({ phone });
-  if (existing && existing.googleSheetSynced) {
+  // HOOK 3: the Sheets append and the CRM sync are INDEPENDENT — either may
+  // succeed alone; each has its own synced flag and is retried on the next
+  // qualification pass until it lands.
+  if (existing && existing.googleSheetSynced && existing.crmSynced) {
     console.log('[WhatsAppAgent] Lead already qualified and synced, skipping:', phone);
     return existing;
   }
@@ -169,80 +169,153 @@ const saveQualifiedLead = async (phone, data) => {
       return null;
     }
   } else {
-    console.log('[WhatsAppAgent] Lead exists but not synced, retrying Sheets:', phone);
+    console.log('[WhatsAppAgent] Lead exists but not fully synced, retrying:', phone);
   }
 
   const MAX_RETRIES = 2;
-  let attempt = 0;
 
-  while (attempt <= MAX_RETRIES) {
-    try {
-      const auth = new google.auth.GoogleAuth({
-        keyFile: process.env.GOOGLE_SHEETS_KEY_PATH,
-        scopes: ['https://www.googleapis.com/auth/spreadsheets']
-      });
-      const sheets = google.sheets({ version: 'v4', auth });
-      await sheets.spreadsheets.values.append({
-        spreadsheetId: process.env.GOOGLE_SHEETS_ID,
-        range: 'Sheet1!A:N',
-        valueInputOption: 'USER_ENTERED',
-        requestBody: {
-          values: [[
-            leadDoc.name || '',
-            leadDoc.phoneNumber || '',
-            leadDoc.phone,
-            leadDoc.eventType || '',
-            leadDoc.city || '',
-            leadDoc.eventDate || '',
-            leadDoc.numberOfEvents || '',
-            leadDoc.venueStatus || '',
-            leadDoc.venueName || '',
-            leadDoc.servicesRequired || '',
-            leadDoc.budget || '',
-            leadDoc.weddingStyle || '',
-            leadDoc.source || '',
-            leadDoc.qualifiedAt ? leadDoc.qualifiedAt.toISOString() : new Date().toISOString()
-          ]]
-        }
-      });
-      leadDoc.googleSheetSynced = true;
-      await leadDoc.save();
-      console.log('[WhatsAppAgent] Lead appended to Google Sheet:', phone);
-      return true;
-    } catch (error) {
-      attempt++;
-      if (attempt > MAX_RETRIES) {
-        await NotificationFailureLog.create({
-          service: 'GoogleSheets',
-          phone,
-          error: error.message,
-          attempts: attempt,
-          createdAt: new Date()
+  // ── Google Sheets append (UNCHANGED, independent of the CRM sync) ──────────
+  if (!leadDoc.googleSheetSynced) {
+    let attempt = 0;
+    while (attempt <= MAX_RETRIES) {
+      try {
+        const auth = new google.auth.GoogleAuth({
+          keyFile: process.env.GOOGLE_SHEETS_KEY_PATH,
+          scopes: ['https://www.googleapis.com/auth/spreadsheets']
         });
-        console.error(`[WhatsAppAgent] Google Sheet append failed after ${attempt} attempts:`, error.message);
-        return null;
+        const sheets = google.sheets({ version: 'v4', auth });
+        await sheets.spreadsheets.values.append({
+          spreadsheetId: process.env.GOOGLE_SHEETS_ID,
+          range: 'Sheet1!A:N',
+          valueInputOption: 'USER_ENTERED',
+          requestBody: {
+            values: [[
+              leadDoc.name || '',
+              leadDoc.phoneNumber || '',
+              leadDoc.phone,
+              leadDoc.eventType || '',
+              leadDoc.city || '',
+              leadDoc.eventDate || '',
+              leadDoc.numberOfEvents || '',
+              leadDoc.venueStatus || '',
+              leadDoc.venueName || '',
+              leadDoc.servicesRequired || '',
+              leadDoc.budget || '',
+              leadDoc.weddingStyle || '',
+              leadDoc.source || '',
+              leadDoc.qualifiedAt ? leadDoc.qualifiedAt.toISOString() : new Date().toISOString()
+            ]]
+          }
+        });
+        leadDoc.googleSheetSynced = true;
+        await leadDoc.save();
+        console.log('[WhatsAppAgent] Lead appended to Google Sheet:', phone);
+        break;
+      } catch (error) {
+        attempt++;
+        if (attempt > MAX_RETRIES) {
+          await NotificationFailureLog.create({
+            service: 'GoogleSheets',
+            phone,
+            error: error.message,
+            attempts: attempt,
+            createdAt: new Date()
+          });
+          console.error(`[WhatsAppAgent] Google Sheet append failed after ${attempt} attempts:`, error.message);
+          break;
+        }
+        await new Promise(resolve => setTimeout(resolve, 2000));
       }
-      await new Promise(resolve => setTimeout(resolve, 2000));
     }
   }
+
+  // ── HOOK 3: CRM sync (crmSynced mirrors the googleSheetSynced retry idiom) ──
+  // Maps the extracted answers onto the linked Enquiry (qualificationData +
+  // additionalInfo.kiaraAnswers), creates the Event Store days (best-effort),
+  // flips the lead's qualified flag, and records wa_qualified_by_kiara.
+  if (!leadDoc.crmSynced) {
+    let attempt = 0;
+    while (attempt <= MAX_RETRIES) {
+      try {
+        await KiaraCrmSyncService.syncQualifiedToCrm(phone, data, conversation);
+        leadDoc.crmSynced = true;
+        await leadDoc.save();
+        console.log('[WhatsAppAgent] Lead synced to CRM:', phone);
+        break;
+      } catch (error) {
+        attempt++;
+        if (attempt > MAX_RETRIES) {
+          await NotificationFailureLog.create({
+            service: 'KiaraCrmSync',
+            phone,
+            error: error.message,
+            attempts: attempt,
+            createdAt: new Date()
+          });
+          console.error(`[WhatsAppAgent] CRM sync failed after ${attempt} attempts:`, error.message);
+          break;
+        }
+        await new Promise(resolve => setTimeout(resolve, 2000));
+      }
+    }
+  }
+
+  return leadDoc.googleSheetSynced && leadDoc.crmSynced ? true : null;
 };
 
-const receiveMessage = async (phone, message) => {
+const receiveMessage = async (phone, message, meta = {}) => {
   try {
     await WAAgentMessageRepository.saveMessage(phone, 'user', message);
+
+    // HOOK 1: conversation upsert (freshness/preview/unread) + CRM lead
+    // linkage with the full intake semantics (normalized-phone dedup,
+    // re-enquiry on terminal leads, round-robin auto-assign).
+    let conversation = await WAConversationService.recordInbound(phone, message);
+    conversation = await WAConversationService.ensureLeadLinked(conversation, {
+      profileName: meta.profileName,
+      firstMessage: message
+    });
+
+    // Human-owned or closed conversation: the message is stored for the team,
+    // Kiara stays silent — zero Anthropic spend, no auto-reply.
+    if (conversation.mode !== 'ai' || conversation.status === 'closed') return;
+
     const history = await WAAgentMessageRepository.getHistory(phone);
     const reply = await sendToClaude(history);
     if (!reply) return;
     await WAAgentMessageRepository.saveMessage(phone, 'assistant', reply);
+    await WAConversationRepository.touchOutbound(conversation._id, reply.slice(0, 120));
     await sendWhatsAppText(phone, reply, process.env.WHATSAPP_AGENT_PHONE_NUMBER_ID);
     const updatedHistory = await WAAgentMessageRepository.getHistory(phone);
     const qualification = await checkQualified(updatedHistory);
+
+    // HOOK 2: escalation + classification routing (vendor/birthday/corporate
+    // close out, destination escalates, qualified always escalates).
+    conversation = await KiaraCrmSyncService.applyExtraction(conversation, qualification);
+
     if (qualification && qualification.qualified) {
-      await saveQualifiedLead(phone, qualification.data);
+      await saveQualifiedLead(phone, qualification.data, conversation);
     }
   } catch (error) {
     console.error('[WhatsAppAgent] receiveMessage error:', error.message);
   }
 };
 
-module.exports = { receiveMessage };
+// Non-text inbound (image/audio/video/sticker/…): stored as a placeholder so
+// humans see it in the thread, conversation freshness/unread bumped, lead
+// ensured — but NO Claude call and NO auto-reply.
+const receiveMedia = async (phone, type, meta = {}) => {
+  try {
+    const placeholder = `[media: ${type || 'unknown'}]`;
+    await WAAgentMessageRepository.saveMessage(phone, 'user', placeholder);
+    const conversation = await WAConversationService.recordInbound(phone, placeholder);
+    await WAConversationService.ensureLeadLinked(conversation, {
+      profileName: meta.profileName,
+      firstMessage: placeholder
+    });
+  } catch (error) {
+    console.error('[WhatsAppAgent] receiveMedia error:', error.message);
+  }
+};
+
+module.exports = { receiveMessage, receiveMedia };

--- a/services/kiaraDefaultPrompt.js
+++ b/services/kiaraDefaultPrompt.js
@@ -1,0 +1,47 @@
+// Kiara's default persona — the EXACT text that was hardcoded in
+// WhatsAppAgentService before the kiara.systemPrompt setting existed. The
+// setting defaults to this string, so an empty settings collection means zero
+// behavior change. Edit the live persona in Settings → Kiara, not here.
+const KIARA_DEFAULT_SYSTEM_PROMPT = `You are Kiara, a wedding planner at Wedsy in Bengaluru. You're texting a potential client on WhatsApp.
+
+Your personality:
+- You text like a real human — short, warm, casual but professional
+- Max 1-2 sentences per reply. Never write paragraphs.
+- Use natural language. Contractions, light punctuation, occasional emoji (not every message)
+- You sound like a knowledgeable friend who happens to plan weddings — not a bot, not a formal agent
+- If someone asks about anything wedding related (venues, decor, catering, budget, trends, mehendi artists, photographers etc.) — answer naturally and helpfully, then gently steer back to understanding their needs
+- Never use bullet points, numbered lists, or formal language
+- Never say things like "Certainly!", "Absolutely!", "Of course!" — too robotic
+- If they say something funny or casual, match their energy
+
+About Wedsy:
+- Bengaluru-based wedding planning and decor company
+- Full-service: planning, decor design, vendor coordination, catering, photography, makeup, logistics, entertainment
+- Primary city is Bengaluru. Outside Bengaluru = destination wedding (handled by a specialist)
+- Only weddings and engagements. No birthdays. Corporate events handled separately.
+
+Your goal is to naturally collect these details through conversation — don't make it feel like a form:
+- Type of event (wedding or engagement)
+- City
+- Date or approximate month
+- For weddings: how many days/functions (weddings can be 2-5 days — ask naturally like "how many days is the wedding going to be?")
+- Wedding style/theme preference — South Indian, North Indian, fusion, destination, etc. If they're unsure, suggest a few options casually and help them think through it. This is important for decor and planning style.
+- Venue (booked or need help finding one)
+- Services needed (full planning, decor only, specific things)
+- Budget (ask softly, totally fine if they skip it)
+
+How to handle edge cases:
+- Vendor/photographer/supplier reaching out → "Oh nice! I'll pass your details to our vendor team, they'll reach out if there's a good fit 😊" then end politely
+- Birthday inquiry → "Ah we actually specialise only in weddings and engagements! But if you ever need a wedding planner, you know where to find us 😄"
+- Corporate inquiry → "Corporate events aren't our space, but we have a team that handles that — I'll connect you!"
+- Outside Bengaluru → "Oh that's a destination wedding for us! We have a specialist for those — are you okay working with a Bengaluru-based planner?"
+- Destination confirmed → "Perfect, I'll have our destination wedding team reach out to you shortly 😊" then end
+
+When you have all the details:
+- Thank them warmly in 1-2 casual sentences
+- Tell them the team will be in touch within 24 hours
+- End the conversation naturally, like a human would
+
+Remember: you're texting, not writing an email. Keep it short, keep it real.`;
+
+module.exports = { KIARA_DEFAULT_SYSTEM_PROMPT };

--- a/utils/rbacPermissions.js
+++ b/utils/rbacPermissions.js
@@ -13,6 +13,9 @@ const RESOURCES = [
   "settings_pipeline", "settings_fields", "settings_assignment", "settings_sla",
   "settings_cadence", "settings_reasons", "settings_integrations",
   "settings_templates", "settings_roles",
+  // Kiara (WhatsApp AI agent) brain — founder-only by policy (granted via the
+  // founder role's *:*:all wildcard; never seeded to other roles).
+  "settings_kiara",
 ];
 const ACTIONS = ["view", "create", "edit", "delete", "assign", "export", "approve"];
 const SCOPES = ["own", "team", "department", "all"];

--- a/utils/whatsapp.js
+++ b/utils/whatsapp.js
@@ -1,8 +1,14 @@
 const NotificationFailureLog = require('../models/NotificationFailureLog');
 
-const sendWhatsApp = async (phone, templateName, parameters = [], buttonParameters = null) => {
+// agentPhoneNumberId (additive, optional): send the template from the Kiara
+// agent number instead of the default business number. Default = unchanged.
+const sendWhatsApp = async (phone, templateName, parameters = [], buttonParameters = null, agentPhoneNumberId = null) => {
   const MAX_RETRIES = 2;
   let attempt = 0;
+  const phoneNumberId = agentPhoneNumberId || process.env.META_WA_PHONE_NUMBER_ID;
+  const accessToken = agentPhoneNumberId
+    ? process.env.META_WA_AGENT_ACCESS_TOKEN
+    : process.env.META_WA_ACCESS_TOKEN;
 
   const components = [
     {
@@ -23,11 +29,11 @@ const sendWhatsApp = async (phone, templateName, parameters = [], buttonParamete
   while (attempt <= MAX_RETRIES) {
     try {
       const response = await fetch(
-        `https://graph.facebook.com/v19.0/${process.env.META_WA_PHONE_NUMBER_ID}/messages`,
+        `https://graph.facebook.com/v19.0/${phoneNumberId}/messages`,
         {
           method: 'POST',
           headers: {
-            'Authorization': `Bearer ${process.env.META_WA_ACCESS_TOKEN}`,
+            'Authorization': `Bearer ${accessToken}`,
             'Content-Type': 'application/json'
           },
           body: JSON.stringify({

--- a/utils/whatsapp.js
+++ b/utils/whatsapp.js
@@ -1,5 +1,9 @@
 const NotificationFailureLog = require('../models/NotificationFailureLog');
 
+// Test seam: e2e suites point this at a local mock so no test ever hits Meta.
+// Unset (production) ⇒ the real Graph endpoint, unchanged.
+const GRAPH_BASE_URL = process.env.META_GRAPH_BASE_URL || 'https://graph.facebook.com/v19.0';
+
 // agentPhoneNumberId (additive, optional): send the template from the Kiara
 // agent number instead of the default business number. Default = unchanged.
 const sendWhatsApp = async (phone, templateName, parameters = [], buttonParameters = null, agentPhoneNumberId = null) => {
@@ -29,7 +33,7 @@ const sendWhatsApp = async (phone, templateName, parameters = [], buttonParamete
   while (attempt <= MAX_RETRIES) {
     try {
       const response = await fetch(
-        `https://graph.facebook.com/v19.0/${phoneNumberId}/messages`,
+        `${GRAPH_BASE_URL}/${phoneNumberId}/messages`,
         {
           method: 'POST',
           headers: {
@@ -83,7 +87,7 @@ const sendWhatsAppText = async (phone, message, agentPhoneNumberId = null) => {
   while (attempt <= MAX_RETRIES) {
     try {
       const response = await fetch(
-        `https://graph.facebook.com/v19.0/${phoneNumberId}/messages`,
+        `${GRAPH_BASE_URL}/${phoneNumberId}/messages`,
         {
           method: 'POST',
           headers: {


### PR DESCRIPTION
## Summary

Integrates the Kiara WhatsApp agent with Wedsy OS CRM in five slices, plus an agent crash fix. All Kiara-agent-file edits in this branch were explicitly authorized.

### Slice 1 — Conversation layer (55dcb6e)
- New `WAConversation` and `VendorContact` models, repository, and service.
- Handles the 24h WhatsApp messaging window, intake linkage, and admin chat operations.

### Slice 2 — Agent hooks: CRM intake on first message, escalation, qualification sync (cea5bb0)
- CRM intake created/linked on a contact's first inbound message.
- Escalation/classification routing into the CRM, and CRM qualification sync (`QualifiedLead.crmSynced`).
- Mission-quiet behavior for agent runs.
- **Crash fix**: resolves the agent crash in the same hook path (see below).

### Slice 3 — Kiara settings (20f8bab)
- `kiara.systemPrompt` and `kiara.reengageTemplateName` under a new founder-only `settings_kiara` category.

### Slice 4 — Admin chat API (13004e2, 9677829, a6f2c30)
- `/wa/conversations` inbox, thread view, takeover/handback, send, and send-template endpoints.
- Inbox `enquiryId` filter, `wa_*` journey titles, and `reengageTemplateSet` exposed on the thread payload.

### Slice 5 — E2E test suite (b11d7e6, d48e9d6)
- Signed webhooks against a local server boot with Anthropic/Meta/Sheets mocked (env-overridable base URLs as mock seams); 85 assertions with full cleanup.

### Agent crash fix
- Fixed the crash in the Kiara agent hook path so a failure no longer takes down message processing (shipped in cea5bb0 alongside the hook work).

### Deploy
- **Zero-seed deploy**: no seed scripts or data migrations required; new models and settings are created lazily at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)