### PR TITLE
feat(venue): browser-e2e server support — OTP send bypass, analytics range fix, deterministic seed

### DIFF
--- a/controllers/venueAnalytics.js
+++ b/controllers/venueAnalytics.js
@@ -52,6 +52,12 @@ const getAnalytics = async (req, res) => {
     const { from, to } = req.query;
     const fromDate = from ? new Date(from) : null;
     const toDate = to ? new Date(to) : null;
+    // A date-only "to" (YYYY-MM-DD) parses to midnight UTC, which silently
+    // excludes everything created later that same day — i.e. today's leads
+    // never appear in any bounded range. Make it inclusive end-of-day.
+    if (toDate && !isNaN(toDate) && /^\d{4}-\d{2}-\d{2}$/.test(String(to))) {
+      toDate.setUTCHours(23, 59, 59, 999);
+    }
     const dateFilter = {};
     if (fromDate && !isNaN(fromDate)) dateFilter.$gte = fromDate;
     if (toDate && !isNaN(toDate)) dateFilter.$lte = toDate;

--- a/controllers/venueOwner.js
+++ b/controllers/venueOwner.js
@@ -366,6 +366,13 @@ const sendLoginOTP = async (req, res) => {
     if (!venueOwner && !member) {
       return res.status(404).json({ message: "No venue account found for this phone number" });
     }
+    // E2E/dev bypass: skip the SMS/WhatsApp provider entirely. Gated on an
+    // explicit env flag AND non-production so prod behaviour cannot change.
+    // Verification already honours DEV_OTP 000000 outside production; this makes
+    // the *send* step work in automated runs where provider creds are blanked.
+    if (process.env.OTP_DEV_BYPASS === "true" && process.env.NODE_ENV !== "production") {
+      return res.status(200).json({ success: true, referenceId: "dev-bypass" });
+    }
     const { ReferenceId } = await SendOTP(phone);
     return res.status(200).json({ success: true, referenceId: ReferenceId });
   } catch (err) {

--- a/scripts/seed-test-venue.js
+++ b/scripts/seed-test-venue.js
@@ -117,6 +117,11 @@ async function run() {
     console.log(`[seed] created venue ${venue.slug} (${venue._id})`);
   } else {
     Object.assign(venue, venueDefaults);
+    // Fields that suites WRITE but the defaults above don't cover — clear them
+    // so a "reset" venue is actually deterministic across repeated runs
+    // (stale policyDoc/logo made the back-compat e2e checks order-dependent).
+    venue.policyDoc = undefined;
+    venue.logo = "";
     await venue.save();
     console.log(`[seed] reset venue ${venue.slug} (${venue._id})`);
   }


### PR DESCRIPTION
Server-side companions to the wedsy-venue browser harness: an env-gated OTP send bypass (`OTP_DEV_BYPASS=true` + non-production returns a stub referenceId without touching SMS/WhatsApp providers, so creds-blank automated runs can exercise the real login UI — prod is byte-for-byte unchanged), a real bug fix the harness caught (date-only `?to=` in venue analytics parsed as midnight UTC, silently excluding every lead created that same day from all bounded ranges — now inclusive end-of-day), and a seed determinism fix (venue reset clears stale `policyDoc`/`logo` so suites are order-independent).

Deploy in coordinated window only. `OTP_DEV_BYPASS` must never be set in prod env.

Review-assist verdict: 7/7 PASS — no route changes, no deps, no secrets; suites 86/86 e2e + 61/61 hardening on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)