### PR TITLE
feat(venue): quality sweep — Venue.logo on PDFs, onboarding ops alert, seed/test infra

### DIFF
--- a/controllers/venueAnalytics.js
+++ b/controllers/venueAnalytics.js
@@ -52,6 +52,12 @@ const getAnalytics = async (req, res) => {
     const { from, to } = req.query;
     const fromDate = from ? new Date(from) : null;
     const toDate = to ? new Date(to) : null;
+    // A date-only "to" (YYYY-MM-DD) parses to midnight UTC, which silently
+    // excludes everything created later that same day — i.e. today's leads
+    // never appear in any bounded range. Make it inclusive end-of-day.
+    if (toDate && !isNaN(toDate) && /^\d{4}-\d{2}-\d{2}$/.test(String(to))) {
+      toDate.setUTCHours(23, 59, 59, 999);
+    }
     const dateFilter = {};
     if (fromDate && !isNaN(fromDate)) dateFilter.$gte = fromDate;
     if (toDate && !isNaN(toDate)) dateFilter.$lte = toDate;

--- a/controllers/venueInvoice.js
+++ b/controllers/venueInvoice.js
@@ -134,12 +134,12 @@ const addPayment = async (req, res) => {
 // GET /venues/:slug/invoices/:invoiceId/pdf
 const invoicePdf = async (req, res) => {
   try {
-    const venue = await resolveOwnedVenue(req, res, "name address formattedAddress contact phone email gstin pan");
+    const venue = await resolveOwnedVenue(req, res, "name address formattedAddress contact phone email gstin pan logo");
     if (!venue) return;
     const invoice = await VenueInvoice.findOne({ _id: req.params.invoiceId, venue: venue._id }).lean();
     if (!invoice) return res.status(404).json({ message: "Invoice not found" });
     const booking = await VenueBooking.findById(invoice.booking).select("coupleName couplePhone").lean();
-    streamInvoicePdf(res, { venue, booking, invoice });
+    await streamInvoicePdf(res, { venue, booking, invoice });
   } catch (err) { return res.status(500).json({ message: err.message }); }
 };
 

--- a/controllers/venueOnboarding.js
+++ b/controllers/venueOnboarding.js
@@ -4,6 +4,7 @@
  */
 const VenueOnboardingRequest = require("../models/VenueOnboardingRequest");
 const { reqStr, optStr, MAXLEN } = require("../utils/venueInput");
+const { notifyOnboardingRequest } = require("../utils/venueOpsAlert");
 
 const createOnboardingRequest = async (req, res) => {
   try {
@@ -25,6 +26,9 @@ const createOnboardingRequest = async (req, res) => {
       phone: String(phone).trim().slice(0, MAXLEN.phone),
       status: "new",
     });
+    // Fire-and-forget ops alert — env-gated, log-only by default, and a
+    // delivery failure must never affect the 201 we owe the requester.
+    notifyOnboardingRequest({ name: doc.name, venueName: doc.venueName, city: doc.city, phone: doc.phone }).catch(() => {});
     return res.status(201).json({ success: true, id: doc._id });
   } catch (err) {
     return res.status(500).json({ message: err.message });

--- a/controllers/venueOwner.js
+++ b/controllers/venueOwner.js
@@ -366,6 +366,13 @@ const sendLoginOTP = async (req, res) => {
     if (!venueOwner && !member) {
       return res.status(404).json({ message: "No venue account found for this phone number" });
     }
+    // E2E/dev bypass: skip the SMS/WhatsApp provider entirely. Gated on an
+    // explicit env flag AND non-production so prod behaviour cannot change.
+    // Verification already honours DEV_OTP 000000 outside production; this makes
+    // the *send* step work in automated runs where provider creds are blanked.
+    if (process.env.OTP_DEV_BYPASS === "true" && process.env.NODE_ENV !== "production") {
+      return res.status(200).json({ success: true, referenceId: "dev-bypass" });
+    }
     const { ReferenceId } = await SendOTP(phone);
     return res.status(200).json({ success: true, referenceId: ReferenceId });
   } catch (err) {

--- a/controllers/venueQuote.js
+++ b/controllers/venueQuote.js
@@ -125,12 +125,12 @@ const updateQuote = async (req, res) => {
 // GET /venues/:slug/quotes/:quoteId/pdf
 const quotePdf = async (req, res) => {
   try {
-    const venue = await resolveOwnedVenue(req, res, "name address formattedAddress contact phone email");
+    const venue = await resolveOwnedVenue(req, res, "name address formattedAddress contact phone email logo");
     if (!venue) return;
     const quote = await VenueQuote.findOne({ _id: req.params.quoteId, venue: venue._id }).lean();
     if (!quote) return res.status(404).json({ message: "Quote not found" });
     const enquiry = await VenueEnquiry.findById(quote.enquiry).select("coupleName name couplePhone").lean();
-    streamQuotePdf(res, { venue, enquiry, quote });
+    await streamQuotePdf(res, { venue, enquiry, quote });
   } catch (err) { return res.status(500).json({ message: err.message }); }
 };
 

--- a/models/Venue.js
+++ b/models/Venue.js
@@ -119,6 +119,9 @@ const VenueSchema = new mongoose.Schema({
   },
   coverPhoto: { type: String, default: "" },
   featurePhoto: { type: String, default: "" },
+  // Venue brand logo (URL from the /file/upload flow, or a data: URI). Rendered
+  // top-left on quote/invoice PDFs when set; absence degrades gracefully.
+  logo: { type: String, default: "" },
   policies: {
     cancellation: { type: String, default: "" },
     refund: { type: String, default: "" },

--- a/scripts/e2e-onboarding-alert.js
+++ b/scripts/e2e-onboarding-alert.js
@@ -1,0 +1,94 @@
+/**
+ * scripts/e2e-onboarding-alert.js — deterministic checks for the onboarding
+ * ops alert (utils/venueOpsAlert). No server, no DB, no network: exercises
+ * the module directly with env permutations and a captured console.
+ *
+ * Usage: node scripts/e2e-onboarding-alert.js
+ */
+let pass = 0;
+let fail = 0;
+function check(name, cond, detail) {
+  if (cond) {
+    pass++;
+    console.log(`✓ PASS  ${name}`);
+  } else {
+    fail++;
+    console.log(`✗ FAIL  ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+function withCapturedLog(fn) {
+  const lines = [];
+  const orig = console.log;
+  console.log = (...args) => lines.push(args.join(" "));
+  return Promise.resolve()
+    .then(fn)
+    .then((r) => {
+      console.log = orig;
+      return { result: r, lines };
+    })
+    .catch((e) => {
+      console.log = orig;
+      throw e;
+    });
+}
+
+async function run() {
+  const { notifyOnboardingRequest, formatOnboardingAlert } = require("../utils/venueOpsAlert");
+  const REQUEST = { name: "Rohaan", venueName: "Crown Estate", city: "Bangalore", phone: "+91 98765 43210" };
+
+  // 1. Message format is exactly what ops expects.
+  const msg = formatOnboardingAlert(REQUEST);
+  check(
+    "alert message format (venue, contact, city)",
+    msg.includes("New venue onboarding request") &&
+      msg.includes("Venue: Crown Estate") &&
+      msg.includes("Contact: Rohaan · +91 98765 43210") &&
+      msg.includes("City: Bangalore"),
+    JSON.stringify(msg)
+  );
+
+  // 2. No OPS_ALERT_PHONE -> complete no-op (nothing logged, nothing sent).
+  delete process.env.OPS_ALERT_PHONE;
+  process.env.REMINDERS_LOG_ONLY = "true";
+  {
+    const { result, lines } = await withCapturedLog(() => notifyOnboardingRequest(REQUEST));
+    check("no OPS_ALERT_PHONE -> skipped silently", result.skipped === "no OPS_ALERT_PHONE" && lines.length === 0, JSON.stringify({ result, lines }));
+  }
+
+  // 3. Log-only (prod default): composes + logs the formatted message, no send.
+  process.env.OPS_ALERT_PHONE = "916364014464";
+  process.env.REMINDERS_LOG_ONLY = "true";
+  {
+    const { result, lines } = await withCapturedLog(() => notifyOnboardingRequest(REQUEST));
+    const joined = lines.join("\n");
+    check(
+      "log-only path logs the formatted message to the ops phone",
+      result.logged === true && joined.includes("[opsAlert][log-only] to=916364014464") && joined.includes("Venue: Crown Estate"),
+      JSON.stringify(lines)
+    );
+  }
+
+  // 4. Send mode WITHOUT creds: gated by isConfigured(), still no throw.
+  process.env.REMINDERS_LOG_ONLY = "false";
+  process.env.WHATSAPP_CLOUD_TOKEN = "";
+  process.env.META_WA_ACCESS_TOKEN = "";
+  process.env.WHATSAPP_PHONE_NUMBER_ID = "";
+  process.env.META_WA_PHONE_NUMBER_ID = "";
+  {
+    const { result, lines } = await withCapturedLog(() => notifyOnboardingRequest(REQUEST));
+    check(
+      "send mode without creds -> skipped via isConfigured, never throws",
+      result.skipped === "whatsapp unconfigured" && lines.join("\n").includes("not configured"),
+      JSON.stringify({ result, lines })
+    );
+  }
+
+  console.log(`\n[e2e-onboarding-alert] ${pass} passed, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
+}
+
+run().catch((e) => {
+  console.error("fatal:", e);
+  process.exit(1);
+});

--- a/scripts/e2e-venue.js
+++ b/scripts/e2e-venue.js
@@ -49,7 +49,7 @@ async function apiBinary(path, { token } = {}) {
   if (token) headers.Authorization = `Bearer ${token}`;
   const res = await fetch(`${API}${path}`, { method: "GET", headers });
   const buf = Buffer.from(await res.arrayBuffer());
-  return { status: res.status, contentType: res.headers.get("content-type") || "", bytes: buf.length, head: buf.slice(0, 5).toString("latin1") };
+  return { status: res.status, contentType: res.headers.get("content-type") || "", bytes: buf.length, head: buf.slice(0, 5).toString("latin1"), body: buf.toString("latin1") };
 }
 
 async function login() {
@@ -517,6 +517,43 @@ async function run() {
     // Shared bucket exhausted -> onboarding 429s at the limiter (no record created).
     const onbOver = await api("POST", `/venues/onboarding-requests`, { body: { name: "R", venueName: "V", phone: "9876543210" } });
     check("public-ratelimit: onboarding over-limit -> 429 (no record created)", onbOver.status === 429, `status ${onbOver.status}`);
+  }
+
+  // ================= Venue logo on quote/invoice PDFs =================
+  if (process.env.E2E_PDF_LOGO === "1") {
+    // Tiny solid-colour JPEG via sharp (already a dependency) — no fixtures.
+    const sharp = require("sharp");
+    const jpeg = await sharp({ create: { width: 24, height: 24, channels: 3, background: { r: 107, g: 30, b: 46 } } }).jpeg().toBuffer();
+    const dataUri = `data:image/jpeg;base64,${jpeg.toString("base64")}`;
+
+    const setLogo = await api("PUT", `/venues/${SLUG}`, { token, body: { logo: dataUri } });
+    check("pdf-logo: PUT venue.logo (listing gate) -> 200", setLogo.status === 200 && setLogo.json.venue && setLogo.json.venue.logo === dataUri, `status ${setLogo.status}`);
+
+    // Fresh lead -> quote -> PDF with the logo embedded as an image XObject.
+    const lead = await api("POST", `/venues/${SLUG}/enquiries/manual`, { token, body: { coupleName: "PDF Logo Couple", couplePhone: `97${Date.now() % 1e8}` } });
+    const leadId = lead.json.enquiryId || (lead.json.enquiry && lead.json.enquiry._id);
+    const q = await api("POST", `/venues/${SLUG}/quotes`, { token, body: { enquiry: leadId, lineItems: [{ label: "Hall", qty: 1, unitPrice: 50000 }], gstPercent: 18, discount: 0 } });
+    const quoteId = q.json.quote && q.json.quote._id;
+    const withLogo = await apiBinary(`/venues/${SLUG}/quotes/${quoteId}/pdf`, { token });
+    check("pdf-logo: quote PDF embeds image object when logo set",
+      withLogo.status === 200 && withLogo.head.startsWith("%PDF") && withLogo.body.includes("/XObject"),
+      `bytes=${withLogo.bytes} hasImage=${withLogo.body.includes("/XObject")}`);
+
+    // Graceful absence: clear the logo -> same PDF renders with no image object.
+    const clearLogo = await api("PUT", `/venues/${SLUG}`, { token, body: { logo: "" } });
+    check("pdf-logo: clearing logo -> 200", clearLogo.status === 200, `status ${clearLogo.status}`);
+    const without = await apiBinary(`/venues/${SLUG}/quotes/${quoteId}/pdf`, { token });
+    check("pdf-logo: PDF without logo still renders (no image object)",
+      without.status === 200 && without.head.startsWith("%PDF") && !without.body.includes("/XObject"),
+      `bytes=${without.bytes}`);
+
+    // Unreachable URL logo must degrade gracefully, never 500.
+    await api("PUT", `/venues/${SLUG}`, { token, body: { logo: "http://127.0.0.1:9/nope.jpg" } });
+    const broken = await apiBinary(`/venues/${SLUG}/quotes/${quoteId}/pdf`, { token });
+    check("pdf-logo: unreachable logo URL degrades gracefully (200, no image)",
+      broken.status === 200 && broken.head.startsWith("%PDF") && !broken.body.includes("/XObject"),
+      `status ${broken.status}`);
+    await api("PUT", `/venues/${SLUG}`, { token, body: { logo: "" } });
   }
 
   finish();

--- a/scripts/seed-bulk-rows.js
+++ b/scripts/seed-bulk-rows.js
@@ -1,0 +1,104 @@
+/**
+ * scripts/seed-bulk-rows.js — volume fixtures for frontend virtualization
+ * checks: bulk-inserts enquiries and/or bookings onto the seeded test venue
+ * (test-palace) so the dashboard tables can be exercised at 5,000 rows.
+ *
+ * SAFETY: refuses to run unless DATABASE_URL points at a local Mongo host
+ * (same guard as scripts/seed-test-venue.js). Inserted docs are tagged with
+ * coupleName prefix "Bulk Row" so they're easy to identify/remove.
+ *
+ * Usage:
+ *   node scripts/seed-bulk-rows.js --enquiries 5000 --bookings 5000
+ *   node scripts/seed-bulk-rows.js --clean        # remove previous bulk rows
+ */
+require("dotenv").config();
+const mongoose = require("mongoose");
+const Venue = require("../models/Venue");
+const VenueEnquiry = require("../models/VenueEnquiry");
+const VenueBooking = require("../models/VenueBooking");
+
+const LOCAL_HOSTS = new Set(["127.0.0.1", "localhost", "::1", "0.0.0.0"]);
+const SLUG = "test-palace";
+
+function argNum(flag) {
+  const i = process.argv.indexOf(flag);
+  if (i === -1) return 0;
+  const n = Number(process.argv[i + 1]);
+  return Number.isFinite(n) && n > 0 ? Math.min(n, 20000) : 0;
+}
+
+function assertLocalMongo() {
+  const url = process.env.DATABASE_URL || "";
+  let host;
+  try {
+    host = new URL(url).hostname;
+  } catch (e) {
+    throw new Error(`Cannot parse DATABASE_URL to verify host: ${e.message}`);
+  }
+  if (!LOCAL_HOSTS.has(host)) {
+    throw new Error(`Refusing to run: DATABASE_URL host "${host}" is not local.`);
+  }
+  return host;
+}
+
+const STAGES = ["new", "contacted", "site_visit_scheduled", "site_visit_done", "proposal_sent", "negotiating"];
+const BOOKING_STATUSES = ["confirmed", "in_progress", "completed"];
+
+async function run() {
+  const host = assertLocalMongo();
+  await mongoose.connect(process.env.DATABASE_URL, { serverSelectionTimeoutMS: 8000 });
+  console.log(`[seed-bulk] connected to local Mongo @ ${host}`);
+
+  const venue = await Venue.findOne({ slug: SLUG }).select("_id").lean();
+  if (!venue) throw new Error(`venue ${SLUG} not found — run seed-test-venue.js first`);
+
+  if (process.argv.includes("--clean")) {
+    const e = await VenueEnquiry.deleteMany({ venueId: venue._id, coupleName: /^Bulk Row/ });
+    const b = await VenueBooking.deleteMany({ venue: venue._id, coupleName: /^Bulk Row/ });
+    console.log(`[seed-bulk] cleaned ${e.deletedCount} enquiries, ${b.deletedCount} bookings`);
+  }
+
+  const nEnq = argNum("--enquiries");
+  const nBook = argNum("--bookings");
+  const now = Date.now();
+
+  if (nEnq) {
+    const docs = Array.from({ length: nEnq }, (_, i) => ({
+      venueId: venue._id,
+      coupleName: `Bulk Row Enq ${i + 1}`,
+      couplePhone: String(6e9 + ((now + i) % 1e9)),
+      stage: STAGES[i % STAGES.length],
+      source: "other",
+      estimatedValue: 50000 + (i % 50) * 1000,
+      createdAt: new Date(now - (i % 365) * 86400000),
+    }));
+    for (let i = 0; i < docs.length; i += 1000) {
+      await VenueEnquiry.insertMany(docs.slice(i, i + 1000), { ordered: false });
+    }
+    console.log(`[seed-bulk] inserted ${nEnq} enquiries`);
+  }
+
+  if (nBook) {
+    const docs = Array.from({ length: nBook }, (_, i) => ({
+      venue: venue._id,
+      coupleName: `Bulk Row Bk ${i + 1}`,
+      couplePhone: String(5e9 + ((now + i) % 1e9)),
+      totalValue: 100000 + (i % 100) * 5000,
+      status: BOOKING_STATUSES[i % BOOKING_STATUSES.length],
+      days: [{ date: new Date(now + (i % 365) * 86400000), eventType: "Wedding", guestCount: 100 + (i % 400) }],
+      createdAt: new Date(now - (i % 365) * 86400000),
+    }));
+    for (let i = 0; i < docs.length; i += 1000) {
+      await VenueBooking.insertMany(docs.slice(i, i + 1000), { ordered: false });
+    }
+    console.log(`[seed-bulk] inserted ${nBook} bookings`);
+  }
+
+  console.log("[seed-bulk] DONE");
+  process.exit(0);
+}
+
+run().catch((e) => {
+  console.error("[seed-bulk] FATAL:", e.message);
+  process.exit(1);
+});

--- a/scripts/seed-test-venue.js
+++ b/scripts/seed-test-venue.js
@@ -117,6 +117,11 @@ async function run() {
     console.log(`[seed] created venue ${venue.slug} (${venue._id})`);
   } else {
     Object.assign(venue, venueDefaults);
+    // Fields that suites WRITE but the defaults above don't cover — clear them
+    // so a "reset" venue is actually deterministic across repeated runs
+    // (stale policyDoc/logo made the back-compat e2e checks order-dependent).
+    venue.policyDoc = undefined;
+    venue.logo = "";
     await venue.save();
     console.log(`[seed] reset venue ${venue.slug} (${venue._id})`);
   }

--- a/services/VenueService.js
+++ b/services/VenueService.js
@@ -66,6 +66,8 @@ const SCALAR_TOP_LEVEL = [
   "name", "tagline", "description", "venueType", "established",
   "city", "address", "phone", "email", "website",
   "coverPhoto", "featurePhoto",
+  // Brand logo for quote/invoice PDFs (listing-gated PUT, same as photos)
+  "logo",
   // Places-enrich location fields (additive)
   "state", "pincode", "googlePlaceId", "formattedAddress",
   // Neighbourhood (area, from Places) + Bangalore region — editable from the

--- a/utils/venueOpsAlert.js
+++ b/utils/venueOpsAlert.js
@@ -1,0 +1,52 @@
+/**
+ * utils/venueOpsAlert.js — fire-and-forget WhatsApp alert to the Wedsy ops
+ * phone when a venue submits a "list your venue" onboarding request.
+ *
+ * Gating (all opt-in, prod-safe by default):
+ *   - OPS_ALERT_PHONE unset            -> no-op
+ *   - REMINDERS_LOG_ONLY !== "false"   -> compose + log, DO NOT send (default)
+ *   - otherwise                        -> send via utils/venueWhatsApp (Meta
+ *                                         Cloud only; no-ops without creds)
+ *
+ * Callers must never await delivery on the request path — use
+ * notifyOnboardingRequest(...).catch(() => {}) semantics; this module also
+ * swallows its own errors so a notification can never break the request.
+ */
+const venueWhatsApp = require("./venueWhatsApp");
+
+function formatOnboardingAlert({ name, venueName, city, phone }) {
+  return [
+    "New venue onboarding request",
+    `Venue: ${venueName}`,
+    `Contact: ${name} · ${phone}`,
+    `City: ${city || "—"}`,
+    "Follow up from the Wedsy OS leads view.",
+  ].join("\n");
+}
+
+async function notifyOnboardingRequest(request) {
+  try {
+    const opsPhone = (process.env.OPS_ALERT_PHONE || "").trim();
+    if (!opsPhone) return { skipped: "no OPS_ALERT_PHONE" };
+
+    const message = formatOnboardingAlert(request);
+    const logOnly = process.env.REMINDERS_LOG_ONLY !== "false"; // default true
+
+    if (logOnly) {
+      console.log(`[opsAlert][log-only] to=${opsPhone}\n${message}`);
+      return { logged: true, message };
+    }
+    if (!venueWhatsApp.isConfigured()) {
+      console.log("[opsAlert] WhatsApp not configured — skipping send");
+      return { skipped: "whatsapp unconfigured" };
+    }
+    const result = await venueWhatsApp.sendText(opsPhone, message);
+    if (!result.ok) console.log(`[opsAlert] send failed: ${result.error}`);
+    return result;
+  } catch (err) {
+    console.log(`[opsAlert] error (ignored): ${err.message}`);
+    return { ok: false, error: err.message };
+  }
+}
+
+module.exports = { notifyOnboardingRequest, formatOnboardingAlert };

--- a/utils/venuePdf.js
+++ b/utils/venuePdf.js
@@ -3,11 +3,37 @@
  * Each function streams directly to the Express response.
  */
 const PDFDocument = require("pdfkit");
+const axios = require("axios");
 const { formatINR } = require("./venueMoney");
 
 const BURGUNDY = "#6b1e2e";
 const GOLD = "#c9a961";
 const GREY = "#555555";
+
+/**
+ * Resolve venue.logo into an image buffer pdfkit can embed (JPEG/PNG).
+ * Supports data: URIs and http(s) URLs (uploads via /file/upload are
+ * sharp-normalised JPEGs). Missing, unreachable or malformed logos resolve
+ * to null and the PDF renders exactly as before — never an error.
+ */
+async function loadLogoBuffer(logo) {
+  if (!logo || typeof logo !== "string") return null;
+  try {
+    if (logo.startsWith("data:image/")) {
+      const b64 = logo.slice(logo.indexOf(",") + 1);
+      const buf = Buffer.from(b64, "base64");
+      return buf.length > 0 ? buf : null;
+    }
+    if (/^https?:\/\//.test(logo)) {
+      const res = await axios.get(logo, { responseType: "arraybuffer", timeout: 4000 });
+      const buf = Buffer.from(res.data);
+      return buf.length > 0 ? buf : null;
+    }
+  } catch {
+    /* graceful absence */
+  }
+  return null;
+}
 
 function startDoc(res, filename) {
   const doc = new PDFDocument({ size: "A4", margin: 50 });
@@ -17,17 +43,29 @@ function startDoc(res, filename) {
   return doc;
 }
 
-function venueHeader(doc, venue, titleText) {
-  doc.fillColor(BURGUNDY).fontSize(22).text(venue.name || "Venue", { continued: false });
+function venueHeader(doc, venue, titleText, logoBuffer) {
+  // Logo top-left when present; the venue text block shifts right beside it.
+  let textX = 50;
+  if (logoBuffer) {
+    try {
+      doc.image(logoBuffer, 50, 50, { fit: [110, 44] });
+      textX = 175;
+    } catch {
+      textX = 50; // bytes pdfkit can't embed — render as if absent
+    }
+  }
+  doc.fillColor(BURGUNDY).fontSize(22).text(venue.name || "Venue", textX, 50, { continued: false });
   const contact = venue.contact || {};
   const lines = [
     venue.address || venue.formattedAddress || "",
     contact.primaryPhone || venue.phone || "",
     contact.email || venue.email || "",
   ].filter(Boolean);
-  doc.moveDown(0.2).fillColor(GREY).fontSize(9).text(lines.join("  •  "));
+  doc.moveDown(0.2).fillColor(GREY).fontSize(9).text(lines.join("  •  "), textX, doc.y);
+  // Keep the title row clear of the logo block however short the text is.
+  if (logoBuffer && doc.y < 100) doc.y = 100;
   doc.moveDown(0.6);
-  doc.fillColor(GOLD).fontSize(16).text(titleText);
+  doc.fillColor(GOLD).fontSize(16).text(titleText, 50, doc.y);
   doc.moveTo(50, doc.y + 4).lineTo(545, doc.y + 4).strokeColor(GOLD).stroke();
   doc.moveDown(0.8);
 }
@@ -75,9 +113,10 @@ function totalsBlock(doc, totals, gstPercent, discount) {
 }
 
 // Quote PDF.
-function streamQuotePdf(res, { venue, enquiry, quote }) {
+async function streamQuotePdf(res, { venue, enquiry, quote }) {
+  const logoBuffer = await loadLogoBuffer(venue.logo); // resolve before piping starts
   const doc = startDoc(res, `quote-${quote.version || 1}.pdf`);
-  venueHeader(doc, venue, `Quotation  ·  v${quote.version || 1}`);
+  venueHeader(doc, venue, `Quotation  ·  v${quote.version || 1}`, logoBuffer);
   doc.fillColor(GREY).fontSize(10);
   doc.text(`For: ${(enquiry && (enquiry.coupleName || enquiry.name)) || "—"}`);
   if (enquiry && enquiry.couplePhone) doc.text(`Phone: ${enquiry.couplePhone}`);
@@ -90,9 +129,10 @@ function streamQuotePdf(res, { venue, enquiry, quote }) {
 }
 
 // Invoice PDF (GST format).
-function streamInvoicePdf(res, { venue, booking, invoice }) {
+async function streamInvoicePdf(res, { venue, booking, invoice }) {
+  const logoBuffer = await loadLogoBuffer(venue.logo); // resolve before piping starts
   const doc = startDoc(res, `${invoice.invoiceNumber}.pdf`);
-  venueHeader(doc, venue, `Tax Invoice  ·  ${invoice.invoiceNumber}`);
+  venueHeader(doc, venue, `Tax Invoice  ·  ${invoice.invoiceNumber}`, logoBuffer);
   doc.fillColor(GREY).fontSize(10);
   const taxLines = [];
   if (venue.gstin) taxLines.push(`GSTIN: ${venue.gstin}`);


### PR DESCRIPTION
Server half of the venue quality sweep: new `Venue.logo` field (listing-gated PUT whitelist) rendered top-left on quote/invoice PDFs with graceful degradation for missing/unreachable/malformed logos (data: URI or http(s), resolved before piping; e2e asserts the /XObject image object appears only when set); a fire-and-forget WhatsApp ops alert to `OPS_ALERT_PHONE` on new onboarding requests (no env var → no-op; `REMINDERS_LOG_ONLY` default → compose+log only; creds-gated send; the requester's 201 can never be affected — 4/4 gate checks, no network); plus `scripts/seed-bulk-rows.js` (local-Mongo-guarded volume fixtures) and seed determinism. Includes the OTP-bypass + analytics-fix commits as identical cherry-picks so the branch stands alone — they merge cleanly in any order with #38.

Deploy in coordinated window only. New env var: `OPS_ALERT_PHONE=916364014464` (alerts stay log-only until `REMINDERS_LOG_ONLY=false`). `Venue.logo` is additive — no migration.

Review-assist verdict: 7/7 PASS — only expected literals (the ops phone in the gate test); suites 91/91 e2e + 61/61 hardening + 4/4 alert checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)