### PR TITLE
feat(venue): Phase 4.2 reviews — owner display/monitor, 24h cache, public payload hardening

### DIFF
--- a/controllers/venue.js
+++ b/controllers/venue.js
@@ -56,6 +56,12 @@ const getVenueBySlug = async (req, res) => {
   try {
     const { slug } = req.params;
     const venue = withPolicyDoc(await VenueService.getVenueBySlug(slug));
+    // Public detail exposes the aggregate rating + count ONLY — individual
+    // Google review texts are an owner-dashboard surface, not a public API.
+    if (venue) {
+      delete venue.googleReviews;
+      delete venue.googleReviewsRefreshedAt;
+    }
     // Stable public verification flag. Derived from status today (same as the
     // dashboard); when Wedsy OS ships a real orthogonal boolean, only this
     // derivation changes — the `isVerified` API name stays, so the couple-side

--- a/controllers/venueOwnerReviews.js
+++ b/controllers/venueOwnerReviews.js
@@ -1,0 +1,60 @@
+/**
+ * controllers/venueOwnerReviews.js — Phase 4.2 owner-facing reviews.
+ * GET serves from the 24h venue-doc cache (fetching when stale); the manual
+ * refresh endpoint forces a fetch and is rate-limited at the router to
+ * respect the Places quota. DISPLAY + MONITOR + REQUEST only — replying to
+ * Google reviews needs the GBP API/OAuth (future, flagged in the UI).
+ */
+const Venue = require("../models/Venue");
+const { getVenueReviews } = require("../utils/venueGoogleReviews");
+
+async function resolveOwnedVenue(req, res) {
+  const venue = await Venue.findOne({ slug: req.params.slug })
+    .select("_id googlePlaceId googleRating googleReviewCount googleReviews googleReviewsRefreshedAt")
+    .lean();
+  if (!venue) { res.status(404).json({ message: "Venue not found" }); return null; }
+  if (String(venue._id) !== String(req.venueOwner.venueId)) { res.status(403).json({ message: "Forbidden" }); return null; }
+  return venue;
+}
+
+function shape(out, venue) {
+  return {
+    hasPlaceId: Boolean(venue.googlePlaceId),
+    rating: out.rating,
+    count: out.count,
+    reviews: out.reviews,
+    refreshedAt: out.refreshedAt,
+    cached: Boolean(out.cached),
+    skipped: out.skipped || undefined,
+  };
+}
+
+// GET /venues/:slug/reviews — venueOwnerAuth (open read; 24h cache).
+const getReviews = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const out = await getVenueReviews(venue, {
+      save: (setFields) => Venue.updateOne({ _id: venue._id }, { $set: setFields }),
+    });
+    return res.status(200).json(shape(out, venue));
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+// POST /venues/:slug/reviews/refresh — venueOwnerAuth + rate limit (router).
+const refreshOwnerReviews = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    if (!venue.googlePlaceId) {
+      return res.status(409).json({ message: "Set your Google Place first (My Listing → location)" });
+    }
+    const out = await getVenueReviews(venue, {
+      force: true,
+      save: (setFields) => Venue.updateOne({ _id: venue._id }, { $set: setFields }),
+    });
+    return res.status(200).json(shape(out, venue));
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+module.exports = { getReviews, refreshOwnerReviews };

--- a/controllers/venueOwnerReviews.js
+++ b/controllers/venueOwnerReviews.js
@@ -20,6 +20,8 @@ async function resolveOwnedVenue(req, res) {
 function shape(out, venue) {
   return {
     hasPlaceId: Boolean(venue.googlePlaceId),
+    // The owner's own place id — powers the "write a review" link in requests.
+    placeId: venue.googlePlaceId || null,
     rating: out.rating,
     count: out.count,
     reviews: out.reviews,

--- a/routes/venue.js
+++ b/routes/venue.js
@@ -21,7 +21,8 @@ const { listMembers, inviteMember, updateMember, getActivity } = require("../con
 const { createOnboardingRequest } = require("../controllers/venueOnboarding");
 const { venueOwnerAuth } = require("../middlewares/venueOwnerAuth");
 const { requireCapability, requireCapabilityOrAdmin } = require("../middlewares/venueRole");
-const { enquiryIpLimiter, enquiryPhoneLimiter, publicReadLimiter } = require("../utils/venueEnquiryRateLimit");
+const { enquiryIpLimiter, enquiryPhoneLimiter, publicReadLimiter, reviewsRefreshLimiter } = require("../utils/venueEnquiryRateLimit");
+const { getReviews, refreshOwnerReviews } = require("../controllers/venueOwnerReviews");
 const { adminOrVenueOwnerAuth } = require("../middlewares/adminOrVenueOwnerAuth");
 const { optionalAdminAuth } = require("../middlewares/optionalAdminAuth");
 const { CheckLogin, CheckAdminLogin } = require("../middlewares/auth");
@@ -91,6 +92,11 @@ router.post("/:slug/invoices/:invoiceId/payments", venueOwnerAuth, requireCapabi
 // ── Phase 3.4: payments summary + Phase 4.1: analytics — open reads ──
 router.get("/:slug/payments/summary", venueOwnerAuth, paymentsSummary);
 router.get("/:slug/analytics", venueOwnerAuth, getAnalytics);
+
+// ── Phase 4.2 reviews: owner-facing display/monitor (24h venue-doc cache);
+//    manual refresh is rate-limited to protect the Places quota ──
+router.get("/:slug/reviews", venueOwnerAuth, getReviews);
+router.post("/:slug/reviews/refresh", venueOwnerAuth, reviewsRefreshLimiter, refreshOwnerReviews);
 
 // Google Sheets integration — ALL routes require the "leads" capability (ruling),
 // since the sync brings leads in. callback is public — authorized by the signed

--- a/scripts/e2e-reviews-cache.js
+++ b/scripts/e2e-reviews-cache.js
@@ -1,0 +1,107 @@
+/**
+ * scripts/e2e-reviews-cache.js — deterministic checks for the Google-reviews
+ * cache seam (utils/venueGoogleReviews). No server, no DB, no network: the
+ * fetch is stubbed at the util's injection point, exactly how creds-blank
+ * automated runs stay offline.
+ *
+ * Usage: node scripts/e2e-reviews-cache.js
+ */
+let pass = 0;
+let fail = 0;
+function check(name, cond, detail) {
+  if (cond) {
+    pass++;
+    console.log(`✓ PASS  ${name}`);
+  } else {
+    fail++;
+    console.log(`✗ FAIL  ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+const GOOGLE_BODY = {
+  result: {
+    rating: 4.6,
+    user_ratings_total: 132,
+    reviews: [{ author_name: "Asha", rating: 5, text: "Beautiful venue!", time: 1700000000 }],
+  },
+};
+
+function stubFetch(calls) {
+  return async (url) => {
+    calls.push(url);
+    return { json: async () => GOOGLE_BODY };
+  };
+}
+
+async function run() {
+  const { getVenueReviews, fetchPlaceReviews } = require("../utils/venueGoogleReviews");
+
+  // 1. Fresh cache (refreshed 1h ago, 24h TTL) → served from the doc, NO fetch.
+  {
+    const calls = [];
+    const venue = {
+      googlePlaceId: "place-1",
+      googleRating: 4.4,
+      googleReviewCount: 120,
+      googleReviews: [{ authorName: "Cached", rating: 4, text: "old" }],
+      googleReviewsRefreshedAt: new Date(Date.now() - 60 * 60 * 1000),
+    };
+    const out = await getVenueReviews(venue, { fetchImpl: stubFetch(calls), key: "k" });
+    check("fresh cache -> cached:true, zero Google calls", out.cached === true && out.rating === 4.4 && calls.length === 0, JSON.stringify({ out, calls: calls.length }));
+  }
+
+  // 2. Stale cache (25h ago) → exactly one fetch, values updated, save() called.
+  {
+    const calls = [];
+    const saved = [];
+    const venue = {
+      googlePlaceId: "place-1",
+      googleRating: 4.4,
+      googleReviewsRefreshedAt: new Date(Date.now() - 25 * 60 * 60 * 1000),
+    };
+    const out = await getVenueReviews(venue, { fetchImpl: stubFetch(calls), key: "k", save: (f) => saved.push(f) });
+    check(
+      "stale cache -> one fetch, updated values persisted",
+      calls.length === 1 && out.rating === 4.6 && out.count === 132 && out.reviews.length === 1 && saved.length === 1 && saved[0].googleRating === 4.6,
+      JSON.stringify({ calls: calls.length, out: { rating: out.rating, count: out.count }, saved: saved.length })
+    );
+  }
+
+  // 3. force:true bypasses a fresh cache (manual refresh path).
+  {
+    const calls = [];
+    const venue = { googlePlaceId: "place-1", googleRating: 4.4, googleReviewsRefreshedAt: new Date() };
+    const out = await getVenueReviews(venue, { force: true, fetchImpl: stubFetch(calls), key: "k", save: () => {} });
+    check("force refresh bypasses TTL", calls.length === 1 && out.rating === 4.6, `calls=${calls.length}`);
+  }
+
+  // 4. No placeId → skipped, never fetches.
+  {
+    const calls = [];
+    const out = await getVenueReviews({ googlePlaceId: "" }, { fetchImpl: stubFetch(calls), key: "k" });
+    check("no placeId -> skipped, zero calls", out.skipped === "no placeId" && calls.length === 0, JSON.stringify(out));
+  }
+
+  // 5. Creds blank → skipped, never fetches (automated-run safety).
+  {
+    const calls = [];
+    const venue = { googlePlaceId: "place-1", googleReviewsRefreshedAt: new Date(Date.now() - 48 * 60 * 60 * 1000) };
+    const out = await getVenueReviews(venue, { fetchImpl: stubFetch(calls), key: "" });
+    check("blank key -> skipped, zero calls", /no GOOGLE/.test(out.skipped || "") && calls.length === 0, JSON.stringify({ out, calls: calls.length }));
+  }
+
+  // 6. fetchPlaceReviews caps stored reviews at 5.
+  {
+    const many = { result: { rating: 4, user_ratings_total: 9, reviews: Array.from({ length: 8 }, (_, i) => ({ author_name: `A${i}`, rating: 5, text: "x" })) } };
+    const out = await fetchPlaceReviews("p", { fetchImpl: async () => ({ json: async () => many }), key: "k" });
+    check("review list capped at 5", out.reviews.length === 5, `n=${out.reviews.length}`);
+  }
+
+  console.log(`\n[e2e-reviews-cache] ${pass} passed, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
+}
+
+run().catch((e) => {
+  console.error("fatal:", e);
+  process.exit(1);
+});

--- a/scripts/e2e-venue.js
+++ b/scripts/e2e-venue.js
@@ -519,6 +519,37 @@ async function run() {
     check("public-ratelimit: onboarding over-limit -> 429 (no record created)", onbOver.status === 429, `status ${onbOver.status}`);
   }
 
+  // ================= Phase 4.2: owner reviews (cache, rate limit, public payload) =================
+  if (process.env.E2E_REVIEWS === "1") {
+    // Seed gives test-palace a fresh deterministic cache -> served without Google.
+    const r1 = await api("GET", `/venues/${SLUG}/reviews`, { token });
+    check("reviews: owner GET serves the cached rating (no Google call)",
+      r1.status === 200 && r1.json.cached === true && r1.json.rating === 4.6 && r1.json.count === 132 && r1.json.reviews.length === 1,
+      `status ${r1.status} rating=${r1.json.rating} cached=${r1.json.cached}`);
+
+    // Manual refresh with creds blanked -> graceful skip (no live call), still 200.
+    const rf = await api("POST", `/venues/${SLUG}/reviews/refresh`, { token });
+    check("reviews: refresh with blank creds -> 200 skipped (cache intact)",
+      rf.status === 200 && rf.json.skipped && rf.json.rating === 4.6, `status ${rf.status} skipped=${rf.json.skipped}`);
+
+    // Refresh rate limit: burst past the limiter -> 429 present.
+    const burst = await Promise.all(Array.from({ length: 6 }, () => api("POST", `/venues/${SLUG}/reviews/refresh`, { token })));
+    check("reviews: refresh burst -> 429 rate limit", burst.some((r) => r.status === 429), `statuses ${[...new Set(burst.map((r) => r.status))].join(",")}`);
+
+    // Public detail: rating + count exposed, individual review texts ABSENT.
+    const pub = await api("GET", `/venues/${SLUG}`, {});
+    const v = pub.json.venue || {};
+    check("reviews: public detail exposes rating+count ONLY (no texts)",
+      pub.status === 200 && v.googleRating === 4.6 && v.googleReviewCount === 132 && v.googleReviews === undefined,
+      `rating=${v.googleRating} texts=${JSON.stringify(v.googleReviews)}`);
+
+    // Public browse list: same guarantee (select already excludes texts).
+    const list = await api("GET", `/venues?limit=3`, {});
+    const items = list.json.venues || list.json || [];
+    check("reviews: public list never includes review texts",
+      list.status === 200 && items.length > 0 && items.every((x) => x.googleReviews === undefined), `n=${items.length}`);
+  }
+
   finish();
 }
 

--- a/scripts/seed-test-venue.js
+++ b/scripts/seed-test-venue.js
@@ -111,6 +111,12 @@ async function run() {
     contact: { primaryName: "Test Owner", primaryPhone: OWNER_PHONE, whatsappPhone: OWNER_PHONE, email: "owner@test-palace.local" },
     pricing: { currency: "INR", perPlate: { veg: 1500, nonVeg: 1900 }, tiers: [{ hours: 12, price: 250000 }] },
     coverPhoto: "https://example.local/test-palace-cover.jpg",
+    // Phase 4.2: deterministic Google-rating fixtures (no live fetch in suites).
+    googlePlaceId: "test-place-id-palace",
+    googleRating: 4.6,
+    googleReviewCount: 132,
+    googleReviews: [{ authorName: "Asha", rating: 5, text: "Beautiful venue!", time: 1700000000 }],
+    googleReviewsRefreshedAt: new Date(),
   };
   if (!venue) {
     venue = await Venue.create(venueDefaults);

--- a/utils/venueEnquiryRateLimit.js
+++ b/utils/venueEnquiryRateLimit.js
@@ -68,4 +68,15 @@ const publicReadLimiter = rateLimit({
   message: { message: "Too many requests, please slow down." },
 });
 
-module.exports = { enquiryIpLimiter, enquiryPhoneLimiter, publicReadLimiter };
+// Owner-triggered Google reviews refresh — quota-guarding, deliberately tight.
+const REVIEWS_REFRESH_WINDOW_MS = num(process.env.VENUE_REVIEWS_REFRESH_WINDOW_MS, 60 * 60 * 1000); // 1h
+const REVIEWS_REFRESH_MAX = num(process.env.VENUE_REVIEWS_REFRESH_MAX, 4);
+const reviewsRefreshLimiter = rateLimit({
+  windowMs: REVIEWS_REFRESH_WINDOW_MS,
+  max: REVIEWS_REFRESH_MAX,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { message: "Reviews were refreshed recently — try again in a bit." },
+});
+
+module.exports = { enquiryIpLimiter, enquiryPhoneLimiter, publicReadLimiter, reviewsRefreshLimiter };

--- a/utils/venueGoogleReviews.js
+++ b/utils/venueGoogleReviews.js
@@ -1,0 +1,72 @@
+/**
+ * utils/venueGoogleReviews.js — owner-facing Google rating/reviews with the
+ * Venue doc as the cache (googleRating / googleReviewCount / googleReviews /
+ * googleReviewsRefreshedAt — the same fields the couple-side enrichment
+ * already maintains, so there is ONE source of truth, no parallel cache doc).
+ *
+ * The Google fetch is injectable (fetchImpl) so suites can stub the seam and
+ * creds-blank automated runs never call out: no GOOGLE_PLACES_API_KEY or no
+ * placeId → { skipped }.
+ */
+const OWNER_TTL_MS = 24 * 60 * 60 * 1000; // 24h owner-surface cache
+
+async function fetchPlaceReviews(placeId, { fetchImpl = fetch, key = process.env.GOOGLE_PLACES_API_KEY } = {}) {
+  if (!placeId) return { skipped: "no placeId" };
+  if (!key) return { skipped: "no GOOGLE_PLACES_API_KEY" };
+  const url = `https://maps.googleapis.com/maps/api/place/details/json?place_id=${encodeURIComponent(placeId)}&fields=reviews,rating,user_ratings_total&key=${key}`;
+  const resp = await fetchImpl(url);
+  const data = await resp.json();
+  const result = (data && data.result) || {};
+  return {
+    rating: typeof result.rating === "number" ? result.rating : null,
+    count: typeof result.user_ratings_total === "number" ? result.user_ratings_total : null,
+    reviews: (result.reviews || []).slice(0, 5).map((r) => ({
+      authorName: r.author_name,
+      rating: r.rating,
+      text: r.text,
+      time: r.time,
+      profilePhotoUrl: r.profile_photo_url,
+    })),
+  };
+}
+
+/**
+ * Cached-or-fetch against the venue doc. `venue` must carry googlePlaceId and
+ * the cache fields; `save(setFields)` persists (injectable for tests).
+ * Returns { rating, count, reviews, refreshedAt, cached?, skipped? }.
+ */
+async function getVenueReviews(venue, { force = false, ttlMs = OWNER_TTL_MS, fetchImpl, key, save } = {}) {
+  const fromDoc = () => ({
+    rating: venue.googleRating ?? null,
+    count: venue.googleReviewCount ?? null,
+    reviews: venue.googleReviews || [],
+    refreshedAt: venue.googleReviewsRefreshedAt || null,
+  });
+
+  if (!venue.googlePlaceId) return { ...fromDoc(), skipped: "no placeId" };
+
+  const fresh =
+    venue.googleReviewsRefreshedAt &&
+    Date.now() - new Date(venue.googleReviewsRefreshedAt).getTime() < ttlMs;
+  if (fresh && !force) return { ...fromDoc(), cached: true };
+
+  const fetched = await fetchPlaceReviews(venue.googlePlaceId, { fetchImpl, key });
+  if (fetched.skipped) return { ...fromDoc(), skipped: fetched.skipped };
+
+  const setFields = {
+    googleReviews: fetched.reviews,
+    googleReviewsRefreshedAt: new Date(),
+  };
+  if (typeof fetched.rating === "number") setFields.googleRating = fetched.rating;
+  if (typeof fetched.count === "number") setFields.googleReviewCount = fetched.count;
+  if (typeof save === "function") await save(setFields);
+
+  return {
+    rating: setFields.googleRating ?? venue.googleRating ?? null,
+    count: setFields.googleReviewCount ?? venue.googleReviewCount ?? null,
+    reviews: fetched.reviews,
+    refreshedAt: setFields.googleReviewsRefreshedAt,
+  };
+}
+
+module.exports = { fetchPlaceReviews, getVenueReviews, OWNER_TTL_MS };


### PR DESCRIPTION
Owner-facing Google reviews, display + monitor + request only (dashboard replies need the GBP API/OAuth — flagged as future): `GET /venues/:slug/reviews` serves from the venue doc's existing enrichment fields as a 24h cache (one source of truth — the spec's separate VenueReviewsCache doc was deliberately not added, reported as an adaptation), with a force-refresh endpoint behind a dedicated limiter (4/hr default, env-tunable) to protect the Places quota. The fetch seam is injectable and creds-blank safe (no key/placeId → skipped, zero network — proven by scripts/e2e-reviews-cache.js, 6/6 with a stubbed fetch). Public API hardening included: the venue detail no longer exposes individual Google review texts — rating + count only (the browse list already excluded them; wedsy-user consumes only rating/count, verified by SSR smoke).

Deploy in coordinated window only. Optional env tuning: VENUE_REVIEWS_REFRESH_MAX / _WINDOW_MS.

Review-assist verdict: 7/7 PASS — both new routes venueOwnerAuth (+limiter on refresh); suites 91/91 e2e + 61/61 hardening + 6/6 cache-seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)