### PR TITLE
feat(venue): Phase 3.5 contracts — policyDoc-seeded clauses + public digital acknowledgment

### DIFF
--- a/controllers/venueAllotment.js
+++ b/controllers/venueAllotment.js
@@ -253,6 +253,10 @@ const occupancy = async (req, res) => {
           status: a.status,
           checkInAt: a.checkInAt,
           checkOutAt: a.checkOutAt,
+          // Actuals let the client clip an early-departure stay to the real
+          // occupied range instead of the planned one.
+          actualCheckInAt: a.actualCheckInAt || null,
+          actualCheckOutAt: a.actualCheckOutAt || null,
         })),
     }));
 

--- a/controllers/venueAllotment.js
+++ b/controllers/venueAllotment.js
@@ -1,0 +1,263 @@
+/**
+ * controllers/venueAllotment.js — Phase 5 (PMS) room allotment lifecycle +
+ * occupancy matrix.
+ *
+ * Double-booking guard: every active allotment owns one VenueRoomNight doc per
+ * occupied night, protected by a UNIQUE (room, night) index. Creation inserts
+ * the night docs FIRST; a duplicate-key failure means another allotment holds
+ * (part of) the range, the partial insert is rolled back and the request 409s.
+ * This is atomic under concurrency on a standalone Mongo — exactly one of N
+ * simultaneous identical requests wins.
+ */
+const Venue = require("../models/Venue");
+const VenueBooking = require("../models/VenueBooking");
+const VenueRoomAllotment = require("../models/VenueRoomAllotment");
+const VenueRoomNight = require("../models/VenueRoomNight");
+const { reqStr, optStr, optDate } = require("../utils/venueInput");
+
+async function resolveOwnedVenue(req, res, select = "_id rooms") {
+  const venue = await Venue.findOne({ slug: req.params.slug }).select(select).lean();
+  if (!venue) { res.status(404).json({ message: "Venue not found" }); return null; }
+  if (String(venue._id) !== String(req.venueOwner.venueId)) { res.status(403).json({ message: "Forbidden" }); return null; }
+  return venue;
+}
+
+// Midnight-UTC night keys for [checkInAt, checkOutAt): one per calendar night,
+// minimum one (day-use). checkOut is the departure moment, so its own day is
+// not occupied unless the stay is within a single day.
+function nightKeys(checkInAt, checkOutAt) {
+  const startDay = Date.UTC(checkInAt.getUTCFullYear(), checkInAt.getUTCMonth(), checkInAt.getUTCDate());
+  const endDay = Date.UTC(checkOutAt.getUTCFullYear(), checkOutAt.getUTCMonth(), checkOutAt.getUTCDate());
+  const nights = [];
+  for (let t = startDay; t < endDay; t += 86400000) nights.push(new Date(t));
+  if (nights.length === 0) nights.push(new Date(startDay));
+  return nights;
+}
+
+function validateAllotmentInput(body) {
+  const guestV = reqStr(body.guestName, "guestName", 200);
+  if (!guestV.ok) return { error: guestV.message };
+  const phoneV = optStr(body.guestPhone, "guestPhone", 30);
+  if (!phoneV.ok) return { error: phoneV.message };
+  const notesV = optStr(body.notes, "notes", 2000);
+  if (!notesV.ok) return { error: notesV.message };
+  const inV = optDate(body.checkInAt, "checkInAt");
+  if (!inV.ok) return { error: inV.message };
+  const outV = optDate(body.checkOutAt, "checkOutAt");
+  if (!outV.ok) return { error: outV.message };
+  if (!inV.value || !outV.value) return { error: "checkInAt and checkOutAt are required" };
+  if (outV.value <= inV.value) return { error: "checkOutAt must be after checkInAt" };
+  if (!body.room) return { error: "room is required" };
+  return {
+    value: {
+      room: String(body.room),
+      guestName: guestV.value,
+      guestPhone: phoneV.value,
+      notes: notesV.value,
+      checkInAt: inV.value,
+      checkOutAt: outV.value,
+    },
+  };
+}
+
+/**
+ * Atomically claim the nights and create one allotment.
+ * Returns { allotment } or { conflict } or { error }.
+ */
+async function createOneAllotment(venue, bookingId, input, ownerId) {
+  const room = (venue.rooms || []).find((r) => String(r._id) === input.room);
+  if (!room) return { error: "Room not found on this venue" };
+  if (room.isActive === false) return { error: `Room "${room.name}" is inactive` };
+
+  const allotment = new VenueRoomAllotment({
+    venue: venue._id,
+    booking: bookingId,
+    room: room._id,
+    guestName: input.guestName,
+    guestPhone: input.guestPhone,
+    notes: input.notes,
+    checkInAt: input.checkInAt,
+    checkOutAt: input.checkOutAt,
+    status: "allotted",
+    createdBy: ownerId,
+  });
+
+  const nights = nightKeys(input.checkInAt, input.checkOutAt).map((night) => ({
+    venue: venue._id,
+    room: room._id,
+    night,
+    allotment: allotment._id,
+  }));
+
+  try {
+    // ordered:true → stops at the first duplicate; successfully inserted docs
+    // before it are rolled back below.
+    await VenueRoomNight.insertMany(nights, { ordered: true });
+  } catch (e) {
+    await VenueRoomNight.deleteMany({ allotment: allotment._id });
+    if (e.code === 11000) {
+      return { conflict: `Room "${room.name}" is already allotted for (part of) ${input.checkInAt.toISOString().slice(0, 10)} → ${input.checkOutAt.toISOString().slice(0, 10)}` };
+    }
+    throw e;
+  }
+
+  try {
+    await allotment.save();
+  } catch (e) {
+    await VenueRoomNight.deleteMany({ allotment: allotment._id });
+    throw e;
+  }
+  return { allotment };
+}
+
+// POST /venues/:slug/bookings/:bookingId/allotments — leads capability.
+// Body: a single allotment object, or { allotments: [...] } for bulk.
+const createAllotments = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const booking = await VenueBooking.findOne({ _id: req.params.bookingId, venue: venue._id }).select("_id").lean();
+    if (!booking) return res.status(404).json({ message: "Booking not found" });
+
+    const raw = req.body || {};
+    const inputs = Array.isArray(raw.allotments) ? raw.allotments : [raw];
+    if (inputs.length === 0 || inputs.length > 50) {
+      return res.status(400).json({ message: "1–50 allotments per request" });
+    }
+
+    const created = [];
+    const conflicts = [];
+    for (const item of inputs) {
+      const v = validateAllotmentInput(item || {});
+      if (v.error) {
+        // Validation failure fails the whole request — nothing partial saved.
+        for (const a of created) {
+          await VenueRoomNight.deleteMany({ allotment: a._id });
+          await VenueRoomAllotment.deleteOne({ _id: a._id });
+        }
+        return res.status(400).json({ message: v.error });
+      }
+      const result = await createOneAllotment(venue, booking._id, v.value, req.venueOwner.venueOwnerId);
+      if (result.error) {
+        for (const a of created) {
+          await VenueRoomNight.deleteMany({ allotment: a._id });
+          await VenueRoomAllotment.deleteOne({ _id: a._id });
+        }
+        return res.status(400).json({ message: result.error });
+      }
+      if (result.conflict) conflicts.push(result.conflict);
+      else created.push(result.allotment);
+    }
+
+    if (created.length === 0 && conflicts.length > 0) {
+      return res.status(409).json({ message: conflicts[0], conflicts });
+    }
+    return res.status(201).json({ allotments: created, conflicts });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+// GET /venues/:slug/bookings/:bookingId/allotments — open read.
+const listAllotments = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const allotments = await VenueRoomAllotment.find({ venue: venue._id, booking: req.params.bookingId })
+      .sort({ checkInAt: 1 })
+      .lean();
+    const roomsById = Object.fromEntries((venue.rooms || []).map((r) => [String(r._id), r]));
+    for (const a of allotments) a.roomDetail = roomsById[String(a.room)] || null;
+    return res.status(200).json({ allotments });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+// PATCH /venues/:slug/allotments/:allotmentId — leads capability.
+// Body: { action: "check_in" | "check_out" | "cancel" } and/or { notes }.
+const updateAllotment = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res, "_id");
+    if (!venue) return;
+    const allotment = await VenueRoomAllotment.findOne({ _id: req.params.allotmentId, venue: venue._id });
+    if (!allotment) return res.status(404).json({ message: "Allotment not found" });
+
+    const { action } = req.body || {};
+    if (req.body && req.body.notes !== undefined) {
+      const v = optStr(req.body.notes, "notes", 2000);
+      if (!v.ok) return res.status(400).json({ message: v.message });
+      allotment.notes = v.value;
+    }
+
+    if (action === "check_in") {
+      if (allotment.status !== "allotted") return res.status(409).json({ message: `Cannot check in from status "${allotment.status}"` });
+      allotment.status = "checked_in";
+      allotment.actualCheckInAt = new Date();
+    } else if (action === "check_out") {
+      if (allotment.status !== "checked_in") return res.status(409).json({ message: `Cannot check out from status "${allotment.status}"` });
+      allotment.status = "checked_out";
+      allotment.actualCheckOutAt = new Date();
+      // Early departure frees nights strictly after the actual check-out day.
+      const out = allotment.actualCheckOutAt;
+      const dayAfter = new Date(Date.UTC(out.getUTCFullYear(), out.getUTCMonth(), out.getUTCDate()) + 86400000);
+      await VenueRoomNight.deleteMany({ allotment: allotment._id, night: { $gte: dayAfter } });
+    } else if (action === "cancel") {
+      if (allotment.status === "checked_out") return res.status(409).json({ message: "Cannot cancel a completed stay" });
+      allotment.status = "cancelled";
+      await VenueRoomNight.deleteMany({ allotment: allotment._id });
+    } else if (action !== undefined) {
+      return res.status(400).json({ message: "action must be check_in, check_out or cancel" });
+    }
+
+    await allotment.save();
+    return res.status(200).json({ allotment });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+// GET /venues/:slug/occupancy?from&to — open read. Rooms × days matrix.
+const occupancy = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const fromV = optDate(req.query.from, "from");
+    const toV = optDate(req.query.to, "to");
+    if (!fromV.ok) return res.status(400).json({ message: fromV.message });
+    if (!toV.ok) return res.status(400).json({ message: toV.message });
+    const now = new Date();
+    const from = fromV.value || new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+    const to = toV.value || new Date(from.getTime() + 14 * 86400000);
+    if (to <= from) return res.status(400).json({ message: "to must be after from" });
+    if (to - from > 92 * 86400000) return res.status(400).json({ message: "range too large (max 92 days)" });
+
+    const allotments = await VenueRoomAllotment.find({
+      venue: venue._id,
+      status: { $in: ["allotted", "checked_in", "checked_out"] },
+      checkInAt: { $lt: to },
+      checkOutAt: { $gt: from },
+    })
+      .populate("booking", "coupleName status")
+      .lean();
+
+    const days = [];
+    for (let t = Date.UTC(from.getUTCFullYear(), from.getUTCMonth(), from.getUTCDate()); t < to.getTime(); t += 86400000) {
+      days.push(new Date(t).toISOString().slice(0, 10));
+    }
+    const rooms = (venue.rooms || []).filter((r) => r.isActive !== false).map((r) => ({
+      _id: r._id,
+      name: r.name,
+      type: r.type,
+      capacity: r.capacity,
+      allotments: allotments
+        .filter((a) => String(a.room) === String(r._id))
+        .map((a) => ({
+          _id: a._id,
+          booking: a.booking,
+          guestName: a.guestName,
+          status: a.status,
+          checkInAt: a.checkInAt,
+          checkOutAt: a.checkOutAt,
+        })),
+    }));
+
+    return res.status(200).json({ from, to, days, rooms });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+module.exports = { createAllotments, listAllotments, updateAllotment, occupancy };

--- a/controllers/venueAnalytics.js
+++ b/controllers/venueAnalytics.js
@@ -52,6 +52,12 @@ const getAnalytics = async (req, res) => {
     const { from, to } = req.query;
     const fromDate = from ? new Date(from) : null;
     const toDate = to ? new Date(to) : null;
+    // A date-only "to" (YYYY-MM-DD) parses to midnight UTC, which silently
+    // excludes everything created later that same day — i.e. today's leads
+    // never appear in any bounded range. Make it inclusive end-of-day.
+    if (toDate && !isNaN(toDate) && /^\d{4}-\d{2}-\d{2}$/.test(String(to))) {
+      toDate.setUTCHours(23, 59, 59, 999);
+    }
     const dateFilter = {};
     if (fromDate && !isNaN(fromDate)) dateFilter.$gte = fromDate;
     if (toDate && !isNaN(toDate)) dateFilter.$lte = toDate;

--- a/controllers/venueBooking.js
+++ b/controllers/venueBooking.js
@@ -6,6 +6,7 @@
  */
 const Venue = require("../models/Venue");
 const VenueBooking = require("../models/VenueBooking");
+const { seedRunsheetForBooking } = require("../utils/venueRunsheet");
 
 async function resolveOwnedVenue(req, res) {
   const venue = await Venue.findOne({ slug: req.params.slug }).select("_id").lean();
@@ -22,7 +23,7 @@ async function createDraftBookingForEnquiry(venueId, enquiry, ownerId) {
   const existing = await VenueBooking.findOne({ enquiry: enquiry._id });
   if (existing) return existing;
   try {
-    return await VenueBooking.create({
+    const booking = await VenueBooking.create({
       venue: venueId,
       enquiry: enquiry._id,
       coupleName: enquiry.coupleName || enquiry.name || "",
@@ -32,6 +33,8 @@ async function createDraftBookingForEnquiry(venueId, enquiry, ownerId) {
       status: "confirmed",
       createdBy: ownerId,
     });
+    await seedRunsheetForBooking(booking); // default event-day skeleton per day
+    return booking;
   } catch (e) {
     // Concurrent create lost the race on the unique index — return the winner.
     if (e.code === 11000) return VenueBooking.findOne({ enquiry: enquiry._id });
@@ -75,6 +78,7 @@ const createBooking = async (req, res) => {
       status: status || "confirmed",
       createdBy: req.venueOwner.venueOwnerId,
     });
+    await seedRunsheetForBooking(booking); // default event-day skeleton per day
     return res.status(201).json({ booking });
   } catch (err) {
     if (err.code === 11000) return res.status(409).json({ message: "A booking already exists for this enquiry" });
@@ -93,6 +97,8 @@ const updateBooking = async (req, res) => {
       if (req.body[k] !== undefined) booking[k] = req.body[k];
     }
     await booking.save();
+    // Newly added days get the default runsheet skeleton (no-op for existing).
+    if (req.body.days !== undefined) await seedRunsheetForBooking(booking);
     return res.status(200).json({ booking });
   } catch (err) { return res.status(500).json({ message: err.message }); }
 };

--- a/controllers/venueContract.js
+++ b/controllers/venueContract.js
@@ -1,0 +1,254 @@
+/**
+ * controllers/venueContract.js — Phase 3.5 contracts.
+ *
+ * Lifecycle: generate (draft, seeded from venue.policyDoc + frozen booking
+ * specifics) → edit while draft → send (signed short-lived public ack token)
+ * → digital acknowledgment by the couple (name + phone matched against the
+ * booking) → acknowledged. Generating a new version voids prior
+ * non-acknowledged versions.
+ *
+ * The public ack route is token-addressed (no auth) and rate-limited at the
+ * router; it never reveals more than the contract being acknowledged.
+ */
+const jwt = require("jsonwebtoken");
+const Venue = require("../models/Venue");
+const VenueBooking = require("../models/VenueBooking");
+const VenueContract = require("../models/VenueContract");
+const { reqStr, optStr } = require("../utils/venueInput");
+
+const ACK_TTL_HOURS = Number(process.env.CONTRACT_ACK_TTL_HOURS) > 0 ? Number(process.env.CONTRACT_ACK_TTL_HOURS) : 168; // 7 days
+
+async function resolveOwnedVenue(req, res, select = "_id name policies policyDoc") {
+  const venue = await Venue.findOne({ slug: req.params.slug }).select(select).lean();
+  if (!venue) { res.status(404).json({ message: "Venue not found" }); return null; }
+  if (String(venue._id) !== String(req.venueOwner.venueId)) { res.status(403).json({ message: "Forbidden" }); return null; }
+  return venue;
+}
+
+// Same read-time migration rules as controllers/venue.js withPolicyDoc.
+function effectivePolicyDoc(venue) {
+  const pd = venue.policyDoc || {};
+  const has = (a) => Array.isArray(a) && a.length > 0;
+  if (has(pd.policies) || has(pd.terms) || has(pd.refund)) {
+    return { policies: pd.policies || [], terms: pd.terms || [], refund: pd.refund || [] };
+  }
+  const legacy = venue.policies || {};
+  const clean = (...vals) => vals.map((s) => (s == null ? "" : String(s).trim())).filter(Boolean);
+  return {
+    policies: clean(legacy.otherRestrictions),
+    terms: [],
+    refund: clean(legacy.cancellation, legacy.refund),
+  };
+}
+
+function seedSections(venue) {
+  const pd = effectivePolicyDoc(venue);
+  return [
+    { heading: "Venue Policies", clauses: pd.policies },
+    { heading: "Terms & Conditions", clauses: pd.terms },
+    { heading: "Cancellation & Refund Policy", clauses: pd.refund },
+  ].filter((s) => s.clauses.length > 0);
+}
+
+function validateSections(input) {
+  if (!Array.isArray(input)) return { error: "sections must be an array" };
+  if (input.length > 20) return { error: "too many sections (max 20)" };
+  const out = [];
+  for (const s of input) {
+    const headV = reqStr(s && s.heading, "section heading", 200);
+    if (!headV.ok) return { error: headV.message };
+    const clauses = Array.isArray(s.clauses) ? s.clauses : [];
+    if (clauses.length > 100) return { error: "too many clauses in a section (max 100)" };
+    const cleaned = clauses.map((c) => String(c == null ? "" : c).trim().slice(0, 2000)).filter(Boolean);
+    out.push({ heading: headV.value, clauses: cleaned });
+  }
+  return { value: out };
+}
+
+// POST /venues/:slug/bookings/:bookingId/contracts — leads capability.
+// Generates the next version; prior non-acknowledged versions become void.
+const generateContract = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const booking = await VenueBooking.findOne({ _id: req.params.bookingId, venue: venue._id }).lean();
+    if (!booking) return res.status(404).json({ message: "Booking not found" });
+
+    const prior = await VenueContract.find({ venue: venue._id, booking: booking._id }).sort({ version: -1 }).lean();
+    if (prior.some((c) => c.status === "acknowledged")) {
+      // An acknowledged contract stays the source of truth; new versions are
+      // still allowed (renegotiation) but the old one is never voided.
+    }
+    const version = prior.length ? (prior[0].version || 1) + 1 : 1;
+
+    const contract = await VenueContract.create({
+      venue: venue._id,
+      booking: booking._id,
+      version,
+      sections: seedSections(venue),
+      parties: {
+        venueName: venue.name || "",
+        coupleName: booking.coupleName || "",
+        couplePhone: booking.couplePhone || "",
+      },
+      specifics: {
+        days: (booking.days || []).map((d) => ({ date: d.date, eventType: d.eventType || "", guestCount: d.guestCount || 0 })),
+        totalValue: Number(booking.totalValue) || 0,
+        paymentSchedule: (booking.paymentSchedule || []).map((m) => ({ label: m.label || "", dueDate: m.dueDate, amount: Number(m.amount) || 0 })),
+      },
+      status: "draft",
+    });
+
+    await VenueContract.updateMany(
+      { venue: venue._id, booking: booking._id, _id: { $ne: contract._id }, status: { $in: ["draft", "sent"] } },
+      { $set: { status: "void" } }
+    );
+
+    return res.status(201).json({ contract });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+// GET /venues/:slug/bookings/:bookingId/contracts — open read.
+const listContracts = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res, "_id");
+    if (!venue) return;
+    const contracts = await VenueContract.find({ venue: venue._id, booking: req.params.bookingId })
+      .sort({ version: -1 })
+      .lean();
+    return res.status(200).json({ contracts });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+// PATCH /venues/:slug/contracts/:contractId — leads capability, draft only.
+const updateContract = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res, "_id");
+    if (!venue) return;
+    const contract = await VenueContract.findOne({ _id: req.params.contractId, venue: venue._id });
+    if (!contract) return res.status(404).json({ message: "Contract not found" });
+    if (contract.status !== "draft") return res.status(409).json({ message: `Only drafts can be edited (status: ${contract.status})` });
+    if (req.body && req.body.sections !== undefined) {
+      const v = validateSections(req.body.sections);
+      if (v.error) return res.status(400).json({ message: v.error });
+      contract.sections = v.value;
+    }
+    await contract.save();
+    return res.status(200).json({ contract });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+// POST /venues/:slug/contracts/:contractId/send — leads capability.
+// draft|sent → sent (re-send regenerates the token); returns the public ack path.
+const sendContract = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res, "_id");
+    if (!venue) return;
+    const contract = await VenueContract.findOne({ _id: req.params.contractId, venue: venue._id });
+    if (!contract) return res.status(404).json({ message: "Contract not found" });
+    if (!["draft", "sent"].includes(contract.status)) {
+      return res.status(409).json({ message: `Cannot send from status "${contract.status}"` });
+    }
+    if (contract.status === "draft") {
+      contract.status = "sent";
+      contract.sentAt = new Date();
+      await contract.save();
+    }
+    const token = jwt.sign(
+      { type: "venue_contract_ack", contractId: String(contract._id) },
+      process.env.JWT_SECRET,
+      { expiresIn: `${ACK_TTL_HOURS}h` }
+    );
+    return res.status(200).json({ contract, ackToken: token, ackPath: `/ack?token=${token}` });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+function verifyAckToken(token) {
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET);
+    if (!payload || payload.type !== "venue_contract_ack" || !payload.contractId) return null;
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
+const last10 = (p) => String(p || "").replace(/\D/g, "").slice(-10);
+
+// GET /venues/contract-ack/:token — PUBLIC (rate-limited at the router).
+const getAckContract = async (req, res) => {
+  try {
+    const payload = verifyAckToken(req.params.token);
+    if (!payload) return res.status(401).json({ message: "This link is invalid or has expired" });
+    const contract = await VenueContract.findById(payload.contractId)
+      .select("sections parties specifics status version sentAt acknowledgedAt acknowledgmentName")
+      .lean();
+    if (!contract) return res.status(404).json({ message: "Contract not found" });
+    if (!["sent", "acknowledged"].includes(contract.status)) {
+      return res.status(409).json({ message: "This contract is no longer open for acknowledgment" });
+    }
+    // Mask the phone — the public page never reveals it.
+    const masked = contract.parties && contract.parties.couplePhone
+      ? contract.parties.couplePhone.replace(/\d(?=\d{3})/g, "•")
+      : "";
+    return res.status(200).json({
+      contract: { ...contract, parties: { ...contract.parties, couplePhone: masked } },
+    });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+// POST /venues/contract-ack/:token — PUBLIC (rate-limited at the router).
+// Body: { name, phone } — phone must match the booking couple's phone.
+const acknowledgeContract = async (req, res) => {
+  try {
+    const payload = verifyAckToken(req.params.token);
+    if (!payload) return res.status(401).json({ message: "This link is invalid or has expired" });
+    const contract = await VenueContract.findById(payload.contractId);
+    if (!contract) return res.status(404).json({ message: "Contract not found" });
+    if (contract.status === "acknowledged") {
+      return res.status(409).json({ message: "This contract has already been acknowledged" });
+    }
+    if (contract.status !== "sent") {
+      return res.status(409).json({ message: "This contract is no longer open for acknowledgment" });
+    }
+
+    const nameV = reqStr((req.body || {}).name, "name", 200);
+    if (!nameV.ok) return res.status(400).json({ message: nameV.message });
+    const phoneV = optStr((req.body || {}).phone, "phone", 30);
+    if (!phoneV.ok) return res.status(400).json({ message: phoneV.message });
+    const given = last10(phoneV.value);
+    const expected = last10(contract.parties && contract.parties.couplePhone);
+    if (!given || given.length < 10) return res.status(400).json({ message: "A valid phone number is required" });
+    if (!expected) return res.status(409).json({ message: "This booking has no phone on record — contact the venue" });
+    if (given !== expected) return res.status(403).json({ message: "The phone number does not match this booking" });
+
+    contract.status = "acknowledged";
+    contract.acknowledgedAt = new Date();
+    contract.acknowledgmentName = nameV.value;
+    contract.acknowledgmentPhone = phoneV.value;
+    await contract.save();
+    return res.status(200).json({ success: true, acknowledgedAt: contract.acknowledgedAt });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+// GET /venues/:slug/contracts/:contractId/pdf — open read.
+const contractPdf = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res, "_id name address formattedAddress contact phone email");
+    if (!venue) return;
+    const contract = await VenueContract.findOne({ _id: req.params.contractId, venue: venue._id }).lean();
+    if (!contract) return res.status(404).json({ message: "Contract not found" });
+    const { streamContractPdf } = require("../utils/venuePdf");
+    streamContractPdf(res, { venue, contract });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+module.exports = {
+  generateContract,
+  listContracts,
+  updateContract,
+  sendContract,
+  contractPdf,
+  getAckContract,
+  acknowledgeContract,
+};

--- a/controllers/venueDashboard.js
+++ b/controllers/venueDashboard.js
@@ -3,6 +3,8 @@ const VenueOwner = require("../models/VenueOwner");
 const VenueEnquiry = require("../models/VenueEnquiry");
 const VenueBooking = require("../models/VenueBooking");
 const VenueInvoice = require("../models/VenueInvoice");
+const VenueRoomAllotment = require("../models/VenueRoomAllotment");
+const VenueRunsheetItem = require("../models/VenueRunsheetItem");
 
 // Stages that no longer need follow-up.
 const TERMINAL_STAGES = ["booked", "lost"];
@@ -91,11 +93,34 @@ const getDashboardOverview = async (req, res) => {
     );
     const revenue = { confirmedValue, received, pending: confirmedValue - received };
 
+    // ── Today (Phase 5 PMS): expected check-ins/outs + runsheet items due ──
+    // UTC day window to match the allotment/runsheet day quantisation.
+    const utcDayStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+    const utcDayEnd = new Date(utcDayStart.getTime() + 86400000);
+    const [checkInsToday, checkOutsToday, runsheetDueToday] = await Promise.all([
+      VenueRoomAllotment.countDocuments({
+        venue: venueId,
+        status: "allotted",
+        checkInAt: { $gte: utcDayStart, $lt: utcDayEnd },
+      }),
+      VenueRoomAllotment.countDocuments({
+        venue: venueId,
+        status: "checked_in",
+        checkOutAt: { $gte: utcDayStart, $lt: utcDayEnd },
+      }),
+      VenueRunsheetItem.countDocuments({
+        venue: venueId,
+        day: utcDayStart,
+        status: { $ne: "done" },
+      }),
+    ]);
+
     return res.status(200).json({
       onboarding: { steps, completed, total, percent },
       isVerified,
       followUps: { dueToday, overdue },
       revenue,
+      today: { checkIns: checkInsToday, checkOuts: checkOutsToday, runsheetDue: runsheetDueToday },
     });
   } catch (err) {
     return res.status(500).json({ message: err.message });

--- a/controllers/venueRooms.js
+++ b/controllers/venueRooms.js
@@ -1,0 +1,102 @@
+/**
+ * controllers/venueRooms.js — Phase 5 (PMS) rooms inventory CRUD.
+ * Lives on Venue.rooms[] (venue-owned subdocs). Writes are listing-gated at
+ * the route; reads are open to any authenticated venue identity.
+ */
+const Venue = require("../models/Venue");
+const VenueRoomAllotment = require("../models/VenueRoomAllotment");
+const { reqStr, optStr, optCount } = require("../utils/venueInput");
+
+const ROOM_TYPES = ["standard", "deluxe", "suite", "dorm", "other"];
+
+async function resolveOwnedVenue(req, res, select = "_id rooms") {
+  const venue = await Venue.findOne({ slug: req.params.slug }).select(select);
+  if (!venue) { res.status(404).json({ message: "Venue not found" }); return null; }
+  if (String(venue._id) !== String(req.venueOwner.venueId)) { res.status(403).json({ message: "Forbidden" }); return null; }
+  return venue;
+}
+
+function validateRoomInput(body, { partial = false } = {}) {
+  const out = {};
+  if (!partial || body.name !== undefined) {
+    const v = reqStr(body.name, "name", 200);
+    if (!v.ok) return { error: v.message };
+    out.name = v.value;
+  }
+  if (body.type !== undefined) {
+    if (!ROOM_TYPES.includes(body.type)) return { error: `type must be one of: ${ROOM_TYPES.join(", ")}` };
+    out.type = body.type;
+  }
+  if (body.capacity !== undefined) {
+    const v = optCount(body.capacity, "capacity", { max: 1000 });
+    if (!v.ok) return { error: v.message };
+    if (v.value !== undefined) out.capacity = v.value;
+  }
+  if (body.notes !== undefined) {
+    const v = optStr(body.notes, "notes", 2000);
+    if (!v.ok) return { error: v.message };
+    out.notes = v.value;
+  }
+  if (body.isActive !== undefined) out.isActive = Boolean(body.isActive);
+  return { value: out };
+}
+
+// GET /venues/:slug/rooms — open read (all roles).
+const listRooms = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    return res.status(200).json({ rooms: venue.rooms || [] });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+// POST /venues/:slug/rooms — listing capability.
+const addRoom = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const v = validateRoomInput(req.body || {});
+    if (v.error) return res.status(400).json({ message: v.error });
+    venue.rooms.push(v.value);
+    await venue.save();
+    return res.status(201).json({ room: venue.rooms[venue.rooms.length - 1], rooms: venue.rooms });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+// PATCH /venues/:slug/rooms/:roomId — listing capability.
+const updateRoom = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const room = venue.rooms.id(req.params.roomId);
+    if (!room) return res.status(404).json({ message: "Room not found" });
+    const v = validateRoomInput(req.body || {}, { partial: true });
+    if (v.error) return res.status(400).json({ message: v.error });
+    Object.assign(room, v.value);
+    await venue.save();
+    return res.status(200).json({ room, rooms: venue.rooms });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+// DELETE /venues/:slug/rooms/:roomId — listing capability.
+// Rooms with allotment history are deactivated (the history must stay
+// resolvable); never-used rooms are removed outright.
+const deleteRoom = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const room = venue.rooms.id(req.params.roomId);
+    if (!room) return res.status(404).json({ message: "Room not found" });
+    const used = await VenueRoomAllotment.exists({ venue: venue._id, room: room._id });
+    if (used) {
+      room.isActive = false;
+      await venue.save();
+      return res.status(200).json({ deactivated: true, rooms: venue.rooms });
+    }
+    room.deleteOne();
+    await venue.save();
+    return res.status(200).json({ deleted: true, rooms: venue.rooms });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+module.exports = { listRooms, addRoom, updateRoom, deleteRoom };

--- a/controllers/venueRunsheetCtl.js
+++ b/controllers/venueRunsheetCtl.js
@@ -1,0 +1,155 @@
+/**
+ * controllers/venueRunsheetCtl.js — Phase 5 (PMS) event-day runsheet CRUD +
+ * reorder. Items belong to (booking, day); writes are leads-gated at the
+ * route; vendor lines may carry vendorPhone for wa.me links.
+ */
+const Venue = require("../models/Venue");
+const VenueBooking = require("../models/VenueBooking");
+const VenueRunsheetItem = require("../models/VenueRunsheetItem");
+const { reqStr, optStr, optDate } = require("../utils/venueInput");
+const { dayKey } = require("../utils/venueRunsheet");
+
+const CATEGORIES = ["setup", "ceremony", "catering", "vendor", "teardown", "other"];
+const STATUSES = ["pending", "in_progress", "done"];
+const TIME_RE = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+async function resolveOwnedVenue(req, res) {
+  const venue = await Venue.findOne({ slug: req.params.slug }).select("_id").lean();
+  if (!venue) { res.status(404).json({ message: "Venue not found" }); return null; }
+  if (String(venue._id) !== String(req.venueOwner.venueId)) { res.status(403).json({ message: "Forbidden" }); return null; }
+  return venue;
+}
+
+function validateItemInput(body, { partial = false } = {}) {
+  const out = {};
+  if (!partial || body.title !== undefined) {
+    const v = reqStr(body.title, "title", 300);
+    if (!v.ok) return { error: v.message };
+    out.title = v.value;
+  }
+  if (body.time !== undefined) {
+    const t = String(body.time || "").trim();
+    if (t && !TIME_RE.test(t)) return { error: "time must be HH:MM (24h)" };
+    out.time = t;
+  }
+  if (body.owner !== undefined) {
+    const v = optStr(body.owner, "owner", 200);
+    if (!v.ok) return { error: v.message };
+    out.owner = v.value;
+  }
+  if (body.vendorPhone !== undefined) {
+    const v = optStr(body.vendorPhone, "vendorPhone", 30);
+    if (!v.ok) return { error: v.message };
+    out.vendorPhone = v.value;
+  }
+  if (body.category !== undefined) {
+    if (!CATEGORIES.includes(body.category)) return { error: `category must be one of: ${CATEGORIES.join(", ")}` };
+    out.category = body.category;
+  }
+  if (body.status !== undefined) {
+    if (!STATUSES.includes(body.status)) return { error: `status must be one of: ${STATUSES.join(", ")}` };
+    out.status = body.status;
+  }
+  if (body.notes !== undefined) {
+    const v = optStr(body.notes, "notes", 2000);
+    if (!v.ok) return { error: v.message };
+    out.notes = v.value;
+  }
+  return { value: out };
+}
+
+// GET /venues/:slug/bookings/:bookingId/runsheet?day=YYYY-MM-DD — open read.
+const listRunsheet = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const query = { venue: venue._id, booking: req.params.bookingId };
+    if (req.query.day) {
+      const v = optDate(req.query.day, "day");
+      if (!v.ok || !v.value) return res.status(400).json({ message: v.message || "day is invalid" });
+      query.day = dayKey(v.value);
+    }
+    const items = await VenueRunsheetItem.find(query).sort({ day: 1, order: 1, time: 1 }).lean();
+    return res.status(200).json({ items });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+// POST /venues/:slug/bookings/:bookingId/runsheet — leads capability.
+const createItem = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const booking = await VenueBooking.findOne({ _id: req.params.bookingId, venue: venue._id }).select("_id").lean();
+    if (!booking) return res.status(404).json({ message: "Booking not found" });
+    const dayV = optDate((req.body || {}).day, "day");
+    if (!dayV.ok || !dayV.value) return res.status(400).json({ message: dayV.message || "day is required" });
+    const v = validateItemInput(req.body || {});
+    if (v.error) return res.status(400).json({ message: v.error });
+    const day = dayKey(dayV.value);
+    const last = await VenueRunsheetItem.findOne({ booking: booking._id, day }).sort({ order: -1 }).select("order").lean();
+    const item = await VenueRunsheetItem.create({
+      ...v.value,
+      venue: venue._id,
+      booking: booking._id,
+      day,
+      order: last ? last.order + 1 : 0,
+    });
+    return res.status(201).json({ item });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+// PATCH /venues/:slug/runsheet/:itemId — leads capability.
+const updateItem = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const item = await VenueRunsheetItem.findOne({ _id: req.params.itemId, venue: venue._id });
+    if (!item) return res.status(404).json({ message: "Runsheet item not found" });
+    const v = validateItemInput(req.body || {}, { partial: true });
+    if (v.error) return res.status(400).json({ message: v.error });
+    Object.assign(item, v.value);
+    await item.save();
+    return res.status(200).json({ item });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+// DELETE /venues/:slug/runsheet/:itemId — leads capability.
+const deleteItem = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const out = await VenueRunsheetItem.deleteOne({ _id: req.params.itemId, venue: venue._id });
+    if (!out.deletedCount) return res.status(404).json({ message: "Runsheet item not found" });
+    return res.status(200).json({ deleted: true });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+// POST /venues/:slug/bookings/:bookingId/runsheet/reorder — leads capability.
+// Body: { day: "YYYY-MM-DD", ids: [itemId, ...] } — order = array index.
+const reorderRunsheet = async (req, res) => {
+  try {
+    const venue = await resolveOwnedVenue(req, res);
+    if (!venue) return;
+    const { ids } = req.body || {};
+    const dayV = optDate((req.body || {}).day, "day");
+    if (!dayV.ok || !dayV.value) return res.status(400).json({ message: dayV.message || "day is required" });
+    if (!Array.isArray(ids) || ids.length === 0 || ids.length > 200) {
+      return res.status(400).json({ message: "ids[] is required (max 200)" });
+    }
+    const day = dayKey(dayV.value);
+    const items = await VenueRunsheetItem.find({ venue: venue._id, booking: req.params.bookingId, day }).select("_id").lean();
+    const valid = new Set(items.map((i) => String(i._id)));
+    if (!ids.every((id) => valid.has(String(id)))) {
+      return res.status(400).json({ message: "ids must all belong to this booking day" });
+    }
+    await Promise.all(
+      ids.map((id, idx) => VenueRunsheetItem.updateOne({ _id: id, venue: venue._id }, { $set: { order: idx } }))
+    );
+    const updated = await VenueRunsheetItem.find({ venue: venue._id, booking: req.params.bookingId, day })
+      .sort({ order: 1 })
+      .lean();
+    return res.status(200).json({ items: updated });
+  } catch (err) { return res.status(500).json({ message: err.message }); }
+};
+
+module.exports = { listRunsheet, createItem, updateItem, deleteItem, reorderRunsheet };

--- a/models/Venue.js
+++ b/models/Venue.js
@@ -50,6 +50,16 @@ const VenueSchema = new mongoose.Schema({
       photos: [String],
     }],
   },
+  // Phase 5 (PMS) — the operational rooms inventory used for guest allotment
+  // and check-in/out. Distinct from accommodation.roomTypes (marketing copy);
+  // both render side by side on the listing surface.
+  rooms: [{
+    name: { type: String, required: true }, // name or number, e.g. "Suite 2"
+    type: { type: String, enum: ["standard", "deluxe", "suite", "dorm", "other"], default: "standard" },
+    capacity: { type: Number, default: 2 },
+    notes: { type: String, default: "" },
+    isActive: { type: Boolean, default: true },
+  }],
   pricing: {
     currency: { type: String, default: "INR" },
     minimumDuration: { type: Number, default: 12 },

--- a/models/VenueContract.js
+++ b/models/VenueContract.js
@@ -1,0 +1,58 @@
+const mongoose = require("mongoose");
+
+// Phase 3.5 — a booking contract: ordered clause sections seeded from the
+// venue's policyDoc plus structured booking specifics. "Acknowledged" is a
+// DIGITAL ACKNOWLEDGMENT (name + phone match against the booking), not a
+// legal e-signature — the UI labels it accordingly.
+const VenueContractSchema = new mongoose.Schema(
+  {
+    venue: { type: mongoose.Schema.Types.ObjectId, ref: "Venue", required: true },
+    booking: { type: mongoose.Schema.Types.ObjectId, ref: "VenueBooking", required: true },
+    version: { type: Number, default: 1 },
+    // Ordered clause sections (heading + numbered clause strings).
+    sections: [
+      {
+        heading: { type: String, default: "" },
+        clauses: [{ type: String }],
+      },
+    ],
+    // Frozen booking facts at generation time (edits to the booking later do
+    // not silently rewrite a sent contract).
+    parties: {
+      venueName: { type: String, default: "" },
+      coupleName: { type: String, default: "" },
+      couplePhone: { type: String, default: "" },
+    },
+    specifics: {
+      days: [
+        {
+          date: { type: Date },
+          eventType: { type: String, default: "" },
+          guestCount: { type: Number, default: 0 },
+        },
+      ],
+      totalValue: { type: Number, default: 0 },
+      paymentSchedule: [
+        {
+          label: { type: String, default: "" },
+          dueDate: { type: Date },
+          amount: { type: Number, default: 0 },
+        },
+      ],
+    },
+    status: {
+      type: String,
+      enum: ["draft", "sent", "acknowledged", "void"],
+      default: "draft",
+    },
+    sentAt: { type: Date },
+    acknowledgedAt: { type: Date },
+    acknowledgmentName: { type: String, default: "" },
+    acknowledgmentPhone: { type: String, default: "" },
+  },
+  { timestamps: true }
+);
+
+VenueContractSchema.index({ venue: 1, booking: 1, version: -1 });
+
+module.exports = mongoose.models.VenueContract || mongoose.model("VenueContract", VenueContractSchema);

--- a/models/VenueRoomAllotment.js
+++ b/models/VenueRoomAllotment.js
@@ -1,0 +1,34 @@
+const mongoose = require("mongoose");
+
+// Phase 5 (PMS) — a room allotted to a booking's guest for a date range.
+// Conflict prevention is enforced atomically through VenueRoomNight's unique
+// (room, night) index — see controllers/venueAllotment.js; this doc is the
+// human-facing record.
+const VenueRoomAllotmentSchema = new mongoose.Schema(
+  {
+    venue: { type: mongoose.Schema.Types.ObjectId, ref: "Venue", required: true },
+    booking: { type: mongoose.Schema.Types.ObjectId, ref: "VenueBooking", required: true },
+    // Subdocument id inside Venue.rooms (not a top-level collection ref).
+    room: { type: mongoose.Schema.Types.ObjectId, required: true },
+    guestName: { type: String, default: "" },
+    guestPhone: { type: String, default: "" },
+    checkInAt: { type: Date, required: true },
+    checkOutAt: { type: Date, required: true },
+    actualCheckInAt: { type: Date },
+    actualCheckOutAt: { type: Date },
+    status: {
+      type: String,
+      enum: ["allotted", "checked_in", "checked_out", "cancelled"],
+      default: "allotted",
+    },
+    notes: { type: String, default: "" },
+    createdBy: { type: mongoose.Schema.Types.ObjectId, ref: "VenueOwner" },
+  },
+  { timestamps: true }
+);
+
+VenueRoomAllotmentSchema.index({ venue: 1, booking: 1 });
+VenueRoomAllotmentSchema.index({ venue: 1, room: 1, checkInAt: 1 });
+
+module.exports =
+  mongoose.models.VenueRoomAllotment || mongoose.model("VenueRoomAllotment", VenueRoomAllotmentSchema);

--- a/models/VenueRoomNight.js
+++ b/models/VenueRoomNight.js
@@ -1,0 +1,21 @@
+const mongoose = require("mongoose");
+
+// Phase 5 (PMS) — one doc per (room, occupied night). The UNIQUE compound
+// index is the atomic double-booking guard: concurrent allotments for an
+// overlapping range race on insertMany here, and exactly one can win — no
+// transactions needed on a standalone local Mongo.
+const VenueRoomNightSchema = new mongoose.Schema(
+  {
+    venue: { type: mongoose.Schema.Types.ObjectId, ref: "Venue", required: true },
+    room: { type: mongoose.Schema.Types.ObjectId, required: true },
+    // Midnight UTC of the occupied night.
+    night: { type: Date, required: true },
+    allotment: { type: mongoose.Schema.Types.ObjectId, ref: "VenueRoomAllotment", required: true },
+  },
+  { timestamps: true }
+);
+
+VenueRoomNightSchema.index({ room: 1, night: 1 }, { unique: true });
+VenueRoomNightSchema.index({ allotment: 1 });
+
+module.exports = mongoose.models.VenueRoomNight || mongoose.model("VenueRoomNight", VenueRoomNightSchema);

--- a/models/VenueRunsheetItem.js
+++ b/models/VenueRunsheetItem.js
@@ -1,0 +1,36 @@
+const mongoose = require("mongoose");
+
+// Phase 5 (PMS) — one line on a booking day's event-day runsheet.
+// `owner` is free text or a team member's name; `vendorPhone` (optional)
+// powers a wa.me link for category=vendor lines.
+const VenueRunsheetItemSchema = new mongoose.Schema(
+  {
+    venue: { type: mongoose.Schema.Types.ObjectId, ref: "Venue", required: true },
+    booking: { type: mongoose.Schema.Types.ObjectId, ref: "VenueBooking", required: true },
+    day: { type: Date, required: true }, // midnight UTC of the booking day
+    time: { type: String, default: "" }, // "HH:MM" display time
+    title: { type: String, required: true },
+    owner: { type: String, default: "" },
+    vendorPhone: { type: String, default: "" },
+    category: {
+      type: String,
+      enum: ["setup", "ceremony", "catering", "vendor", "teardown", "other"],
+      default: "other",
+    },
+    status: {
+      type: String,
+      enum: ["pending", "in_progress", "done"],
+      default: "pending",
+    },
+    order: { type: Number, default: 0 },
+    notes: { type: String, default: "" },
+    // true for the auto-seeded skeleton rows (still editable/deletable).
+    seeded: { type: Boolean, default: false },
+  },
+  { timestamps: true }
+);
+
+VenueRunsheetItemSchema.index({ venue: 1, booking: 1, day: 1, order: 1 });
+
+module.exports =
+  mongoose.models.VenueRunsheetItem || mongoose.model("VenueRunsheetItem", VenueRunsheetItemSchema);

--- a/routes/venue.js
+++ b/routes/venue.js
@@ -20,6 +20,7 @@ const sheets = require("../controllers/venueSheetsSync");
 const { listMembers, inviteMember, updateMember, getActivity } = require("../controllers/venueTeam");
 const { createOnboardingRequest } = require("../controllers/venueOnboarding");
 const { listRooms, addRoom, updateRoom, deleteRoom } = require("../controllers/venueRooms");
+const { generateContract, listContracts, updateContract, sendContract, contractPdf, getAckContract, acknowledgeContract } = require("../controllers/venueContract");
 const { createAllotments, listAllotments, updateAllotment, occupancy } = require("../controllers/venueAllotment");
 const { listRunsheet, createItem: createRunsheetItem, updateItem: updateRunsheetItem, deleteItem: deleteRunsheetItem, reorderRunsheet } = require("../controllers/venueRunsheetCtl");
 const { venueOwnerAuth } = require("../middlewares/venueOwnerAuth");
@@ -44,6 +45,11 @@ router.get("/", optionalAdminAuth, getVenues);
 router.post("/", CheckAdminLogin, createVenue);
 // Public "list your venue" lead from the landing page — rate-limited + validated.
 router.post("/onboarding-requests", publicReadLimiter, createOnboardingRequest);
+
+// ── Phase 3.5 contracts: PUBLIC token-addressed acknowledgment (rate-limited,
+//    no auth — the signed short-lived token is the credential) ──
+router.get("/contract-ack/:token", publicReadLimiter, getAckContract);
+router.post("/contract-ack/:token", publicReadLimiter, acknowledgeContract);
 // Venue-owner dashboard home widgets (onboarding, verification, follow-ups).
 router.get("/dashboard/overview", venueOwnerAuth, getDashboardOverview);
 router.get("/:slug", getVenueBySlug);
@@ -111,6 +117,13 @@ router.post("/:slug/bookings/:bookingId/runsheet", venueOwnerAuth, requireCapabi
 router.post("/:slug/bookings/:bookingId/runsheet/reorder", venueOwnerAuth, requireCapability("leads"), reorderRunsheet);
 router.patch("/:slug/runsheet/:itemId", venueOwnerAuth, requireCapability("leads"), updateRunsheetItem);
 router.delete("/:slug/runsheet/:itemId", venueOwnerAuth, requireCapability("leads"), deleteRunsheetItem);
+
+// ── Phase 3.5 contracts (booking surface -> leads capability) ──
+router.get("/:slug/bookings/:bookingId/contracts", venueOwnerAuth, listContracts);
+router.post("/:slug/bookings/:bookingId/contracts", venueOwnerAuth, requireCapability("leads"), generateContract);
+router.patch("/:slug/contracts/:contractId", venueOwnerAuth, requireCapability("leads"), updateContract);
+router.post("/:slug/contracts/:contractId/send", venueOwnerAuth, requireCapability("leads"), sendContract);
+router.get("/:slug/contracts/:contractId/pdf", venueOwnerAuth, contractPdf);
 
 router.get("/:slug/analytics", venueOwnerAuth, getAnalytics);
 

--- a/routes/venue.js
+++ b/routes/venue.js
@@ -19,6 +19,9 @@ const { getAnalytics } = require("../controllers/venueAnalytics");
 const sheets = require("../controllers/venueSheetsSync");
 const { listMembers, inviteMember, updateMember, getActivity } = require("../controllers/venueTeam");
 const { createOnboardingRequest } = require("../controllers/venueOnboarding");
+const { listRooms, addRoom, updateRoom, deleteRoom } = require("../controllers/venueRooms");
+const { createAllotments, listAllotments, updateAllotment, occupancy } = require("../controllers/venueAllotment");
+const { listRunsheet, createItem: createRunsheetItem, updateItem: updateRunsheetItem, deleteItem: deleteRunsheetItem, reorderRunsheet } = require("../controllers/venueRunsheetCtl");
 const { venueOwnerAuth } = require("../middlewares/venueOwnerAuth");
 const { requireCapability, requireCapabilityOrAdmin } = require("../middlewares/venueRole");
 const { enquiryIpLimiter, enquiryPhoneLimiter, publicReadLimiter } = require("../utils/venueEnquiryRateLimit");
@@ -90,6 +93,25 @@ router.post("/:slug/invoices/:invoiceId/payments", venueOwnerAuth, requireCapabi
 
 // ── Phase 3.4: payments summary + Phase 4.1: analytics — open reads ──
 router.get("/:slug/payments/summary", venueOwnerAuth, paymentsSummary);
+
+// ── Phase 5 (PMS): rooms inventory (listing), allotments + runsheet (leads),
+//    occupancy (open read) ──
+router.get("/:slug/rooms", venueOwnerAuth, listRooms);
+router.post("/:slug/rooms", venueOwnerAuth, requireCapability("listing"), addRoom);
+router.patch("/:slug/rooms/:roomId", venueOwnerAuth, requireCapability("listing"), updateRoom);
+router.delete("/:slug/rooms/:roomId", venueOwnerAuth, requireCapability("listing"), deleteRoom);
+
+router.get("/:slug/bookings/:bookingId/allotments", venueOwnerAuth, listAllotments);
+router.post("/:slug/bookings/:bookingId/allotments", venueOwnerAuth, requireCapability("leads"), createAllotments);
+router.patch("/:slug/allotments/:allotmentId", venueOwnerAuth, requireCapability("leads"), updateAllotment);
+router.get("/:slug/occupancy", venueOwnerAuth, occupancy);
+
+router.get("/:slug/bookings/:bookingId/runsheet", venueOwnerAuth, listRunsheet);
+router.post("/:slug/bookings/:bookingId/runsheet", venueOwnerAuth, requireCapability("leads"), createRunsheetItem);
+router.post("/:slug/bookings/:bookingId/runsheet/reorder", venueOwnerAuth, requireCapability("leads"), reorderRunsheet);
+router.patch("/:slug/runsheet/:itemId", venueOwnerAuth, requireCapability("leads"), updateRunsheetItem);
+router.delete("/:slug/runsheet/:itemId", venueOwnerAuth, requireCapability("leads"), deleteRunsheetItem);
+
 router.get("/:slug/analytics", venueOwnerAuth, getAnalytics);
 
 // Google Sheets integration — ALL routes require the "leads" capability (ruling),

--- a/scripts/e2e-hardening.js
+++ b/scripts/e2e-hardening.js
@@ -305,6 +305,44 @@ async function run() {
     ok("7 gated route without token -> 401", noTok.status === 401, `status ${noTok.status}`);
   }
 
+  // ═══════════ 9. PMS WRITE SURFACES (rooms / allotments / runsheet) ═══════════
+  console.log("\n— 9. PMS hostile input —");
+  {
+    // XSS room name stored verbatim (inert), giant name rejected
+    const xssName = '<img src=x onerror=alert(1)>Suite';
+    const rx = await api("POST", `/venues/${A}/rooms`, { token: tokenA, body: { name: xssName, type: "suite" } });
+    ok("9 XSS room name stored verbatim (inert)", rx.status === 201 && rx.json.room.name === xssName, `status ${rx.status}`);
+    const rGiant = await api("POST", `/venues/${A}/rooms`, { token: tokenA, body: { name: "R".repeat(10000) } });
+    ok("9 10k-char room name -> 400", rGiant.status === 400, `status ${rGiant.status}`);
+    const rNegCap = await api("POST", `/venues/${A}/rooms`, { token: tokenA, body: { name: "Neg", capacity: -3 } });
+    ok("9 negative capacity -> 400", rNegCap.status === 400, `status ${rNegCap.status}`);
+
+    // a booking to hang allotments off
+    const bkr = await api("POST", `/venues/${A}/bookings`, { token: tokenA, body: { coupleName: "PMS Torture", days: [{ date: new Date(Date.now() + 30 * 86400000).toISOString() }] } });
+    const bId = bkr.json.booking && bkr.json.booking._id;
+    const roomId = rx.json.room._id;
+
+    const aAbsurd = await api("POST", `/venues/${A}/bookings/${bId}/allotments`, { token: tokenA, body: { room: roomId, guestName: "X", checkInAt: "9999-01-01", checkOutAt: "9999-01-02" } });
+    ok("9 absurd-year allotment dates -> 400", aAbsurd.status === 400, `status ${aAbsurd.status}`);
+    const aJunkRoom = await api("POST", `/venues/${A}/bookings/${bId}/allotments`, { token: tokenA, body: { room: "not-an-objectid", guestName: "X", checkInAt: new Date(Date.now() + 86400000).toISOString(), checkOutAt: new Date(Date.now() + 2 * 86400000).toISOString() } });
+    ok("9 junk room id -> 4xx, not 500", aJunkRoom.status >= 400 && aJunkRoom.status < 500, `status ${aJunkRoom.status}`);
+    const aHuge = await api("POST", `/venues/${A}/bookings/${bId}/allotments`, { token: tokenA, body: { allotments: Array.from({ length: 51 }, () => ({ room: roomId, guestName: "X", checkInAt: new Date().toISOString(), checkOutAt: new Date(Date.now() + 86400000).toISOString() })) } });
+    ok("9 51-item bulk allotment -> 400", aHuge.status === 400, `status ${aHuge.status}`);
+
+    const rsGiant = await api("POST", `/venues/${A}/bookings/${bId}/runsheet`, { token: tokenA, body: { day: new Date(Date.now() + 30 * 86400000).toISOString(), title: "T".repeat(10000) } });
+    ok("9 10k-char runsheet title -> 400", rsGiant.status === 400, `status ${rsGiant.status}`);
+    const rsBadStatus = await api("POST", `/venues/${A}/bookings/${bId}/runsheet`, { token: tokenA, body: { day: new Date(Date.now() + 30 * 86400000).toISOString(), title: "ok", status: "exploded" } });
+    ok("9 bad runsheet status enum -> 400", rsBadStatus.status === 400, `status ${rsBadStatus.status}`);
+    const reorderForeign = await api("POST", `/venues/${A}/bookings/${bId}/runsheet/reorder`, { token: tokenA, body: { day: new Date(Date.now() + 30 * 86400000).toISOString(), ids: [leadId] } });
+    ok("9 reorder with foreign ids -> 400", reorderForeign.status === 400, `status ${reorderForeign.status}`);
+
+    // tenancy: venue B's owner cannot touch venue A's PMS surfaces
+    const idor = await api("POST", `/venues/${A}/rooms`, { token: tokenB, body: { name: "Intruder" } });
+    ok("9 cross-venue room write -> 403", idor.status === 403, `status ${idor.status}`);
+    const idorOcc = await api("GET", `/venues/${A}/occupancy`, { token: tokenB });
+    ok("9 cross-venue occupancy read -> 403", idorOcc.status === 403, `status ${idorOcc.status}`);
+  }
+
   finish();
 }
 

--- a/scripts/e2e-venue.js
+++ b/scripts/e2e-venue.js
@@ -502,6 +502,83 @@ async function run() {
     check("onboarding: null body -> not 500", onbNull.status !== 500, `status ${onbNull.status}`);
   }
 
+  // ================= Phase 3.5: contracts (generate / edit / send / public ack / pdf) =================
+  if (process.env.E2E_CONTRACTS === "1") {
+    // Seed structured policies so generation has known content.
+    await api("PUT", `/venues/${SLUG}`, { token, body: { policyDoc: { policies: ["No outside DJ after 11pm"], terms: ["50% advance to confirm"], refund: ["No refund within 7 days"] } } });
+    const couplePhone = `95${Date.now() % 1e8}`;
+    const bk = await api("POST", `/venues/${SLUG}/bookings`, {
+      token,
+      body: { coupleName: "Contract Couple", couplePhone, totalValue: 400000, days: [{ date: new Date(Date.now() + 30 * 86400000).toISOString(), eventType: "Wedding", guestCount: 250 }], paymentSchedule: [{ label: "Advance", amount: 100000 }] },
+    });
+    const bkId = bk.json.booking._id;
+
+    // generate v1 — seeded from policyDoc + frozen specifics
+    const g1 = await api("POST", `/venues/${SLUG}/bookings/${bkId}/contracts`, { token });
+    const c1 = g1.json.contract;
+    check("contracts: generate v1 seeds from policyDoc",
+      g1.status === 201 && c1.version === 1 && c1.sections.length === 3
+        && c1.sections[0].clauses[0] === "No outside DJ after 11pm"
+        && c1.parties.coupleName === "Contract Couple"
+        && c1.specifics.totalValue === 400000,
+      `status ${g1.status} sections=${c1 && c1.sections.length}`);
+
+    // edit while draft
+    const ed = await api("PATCH", `/venues/${SLUG}/contracts/${c1._id}`, { token, body: { sections: [{ heading: "Venue Policies", clauses: ["No outside DJ after 11pm", "Decor by approved vendors only"] }] } });
+    check("contracts: edit draft sections -> 200", ed.status === 200 && ed.json.contract.sections[0].clauses.length === 2, `status ${ed.status}`);
+    const edBad = await api("PATCH", `/venues/${SLUG}/contracts/${c1._id}`, { token, body: { sections: [{ heading: "   ", clauses: ["x"] }] } });
+    check("contracts: blank section heading -> 400", edBad.status === 400, `status ${edBad.status}`);
+
+    // send -> public ack link
+    const sent = await api("POST", `/venues/${SLUG}/contracts/${c1._id}/send`, { token });
+    check("contracts: send -> sent + ack token", sent.status === 200 && sent.json.contract.status === "sent" && sent.json.contract.sentAt && sent.json.ackToken, `status ${sent.status}`);
+    const ackToken = sent.json.ackToken;
+
+    // public read (no auth) — phone masked
+    const pub = await api("GET", `/venues/contract-ack/${ackToken}`, {});
+    check("contracts: public ack GET shows contract, masks phone",
+      pub.status === 200 && pub.json.contract.sections.length === 1 && /•/.test(pub.json.contract.parties.couplePhone),
+      `status ${pub.status} phone=${pub.json.contract && pub.json.contract.parties.couplePhone}`);
+
+    // garbage + tampered tokens rejected
+    const badTok = await api("GET", `/venues/contract-ack/not-a-token`, {});
+    check("contracts: garbage token -> 401", badTok.status === 401, `status ${badTok.status}`);
+    const tampered = await api("POST", `/venues/contract-ack/${ackToken.slice(0, -2)}xx`, { body: { name: "X", phone: couplePhone } });
+    check("contracts: tampered token -> 401", tampered.status === 401, `status ${tampered.status}`);
+
+    // wrong phone -> 403; hostile name -> 400
+    const wrong = await api("POST", `/venues/contract-ack/${ackToken}`, { body: { name: "Impostor", phone: "9000000000" } });
+    check("contracts: wrong phone -> 403", wrong.status === 403, `status ${wrong.status}`);
+    const blankName = await api("POST", `/venues/contract-ack/${ackToken}`, { body: { name: "   ", phone: couplePhone } });
+    check("contracts: blank name -> 400", blankName.status === 400, `status ${blankName.status}`);
+
+    // right phone -> acknowledged + stamps
+    const ack = await api("POST", `/venues/contract-ack/${ackToken}`, { body: { name: "Contract Couple", phone: couplePhone } });
+    check("contracts: matching phone -> acknowledged", ack.status === 200 && ack.json.acknowledgedAt, `status ${ack.status}`);
+    const ackAgain = await api("POST", `/venues/contract-ack/${ackToken}`, { body: { name: "Again", phone: couplePhone } });
+    check("contracts: double-acknowledge -> 409", ackAgain.status === 409, `status ${ackAgain.status}`);
+
+    // pdf bytes
+    const pdf = await apiBinary(`/venues/${SLUG}/contracts/${c1._id}/pdf`, { token });
+    check("contracts: PDF returns bytes", pdf.status === 200 && pdf.head.startsWith("%PDF") && pdf.bytes > 800, `bytes=${pdf.bytes}`);
+
+    // new version supersedes (voids) prior non-acknowledged; acknowledged stays
+    const g2 = await api("POST", `/venues/${SLUG}/bookings/${bkId}/contracts`, { token });
+    check("contracts: v2 generated", g2.status === 201 && g2.json.contract.version === 2, `v=${g2.json.contract && g2.json.contract.version}`);
+    const both = await api("GET", `/venues/${SLUG}/bookings/${bkId}/contracts`, { token });
+    const v1After = both.json.contracts.find((c) => c.version === 1);
+    check("contracts: acknowledged v1 NOT voided by v2", v1After && v1After.status === "acknowledged", `v1=${v1After && v1After.status}`);
+    const g3 = await api("POST", `/venues/${SLUG}/bookings/${bkId}/contracts`, { token });
+    const all3 = await api("GET", `/venues/${SLUG}/bookings/${bkId}/contracts`, { token });
+    const v2After = all3.json.contracts.find((c) => c.version === 2);
+    check("contracts: draft v2 voided by v3 (supersede)", g3.status === 201 && v2After && v2After.status === "void", `v2=${v2After && v2After.status}`);
+
+    // draft-only editing: v1 (acknowledged) cannot be edited
+    const edAck = await api("PATCH", `/venues/${SLUG}/contracts/${c1._id}`, { token, body: { sections: [] } });
+    check("contracts: editing acknowledged contract -> 409", edAck.status === 409, `status ${edAck.status}`);
+  }
+
+
   // ================= Public-route rate limiting (callback + generate-location) =================
   // Run on a freshly-started server (publicReadLimiter counters reset on restart).
   if (process.env.E2E_PUBLIC_RATELIMIT === "1") {
@@ -645,82 +722,6 @@ async function run() {
     const rs2 = await api("GET", `/venues/${SLUG}/bookings/${bkId}/runsheet`, { token });
     const day9Items = rs2.json.items.filter((i) => i.day && i.day.slice(0, 10) === iso(day(9)).slice(0, 10));
     check("pms: new booking day auto-seeds skeleton", addDay.status === 200 && day9Items.length === 3, `day9=${day9Items.length}`);
-  }
-
-  // ================= Phase 3.5: contracts (generate / edit / send / public ack / pdf) =================
-  if (process.env.E2E_CONTRACTS === "1") {
-    // Seed structured policies so generation has known content.
-    await api("PUT", `/venues/${SLUG}`, { token, body: { policyDoc: { policies: ["No outside DJ after 11pm"], terms: ["50% advance to confirm"], refund: ["No refund within 7 days"] } } });
-    const couplePhone = `95${Date.now() % 1e8}`;
-    const bk = await api("POST", `/venues/${SLUG}/bookings`, {
-      token,
-      body: { coupleName: "Contract Couple", couplePhone, totalValue: 400000, days: [{ date: new Date(Date.now() + 30 * 86400000).toISOString(), eventType: "Wedding", guestCount: 250 }], paymentSchedule: [{ label: "Advance", amount: 100000 }] },
-    });
-    const bkId = bk.json.booking._id;
-
-    // generate v1 — seeded from policyDoc + frozen specifics
-    const g1 = await api("POST", `/venues/${SLUG}/bookings/${bkId}/contracts`, { token });
-    const c1 = g1.json.contract;
-    check("contracts: generate v1 seeds from policyDoc",
-      g1.status === 201 && c1.version === 1 && c1.sections.length === 3
-        && c1.sections[0].clauses[0] === "No outside DJ after 11pm"
-        && c1.parties.coupleName === "Contract Couple"
-        && c1.specifics.totalValue === 400000,
-      `status ${g1.status} sections=${c1 && c1.sections.length}`);
-
-    // edit while draft
-    const ed = await api("PATCH", `/venues/${SLUG}/contracts/${c1._id}`, { token, body: { sections: [{ heading: "Venue Policies", clauses: ["No outside DJ after 11pm", "Decor by approved vendors only"] }] } });
-    check("contracts: edit draft sections -> 200", ed.status === 200 && ed.json.contract.sections[0].clauses.length === 2, `status ${ed.status}`);
-    const edBad = await api("PATCH", `/venues/${SLUG}/contracts/${c1._id}`, { token, body: { sections: [{ heading: "   ", clauses: ["x"] }] } });
-    check("contracts: blank section heading -> 400", edBad.status === 400, `status ${edBad.status}`);
-
-    // send -> public ack link
-    const sent = await api("POST", `/venues/${SLUG}/contracts/${c1._id}/send`, { token });
-    check("contracts: send -> sent + ack token", sent.status === 200 && sent.json.contract.status === "sent" && sent.json.contract.sentAt && sent.json.ackToken, `status ${sent.status}`);
-    const ackToken = sent.json.ackToken;
-
-    // public read (no auth) — phone masked
-    const pub = await api("GET", `/venues/contract-ack/${ackToken}`, {});
-    check("contracts: public ack GET shows contract, masks phone",
-      pub.status === 200 && pub.json.contract.sections.length === 1 && /•/.test(pub.json.contract.parties.couplePhone),
-      `status ${pub.status} phone=${pub.json.contract && pub.json.contract.parties.couplePhone}`);
-
-    // garbage + tampered tokens rejected
-    const badTok = await api("GET", `/venues/contract-ack/not-a-token`, {});
-    check("contracts: garbage token -> 401", badTok.status === 401, `status ${badTok.status}`);
-    const tampered = await api("POST", `/venues/contract-ack/${ackToken.slice(0, -2)}xx`, { body: { name: "X", phone: couplePhone } });
-    check("contracts: tampered token -> 401", tampered.status === 401, `status ${tampered.status}`);
-
-    // wrong phone -> 403; hostile name -> 400
-    const wrong = await api("POST", `/venues/contract-ack/${ackToken}`, { body: { name: "Impostor", phone: "9000000000" } });
-    check("contracts: wrong phone -> 403", wrong.status === 403, `status ${wrong.status}`);
-    const blankName = await api("POST", `/venues/contract-ack/${ackToken}`, { body: { name: "   ", phone: couplePhone } });
-    check("contracts: blank name -> 400", blankName.status === 400, `status ${blankName.status}`);
-
-    // right phone -> acknowledged + stamps
-    const ack = await api("POST", `/venues/contract-ack/${ackToken}`, { body: { name: "Contract Couple", phone: couplePhone } });
-    check("contracts: matching phone -> acknowledged", ack.status === 200 && ack.json.acknowledgedAt, `status ${ack.status}`);
-    const ackAgain = await api("POST", `/venues/contract-ack/${ackToken}`, { body: { name: "Again", phone: couplePhone } });
-    check("contracts: double-acknowledge -> 409", ackAgain.status === 409, `status ${ackAgain.status}`);
-
-    // pdf bytes
-    const pdf = await apiBinary(`/venues/${SLUG}/contracts/${c1._id}/pdf`, { token });
-    check("contracts: PDF returns bytes", pdf.status === 200 && pdf.head.startsWith("%PDF") && pdf.bytes > 800, `bytes=${pdf.bytes}`);
-
-    // new version supersedes (voids) prior non-acknowledged; acknowledged stays
-    const g2 = await api("POST", `/venues/${SLUG}/bookings/${bkId}/contracts`, { token });
-    check("contracts: v2 generated", g2.status === 201 && g2.json.contract.version === 2, `v=${g2.json.contract && g2.json.contract.version}`);
-    const both = await api("GET", `/venues/${SLUG}/bookings/${bkId}/contracts`, { token });
-    const v1After = both.json.contracts.find((c) => c.version === 1);
-    check("contracts: acknowledged v1 NOT voided by v2", v1After && v1After.status === "acknowledged", `v1=${v1After && v1After.status}`);
-    const g3 = await api("POST", `/venues/${SLUG}/bookings/${bkId}/contracts`, { token });
-    const all3 = await api("GET", `/venues/${SLUG}/bookings/${bkId}/contracts`, { token });
-    const v2After = all3.json.contracts.find((c) => c.version === 2);
-    check("contracts: draft v2 voided by v3 (supersede)", g3.status === 201 && v2After && v2After.status === "void", `v2=${v2After && v2After.status}`);
-
-    // draft-only editing: v1 (acknowledged) cannot be edited
-    const edAck = await api("PATCH", `/venues/${SLUG}/contracts/${c1._id}`, { token, body: { sections: [] } });
-    check("contracts: editing acknowledged contract -> 409", edAck.status === 409, `status ${edAck.status}`);
   }
 
   finish();

--- a/scripts/e2e-venue.js
+++ b/scripts/e2e-venue.js
@@ -519,6 +519,134 @@ async function run() {
     check("public-ratelimit: onboarding over-limit -> 429 (no record created)", onbOver.status === 429, `status ${onbOver.status}`);
   }
 
+  // ================= Phase 5 (PMS): rooms, allotments, runsheet, occupancy =================
+  if (process.env.E2E_PMS === "1") {
+    const day = (offset) => {
+      const t = Date.now() + offset * 86400000;
+      const d = new Date(t);
+      return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+    };
+    const iso = (d) => d.toISOString();
+
+    // ── rooms CRUD + hostile input ──
+    const r1 = await api("POST", `/venues/${SLUG}/rooms`, { token, body: { name: "PMS Suite 1", type: "suite", capacity: 2 } });
+    check("pms: add room -> 201", r1.status === 201 && r1.json.room && r1.json.room.name === "PMS Suite 1", `status ${r1.status}`);
+    const roomA = r1.json.room && r1.json.room._id;
+    const r2 = await api("POST", `/venues/${SLUG}/rooms`, { token, body: { name: "PMS Std 2", type: "standard", capacity: 3 } });
+    const roomB = r2.json.room && r2.json.room._id;
+    const rBadType = await api("POST", `/venues/${SLUG}/rooms`, { token, body: { name: "X", type: "penthouse" } });
+    check("pms: bad room type -> 400", rBadType.status === 400, `status ${rBadType.status}`);
+    const rBlank = await api("POST", `/venues/${SLUG}/rooms`, { token, body: { name: "   " } });
+    check("pms: blank room name -> 400", rBlank.status === 400, `status ${rBlank.status}`);
+    const rPatch = await api("PATCH", `/venues/${SLUG}/rooms/${roomA}`, { token, body: { capacity: 4, notes: "lake view" } });
+    check("pms: patch room -> 200 persists", rPatch.status === 200 && rPatch.json.room.capacity === 4, `status ${rPatch.status}`);
+
+    // ── booking with two days -> auto-seeded runsheet skeleton per day ──
+    const bk = await api("POST", `/venues/${SLUG}/bookings`, {
+      token,
+      body: { coupleName: "PMS Couple", couplePhone: `96${Date.now() % 1e8}`, totalValue: 300000, days: [{ date: iso(day(7)), eventType: "Wedding", guestCount: 200 }, { date: iso(day(8)), eventType: "Reception", guestCount: 350 }] },
+    });
+    check("pms: booking with 2 days -> 201", bk.status === 201 && bk.json.booking, `status ${bk.status}`);
+    const bkId = bk.json.booking._id;
+    const rs0 = await api("GET", `/venues/${SLUG}/bookings/${bkId}/runsheet`, { token });
+    check("pms: auto-seeded runsheet = 3 items × 2 days", rs0.status === 200 && rs0.json.items.length === 6 && rs0.json.items.every((i) => i.seeded), `n=${rs0.json.items && rs0.json.items.length}`);
+
+    // ── allotment lifecycle ──
+    const al1 = await api("POST", `/venues/${SLUG}/bookings/${bkId}/allotments`, {
+      token,
+      body: { room: roomA, guestName: "Groom's family", checkInAt: iso(day(7)), checkOutAt: iso(day(9)) },
+    });
+    check("pms: allot room -> 201", al1.status === 201 && al1.json.allotments.length === 1, `status ${al1.status}`);
+    const alId = al1.json.allotments[0] && al1.json.allotments[0]._id;
+
+    // overlap rejected (different booking range overlapping night 8)
+    const alOverlap = await api("POST", `/venues/${SLUG}/bookings/${bkId}/allotments`, {
+      token,
+      body: { room: roomA, guestName: "Clash", checkInAt: iso(day(8)), checkOutAt: iso(day(10)) },
+    });
+    check("pms: overlapping allotment -> 409", alOverlap.status === 409, `status ${alOverlap.status}`);
+
+    // CONCURRENCY: 5 simultaneous identical requests on roomB -> exactly one wins
+    const burst = await Promise.all(
+      Array.from({ length: 5 }, (_, i) =>
+        api("POST", `/venues/${SLUG}/bookings/${bkId}/allotments`, {
+          token,
+          body: { room: roomB, guestName: `Racer ${i}`, checkInAt: iso(day(7)), checkOutAt: iso(day(8)) },
+        })
+      )
+    );
+    const winners = burst.filter((r) => r.status === 201).length;
+    const losers = burst.filter((r) => r.status === 409).length;
+    check("pms: 5 concurrent same-room allotments -> exactly 1 wins, 4 conflict", winners === 1 && losers === 4, `winners=${winners} losers=${losers}`);
+
+    // check-in stamps actualCheckInAt
+    const ci = await api("PATCH", `/venues/${SLUG}/allotments/${alId}`, { token, body: { action: "check_in" } });
+    check("pms: check-in stamps actualCheckInAt", ci.status === 200 && ci.json.allotment.status === "checked_in" && ci.json.allotment.actualCheckInAt, `status ${ci.status}`);
+    const ciAgain = await api("PATCH", `/venues/${SLUG}/allotments/${alId}`, { token, body: { action: "check_in" } });
+    check("pms: double check-in -> 409", ciAgain.status === 409, `status ${ciAgain.status}`);
+    const co = await api("PATCH", `/venues/${SLUG}/allotments/${alId}`, { token, body: { action: "check_out" } });
+    check("pms: check-out stamps actualCheckOutAt", co.status === 200 && co.json.allotment.status === "checked_out" && co.json.allotment.actualCheckOutAt, `status ${co.status}`);
+
+    // cancel frees the range: cancel the roomB winner, re-allot same range OK
+    const winnerId = burst.find((r) => r.status === 201).json.allotments[0]._id;
+    const cancel = await api("PATCH", `/venues/${SLUG}/allotments/${winnerId}`, { token, body: { action: "cancel" } });
+    check("pms: cancel allotment -> 200", cancel.status === 200 && cancel.json.allotment.status === "cancelled", `status ${cancel.status}`);
+    const realot = await api("POST", `/venues/${SLUG}/bookings/${bkId}/allotments`, {
+      token,
+      body: { room: roomB, guestName: "After cancel", checkInAt: iso(day(7)), checkOutAt: iso(day(8)) },
+    });
+    check("pms: cancelled range can be re-allotted", realot.status === 201, `status ${realot.status}`);
+
+    // hostile allotment input
+    const alBad = await api("POST", `/venues/${SLUG}/bookings/${bkId}/allotments`, { token, body: { room: roomA, guestName: "X", checkInAt: "not-a-date", checkOutAt: iso(day(9)) } });
+    check("pms: invalid checkInAt -> 400", alBad.status === 400, `status ${alBad.status}`);
+    const alRev = await api("POST", `/venues/${SLUG}/bookings/${bkId}/allotments`, { token, body: { room: roomA, guestName: "X", checkInAt: iso(day(9)), checkOutAt: iso(day(7)) } });
+    check("pms: checkOut before checkIn -> 400", alRev.status === 400, `status ${alRev.status}`);
+
+    // ── runsheet CRUD + reorder + vendor wa.me field ──
+    const it1 = await api("POST", `/venues/${SLUG}/bookings/${bkId}/runsheet`, {
+      token,
+      body: { day: iso(day(7)), time: "14:30", title: "Florist arrival", category: "vendor", vendorPhone: "9876501234", owner: "Asiya" },
+    });
+    check("pms: add vendor runsheet item -> 201", it1.status === 201 && it1.json.item.vendorPhone === "9876501234", `status ${it1.status}`);
+    const itemId = it1.json.item._id;
+    const itBadTime = await api("POST", `/venues/${SLUG}/bookings/${bkId}/runsheet`, { token, body: { day: iso(day(7)), time: "25:99", title: "X" } });
+    check("pms: invalid time -> 400", itBadTime.status === 400, `status ${itBadTime.status}`);
+    const itDone = await api("PATCH", `/venues/${SLUG}/runsheet/${itemId}`, { token, body: { status: "done" } });
+    check("pms: runsheet check-off -> done", itDone.status === 200 && itDone.json.item.status === "done", `status ${itDone.status}`);
+
+    const rsDay = await api("GET", `/venues/${SLUG}/bookings/${bkId}/runsheet?day=${iso(day(7))}`, { token });
+    const dayIds = rsDay.json.items.map((i) => i._id);
+    const reordered = await api("POST", `/venues/${SLUG}/bookings/${bkId}/runsheet/reorder`, { token, body: { day: iso(day(7)), ids: [...dayIds].reverse() } });
+    check("pms: reorder persists (first becomes last)", reordered.status === 200 && String(reordered.json.items[0]._id) === String(dayIds[dayIds.length - 1]), `status ${reordered.status}`);
+    const del = await api("DELETE", `/venues/${SLUG}/runsheet/${itemId}`, { token });
+    check("pms: delete runsheet item -> 200", del.status === 200 && del.json.deleted, `status ${del.status}`);
+
+    // ── occupancy matrix vs what we just created ──
+    const occ = await api("GET", `/venues/${SLUG}/occupancy?from=${iso(day(6))}&to=${iso(day(10))}`, { token });
+    const occOk = occ.status === 200 && Array.isArray(occ.json.days) && occ.json.days.length === 4 && Array.isArray(occ.json.rooms);
+    check("pms: occupancy shape (4 days, rooms[])", occOk, `status ${occ.status} days=${occ.json.days && occ.json.days.length}`);
+    if (occOk) {
+      const occA = occ.json.rooms.find((r) => String(r._id) === String(roomA));
+      const occB = occ.json.rooms.find((r) => String(r._id) === String(roomB));
+      check("pms: occupancy shows roomA stay (checked_out) + roomB re-allotment",
+        occA && occA.allotments.length >= 1 && occB && occB.allotments.some((a) => a.guestName === "After cancel"),
+        `A=${occA && occA.allotments.length} B=${occB && occB.allotments.length}`);
+      check("pms: cancelled allotment absent from occupancy", occB && !occB.allotments.some((a) => a.status === "cancelled"));
+    }
+    const occBad = await api("GET", `/venues/${SLUG}/occupancy?from=${iso(day(10))}&to=${iso(day(6))}`, { token });
+    check("pms: occupancy to<=from -> 400", occBad.status === 400, `status ${occBad.status}`);
+
+    // ── day added to existing booking -> new day auto-seeds ──
+    const addDay = await api("PATCH", `/venues/${SLUG}/bookings/${bkId}`, {
+      token,
+      body: { days: [{ date: iso(day(7)), eventType: "Wedding", guestCount: 200 }, { date: iso(day(8)), eventType: "Reception", guestCount: 350 }, { date: iso(day(9)), eventType: "Brunch", guestCount: 80 }] },
+    });
+    const rs2 = await api("GET", `/venues/${SLUG}/bookings/${bkId}/runsheet`, { token });
+    const day9Items = rs2.json.items.filter((i) => i.day && i.day.slice(0, 10) === iso(day(9)).slice(0, 10));
+    check("pms: new booking day auto-seeds skeleton", addDay.status === 200 && day9Items.length === 3, `day9=${day9Items.length}`);
+  }
+
   finish();
 }
 

--- a/scripts/e2e-venue.js
+++ b/scripts/e2e-venue.js
@@ -647,6 +647,82 @@ async function run() {
     check("pms: new booking day auto-seeds skeleton", addDay.status === 200 && day9Items.length === 3, `day9=${day9Items.length}`);
   }
 
+  // ================= Phase 3.5: contracts (generate / edit / send / public ack / pdf) =================
+  if (process.env.E2E_CONTRACTS === "1") {
+    // Seed structured policies so generation has known content.
+    await api("PUT", `/venues/${SLUG}`, { token, body: { policyDoc: { policies: ["No outside DJ after 11pm"], terms: ["50% advance to confirm"], refund: ["No refund within 7 days"] } } });
+    const couplePhone = `95${Date.now() % 1e8}`;
+    const bk = await api("POST", `/venues/${SLUG}/bookings`, {
+      token,
+      body: { coupleName: "Contract Couple", couplePhone, totalValue: 400000, days: [{ date: new Date(Date.now() + 30 * 86400000).toISOString(), eventType: "Wedding", guestCount: 250 }], paymentSchedule: [{ label: "Advance", amount: 100000 }] },
+    });
+    const bkId = bk.json.booking._id;
+
+    // generate v1 — seeded from policyDoc + frozen specifics
+    const g1 = await api("POST", `/venues/${SLUG}/bookings/${bkId}/contracts`, { token });
+    const c1 = g1.json.contract;
+    check("contracts: generate v1 seeds from policyDoc",
+      g1.status === 201 && c1.version === 1 && c1.sections.length === 3
+        && c1.sections[0].clauses[0] === "No outside DJ after 11pm"
+        && c1.parties.coupleName === "Contract Couple"
+        && c1.specifics.totalValue === 400000,
+      `status ${g1.status} sections=${c1 && c1.sections.length}`);
+
+    // edit while draft
+    const ed = await api("PATCH", `/venues/${SLUG}/contracts/${c1._id}`, { token, body: { sections: [{ heading: "Venue Policies", clauses: ["No outside DJ after 11pm", "Decor by approved vendors only"] }] } });
+    check("contracts: edit draft sections -> 200", ed.status === 200 && ed.json.contract.sections[0].clauses.length === 2, `status ${ed.status}`);
+    const edBad = await api("PATCH", `/venues/${SLUG}/contracts/${c1._id}`, { token, body: { sections: [{ heading: "   ", clauses: ["x"] }] } });
+    check("contracts: blank section heading -> 400", edBad.status === 400, `status ${edBad.status}`);
+
+    // send -> public ack link
+    const sent = await api("POST", `/venues/${SLUG}/contracts/${c1._id}/send`, { token });
+    check("contracts: send -> sent + ack token", sent.status === 200 && sent.json.contract.status === "sent" && sent.json.contract.sentAt && sent.json.ackToken, `status ${sent.status}`);
+    const ackToken = sent.json.ackToken;
+
+    // public read (no auth) — phone masked
+    const pub = await api("GET", `/venues/contract-ack/${ackToken}`, {});
+    check("contracts: public ack GET shows contract, masks phone",
+      pub.status === 200 && pub.json.contract.sections.length === 1 && /•/.test(pub.json.contract.parties.couplePhone),
+      `status ${pub.status} phone=${pub.json.contract && pub.json.contract.parties.couplePhone}`);
+
+    // garbage + tampered tokens rejected
+    const badTok = await api("GET", `/venues/contract-ack/not-a-token`, {});
+    check("contracts: garbage token -> 401", badTok.status === 401, `status ${badTok.status}`);
+    const tampered = await api("POST", `/venues/contract-ack/${ackToken.slice(0, -2)}xx`, { body: { name: "X", phone: couplePhone } });
+    check("contracts: tampered token -> 401", tampered.status === 401, `status ${tampered.status}`);
+
+    // wrong phone -> 403; hostile name -> 400
+    const wrong = await api("POST", `/venues/contract-ack/${ackToken}`, { body: { name: "Impostor", phone: "9000000000" } });
+    check("contracts: wrong phone -> 403", wrong.status === 403, `status ${wrong.status}`);
+    const blankName = await api("POST", `/venues/contract-ack/${ackToken}`, { body: { name: "   ", phone: couplePhone } });
+    check("contracts: blank name -> 400", blankName.status === 400, `status ${blankName.status}`);
+
+    // right phone -> acknowledged + stamps
+    const ack = await api("POST", `/venues/contract-ack/${ackToken}`, { body: { name: "Contract Couple", phone: couplePhone } });
+    check("contracts: matching phone -> acknowledged", ack.status === 200 && ack.json.acknowledgedAt, `status ${ack.status}`);
+    const ackAgain = await api("POST", `/venues/contract-ack/${ackToken}`, { body: { name: "Again", phone: couplePhone } });
+    check("contracts: double-acknowledge -> 409", ackAgain.status === 409, `status ${ackAgain.status}`);
+
+    // pdf bytes
+    const pdf = await apiBinary(`/venues/${SLUG}/contracts/${c1._id}/pdf`, { token });
+    check("contracts: PDF returns bytes", pdf.status === 200 && pdf.head.startsWith("%PDF") && pdf.bytes > 800, `bytes=${pdf.bytes}`);
+
+    // new version supersedes (voids) prior non-acknowledged; acknowledged stays
+    const g2 = await api("POST", `/venues/${SLUG}/bookings/${bkId}/contracts`, { token });
+    check("contracts: v2 generated", g2.status === 201 && g2.json.contract.version === 2, `v=${g2.json.contract && g2.json.contract.version}`);
+    const both = await api("GET", `/venues/${SLUG}/bookings/${bkId}/contracts`, { token });
+    const v1After = both.json.contracts.find((c) => c.version === 1);
+    check("contracts: acknowledged v1 NOT voided by v2", v1After && v1After.status === "acknowledged", `v1=${v1After && v1After.status}`);
+    const g3 = await api("POST", `/venues/${SLUG}/bookings/${bkId}/contracts`, { token });
+    const all3 = await api("GET", `/venues/${SLUG}/bookings/${bkId}/contracts`, { token });
+    const v2After = all3.json.contracts.find((c) => c.version === 2);
+    check("contracts: draft v2 voided by v3 (supersede)", g3.status === 201 && v2After && v2After.status === "void", `v2=${v2After && v2After.status}`);
+
+    // draft-only editing: v1 (acknowledged) cannot be edited
+    const edAck = await api("PATCH", `/venues/${SLUG}/contracts/${c1._id}`, { token, body: { sections: [] } });
+    check("contracts: editing acknowledged contract -> 409", edAck.status === 409, `status ${edAck.status}`);
+  }
+
   finish();
 }
 

--- a/scripts/seed-test-venue.js
+++ b/scripts/seed-test-venue.js
@@ -23,6 +23,10 @@ try { VenueBooking = require("../models/VenueBooking"); } catch (_) {}
 try { VenueQuote = require("../models/VenueQuote"); } catch (_) {}
 try { VenueInvoice = require("../models/VenueInvoice"); } catch (_) {}
 try { VenueMessageTemplate = require("../models/VenueMessageTemplate"); } catch (_) {}
+let VenueRoomAllotment, VenueRoomNight, VenueRunsheetItem;
+try { VenueRoomAllotment = require("../models/VenueRoomAllotment"); } catch (_) {}
+try { VenueRoomNight = require("../models/VenueRoomNight"); } catch (_) {}
+try { VenueRunsheetItem = require("../models/VenueRunsheetItem"); } catch (_) {}
 try { VenueTeamMember = require("../models/VenueTeamMember"); } catch (_) {}
 try { ({ computeTotals } = require("../utils/venueMoney")); } catch (_) {}
 
@@ -122,6 +126,7 @@ async function run() {
     // (stale policyDoc/logo made the back-compat e2e checks order-dependent).
     venue.policyDoc = undefined;
     venue.logo = "";
+    venue.rooms = []; // Phase 5: rooms inventory is rebuilt by suites that need it
     await venue.save();
     console.log(`[seed] reset venue ${venue.slug} (${venue._id})`);
   }
@@ -153,6 +158,10 @@ async function run() {
   if (VenueBooking) await VenueBooking.deleteMany({ venue: venue._id });
   if (VenueQuote) await VenueQuote.deleteMany({ venue: venue._id });
   if (VenueInvoice) await VenueInvoice.deleteMany({ venue: venue._id });
+  // Phase 5 (PMS) collections — allotments/nights/runsheets are venue-scoped.
+  if (VenueRoomAllotment) await VenueRoomAllotment.deleteMany({ venue: venue._id });
+  if (VenueRoomNight) await VenueRoomNight.deleteMany({ venue: venue._id });
+  if (VenueRunsheetItem) await VenueRunsheetItem.deleteMany({ venue: venue._id });
 
   const enquiries = [];
   for (const spec of LEAD_SPECS) {

--- a/scripts/seed-test-venue.js
+++ b/scripts/seed-test-venue.js
@@ -117,6 +117,11 @@ async function run() {
     console.log(`[seed] created venue ${venue.slug} (${venue._id})`);
   } else {
     Object.assign(venue, venueDefaults);
+    // Fields that suites WRITE but the defaults above don't cover — clear them
+    // so a "reset" venue is actually deterministic across repeated runs
+    // (stale policyDoc/logo made the back-compat e2e checks order-dependent).
+    venue.policyDoc = undefined;
+    venue.logo = "";
     await venue.save();
     console.log(`[seed] reset venue ${venue.slug} (${venue._id})`);
   }

--- a/utils/venuePdf.js
+++ b/utils/venuePdf.js
@@ -116,4 +116,61 @@ function streamInvoicePdf(res, { venue, booking, invoice }) {
   doc.end();
 }
 
-module.exports = { streamQuotePdf, streamInvoicePdf };
+// Contract PDF (Phase 3.5) — numbered clause sections + booking specifics +
+// digital-acknowledgment block. NOTE: once the venue-logo support from
+// claude/venue-quality-sweep lands, wire loadLogoBuffer here too (punch list).
+function streamContractPdf(res, { venue, contract }) {
+  const doc = startDoc(res, `contract-v${contract.version || 1}.pdf`);
+  venueHeader(doc, venue, `Venue Contract  ·  v${contract.version || 1}`);
+
+  const parties = contract.parties || {};
+  const specifics = contract.specifics || {};
+  doc.fillColor(GREY).fontSize(10);
+  doc.text(`Between: ${parties.venueName || venue.name || "Venue"} and ${parties.coupleName || "—"}`);
+  doc.text(`Status: ${contract.status}${contract.sentAt ? `  ·  sent ${new Date(contract.sentAt).toDateString()}` : ""}`);
+  doc.moveDown(0.6);
+
+  // Booking specifics
+  doc.fillColor(BURGUNDY).fontSize(12).text("Booking Specifics");
+  doc.moveDown(0.2).fillColor("#222222").fontSize(10);
+  for (const d of specifics.days || []) {
+    doc.text(`• ${d.date ? new Date(d.date).toDateString() : "—"}${d.eventType ? ` — ${d.eventType}` : ""}${d.guestCount ? ` (${d.guestCount} guests)` : ""}`);
+  }
+  doc.text(`Total value: ${formatINR(specifics.totalValue || 0)}`);
+  if ((specifics.paymentSchedule || []).length) {
+    doc.moveDown(0.2).fillColor(GREY).text("Payment schedule:");
+    doc.fillColor("#222222");
+    for (const m of specifics.paymentSchedule) {
+      doc.text(`  – ${m.label || "Milestone"}: ${formatINR(m.amount || 0)}${m.dueDate ? ` due ${new Date(m.dueDate).toDateString()}` : ""}`);
+    }
+  }
+  doc.moveDown(0.8);
+
+  // Numbered clause sections
+  let clauseNo = 1;
+  for (const section of contract.sections || []) {
+    doc.fillColor(BURGUNDY).fontSize(12).text(section.heading || "Section");
+    doc.moveDown(0.2).fillColor("#222222").fontSize(10);
+    for (const clause of section.clauses || []) {
+      doc.text(`${clauseNo}. ${clause}`, { width: 495 });
+      doc.moveDown(0.15);
+      clauseNo += 1;
+    }
+    doc.moveDown(0.5);
+  }
+
+  // Digital acknowledgment block
+  doc.moveDown(0.8);
+  doc.moveTo(50, doc.y).lineTo(545, doc.y).strokeColor(GOLD).stroke();
+  doc.moveDown(0.4).fillColor(BURGUNDY).fontSize(12).text("Digital Acknowledgment");
+  doc.moveDown(0.2).fillColor(GREY).fontSize(9);
+  if (contract.status === "acknowledged") {
+    doc.text(`Acknowledged by ${contract.acknowledgmentName || "—"} on ${contract.acknowledgedAt ? new Date(contract.acknowledgedAt).toUTCString() : "—"} (phone verified against the booking).`);
+  } else {
+    doc.text("Pending — the couple acknowledges this contract through the secure link shared by the venue.");
+  }
+  doc.moveDown(0.3).text("This is a digital acknowledgment recorded by Wedsy on behalf of the venue, not an electronic signature service.", { width: 495 });
+  doc.end();
+}
+
+module.exports = { streamQuotePdf, streamInvoicePdf, streamContractPdf };

--- a/utils/venueRunsheet.js
+++ b/utils/venueRunsheet.js
@@ -1,0 +1,52 @@
+/**
+ * utils/venueRunsheet.js — default runsheet skeleton for new booking days.
+ * Seeded rows are ordinary items (editable, deletable) flagged seeded:true.
+ */
+const VenueRunsheetItem = require("../models/VenueRunsheetItem");
+
+const SKELETON = [
+  { time: "09:00", title: "Setup & decor begins", category: "setup", order: 0 },
+  { time: "18:00", title: "Event / ceremony", category: "ceremony", order: 1 },
+  { time: "23:00", title: "Teardown & handover", category: "teardown", order: 2 },
+];
+
+const dayKey = (d) => {
+  const x = new Date(d);
+  return new Date(Date.UTC(x.getUTCFullYear(), x.getUTCMonth(), x.getUTCDate()));
+};
+
+/**
+ * Seed the default skeleton for every booking day that has no runsheet items
+ * yet. Idempotent — existing days (even with all items deleted by hand after
+ * a prior seed… no: deleted-by-hand days WOULD reseed; so seeding only fires
+ * for days never seen, tracked by any-item-or-seeded-marker — we keep it
+ * simple and only seed days with zero items, which matches "auto-seed when a
+ * booking day is created").
+ */
+async function seedRunsheetForBooking(booking) {
+  if (!booking || !Array.isArray(booking.days) || booking.days.length === 0) return 0;
+  let seeded = 0;
+  const seen = new Set();
+  for (const day of booking.days) {
+    if (!day || !day.date) continue;
+    const key = dayKey(day.date);
+    const iso = key.toISOString();
+    if (seen.has(iso)) continue; // duplicate day entries get one runsheet
+    seen.add(iso);
+    const exists = await VenueRunsheetItem.exists({ booking: booking._id, day: key });
+    if (exists) continue;
+    await VenueRunsheetItem.insertMany(
+      SKELETON.map((s) => ({
+        ...s,
+        venue: booking.venue,
+        booking: booking._id,
+        day: key,
+        seeded: true,
+      }))
+    );
+    seeded += SKELETON.length;
+  }
+  return seeded;
+}
+
+module.exports = { seedRunsheetForBooking, dayKey, SKELETON };


### PR DESCRIPTION
STACKED ON claude/venue-pms — merge pms first; this diff shrinks to contracts-only once pms lands.

`VenueContract`: ordered clause sections seeded from the venue's effective policyDoc (same legacy-migration rules as the read path) plus booking facts frozen at generation; lifecycle draft (editable, policyDoc-style validation) → send (signed ack token, `CONTRACT_ACK_TTL_HOURS` default 168h) → digital acknowledgment; new versions void prior draft/sent but never an acknowledged contract. The one new public surface is the token-addressed ack route (GET shows the contract read-only with the couple's phone masked; POST stamps acknowledged only when the phone matches the booking) — rate-limited via publicReadLimiter and validated by jwt.verify + a dedicated token type, so other token kinds can't be replayed. PDF via venuePdf with numbered clauses and an acknowledgment block explicitly labelled "not an electronic signature service". E2E_CONTRACTS: 16/16.

Deploy in coordinated window only. New env (optional): CONTRACT_ACK_TTL_HOURS.

Review-assist verdict: 7/7 PASS — ack route confirmed rate-limited + token-validated (routes/venue.js:51-52, controllers/venueContract.js:166-169); money frozen server-side from the booking; full-lineage suites 128/128 e2e + 72/72 hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)