### PR TITLE
Hotfix: rate limiter vs MB4 chat polling — raise budget, exempt session-verify + conversation polling, dedicated strict login limiter

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -7,7 +7,18 @@ const auth = require("../controllers/auth");
 const authInternational = require("../controllers/auth.international");
 
 // Admin Auth
-router.post("/admin", auth.AdminLogin);
+// Login keeps a strict budget (20/15min/IP) so raising the general limiter
+// for chat polling doesn't loosen brute-force protection. Same localhost
+// skip as the general limiter so local e2e runs aren't throttled.
+const adminLoginLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 20,
+  message: { error: "Too many requests, please try again later." },
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: (req) => ["127.0.0.1", "::1", "::ffff:127.0.0.1"].includes(req.ip),
+});
+router.post("/admin", adminLoginLimiter, auth.AdminLogin);
 router.get("/admin", CheckLogin, auth.GetAdmin);
 // Settings Suite: resolved permissions for the caller (drives Settings UI visibility).
 router.get("/admin/permissions", CheckAdminLogin, auth.GetPermissions);

--- a/server.js
+++ b/server.js
@@ -44,12 +44,19 @@ app.use(bodyParser.json({
 //Rate limiting
 const limiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  max: 200,
+  max: 2000,
   message: { error: 'Too many requests, please try again later.' },
   standardHeaders: true,
   legacyHeaders: false,
   // Skip localhost — both IPv4 and IPv6 loopback (::1, and the IPv4-mapped form).
-  skip: (req) => ['127.0.0.1', '::1', '::ffff:127.0.0.1'].includes(req.ip), // skip localhost
+  // Also skip session verification and the chat polling reads: the Client File
+  // chat polls every 5s, which would saturate any per-IP budget and 429 the
+  // whole app. Auth on those routes still rejects unauthenticated callers;
+  // per-user keyed limits land in MB5.
+  skip: (req) =>
+    ['127.0.0.1', '::1', '::ffff:127.0.0.1'].includes(req.ip) || // skip localhost
+    (req.method === 'GET' &&
+      (req.path === '/auth/admin' || req.path.startsWith('/wa/conversations'))),
 });
 app.use(limiter);
 


### PR DESCRIPTION
## Problem

The global rate limiter (200 req/15min/IP) is mathematically saturated by MB4's chat polling: the Client File chat polls every 5s (~180 req/15min by itself) and the inbox every 30s. Any user with a chat open burns their entire budget, every subsequent request 429s, and the auth guard shows the retry screen app-wide.

## Changes (surgical — 2 files, +21/−3; the proper per-user rework lands in MB5)

- **General limiter raised 200 → 2000 req/15min/IP** (`server.js`).
- **Two GET exemptions from the general limiter**: `GET /auth/admin` (session verification must never self-lock a user) and `GET /wa/conversations*` (the polling reads). `CheckAdminLogin` still rejects unauthenticated callers fast, so exposure is bounded; per-user keyed limits arrive in MB5.
- **New `adminLoginLimiter` on `POST /auth/admin`**: strict 20 req/15min/IP, so the raised general budget doesn't weaken brute-force protection (login previously rode only the general limiter). `forgotLimiter` (5/hour) untouched.

## Verification (test port, X-Forwarded-For so the localhost skip doesn't mask the limiters)

- 300 × `GET /wa/conversations` and 300 × `GET /auth/admin` → zero 429s
- 30 × `POST /auth/admin` with bad creds → 429 from request 21 onward
- Lifecycle smoke: `/enquiry` and `/stats` respond normally
- Kiara e2e suite: 85 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)