### PR TITLE
MB5+6: Sales Engine v2 + Calendar/Attendance/Google + Instagram + 429 queue + MB4 bug fixes

### DIFF
--- a/controllers/attendance.js
+++ b/controllers/attendance.js
@@ -1,0 +1,68 @@
+const AttendanceService = require("../services/AttendanceService");
+
+const respond = (res, error) =>
+  res.status(error.status || 500).json({ message: error.message });
+
+// Live-meeting set for in_meeting status. Lazy-required so the attendance
+// brick has no hard dependency on the calendar brick (Slice 3 fills this in).
+const liveMeetingIds = async () => {
+  try {
+    const CalendarEventService = require("../services/CalendarEventService");
+    return await CalendarEventService.liveMeetingAdminIds();
+  } catch (_) {
+    return new Set();
+  }
+};
+
+const CheckIn = async (req, res) => {
+  try {
+    await AttendanceService.checkIn(req.auth.user_id);
+    res.status(200).json(await AttendanceService.me(req.auth.user_id, await liveMeetingIds()));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+const CheckOut = async (req, res) => {
+  try {
+    await AttendanceService.checkOut(req.auth.user_id);
+    res.status(200).json(await AttendanceService.me(req.auth.user_id, await liveMeetingIds()));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+const Heartbeat = async (req, res) => {
+  try {
+    await AttendanceService.heartbeat(req.auth.user_id);
+    res.status(200).json({ ok: true });
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+const Me = async (req, res) => {
+  try {
+    res.status(200).json(await AttendanceService.me(req.auth.user_id, await liveMeetingIds()));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+const Team = async (req, res) => {
+  try {
+    res
+      .status(200)
+      .json(
+        await AttendanceService.team(
+          { date: req.query.date },
+          req.scopeFilter || {},
+          await liveMeetingIds()
+        )
+      );
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+module.exports = { CheckIn, CheckOut, Heartbeat, Me, Team };

--- a/controllers/calendar.js
+++ b/controllers/calendar.js
@@ -1,0 +1,126 @@
+const CalendarEventService = require("../services/CalendarEventService");
+const AdminNotificationService = require("../services/AdminNotificationService");
+
+const respond = (res, error) =>
+  res.status(error.status || 500).json({ message: error.message });
+
+const Team = async (req, res) => {
+  try {
+    res.status(200).json(
+      await CalendarEventService.teamCalendar(
+        { from: req.query.from, to: req.query.to },
+        req.scopeFilter || {}
+      )
+    );
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+const Create = async (req, res) => {
+  try {
+    res.status(201).json(await CalendarEventService.createEvent(req.auth.user_id, req.body || {}));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+const SaveNotes = async (req, res) => {
+  try {
+    res
+      .status(200)
+      .json(await CalendarEventService.saveNotes(req.params.id, req.auth.user_id, (req.body || {}).notes));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+const Close = async (req, res) => {
+  try {
+    res.status(200).json(await CalendarEventService.closeMeeting(req.params.id, req.auth.user_id, req.body || {}));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+const MeetingMode = async (req, res) => {
+  try {
+    res.status(200).json(await CalendarEventService.meetingMode(req.auth.user_id));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+const Unclosed = async (req, res) => {
+  try {
+    res.status(200).json({ list: await CalendarEventService.unclosedList(req.scopeFilter || {}) });
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+const CompleteHuddle = async (req, res) => {
+  try {
+    res
+      .status(200)
+      .json(await CalendarEventService.completeHuddle(req.params.id, req.auth.user_id, req.body || {}));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+const LeadEvents = async (req, res) => {
+  try {
+    res.status(200).json(await CalendarEventService.leadEvents(req.params.leadId));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// ── Admin notifications (in-OS dashboard entries) ─────────────────────────────
+
+const MyNotifications = async (req, res) => {
+  try {
+    const list = await AdminNotificationService.listMine(req.auth.user_id, {
+      unreadOnly: req.query.unread === "true",
+      limit: parseInt(req.query.limit, 10) || 50,
+    });
+    const unread = await AdminNotificationService.unreadCount(req.auth.user_id);
+    res.status(200).json({ list, unread });
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+const MarkRead = async (req, res) => {
+  try {
+    const updated = await AdminNotificationService.markRead(req.auth.user_id, req.params.id);
+    if (!updated) return res.status(404).json({ message: "Notification not found" });
+    res.status(200).json(updated);
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+const MarkAllRead = async (req, res) => {
+  try {
+    await AdminNotificationService.markAllRead(req.auth.user_id);
+    res.status(200).json({ ok: true });
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+module.exports = {
+  Team,
+  Create,
+  SaveNotes,
+  Close,
+  MeetingMode,
+  Unclosed,
+  CompleteHuddle,
+  LeadEvents,
+  MyNotifications,
+  MarkRead,
+  MarkAllRead,
+};

--- a/controllers/enquiry-cockpit.js
+++ b/controllers/enquiry-cockpit.js
@@ -48,6 +48,18 @@ const UpdateQualification = async (req, res) => {
   }
 };
 
+// POST /enquiry/:_id/meet-refused (MB6 Slice 6)
+const MeetRefused = async (req, res) => {
+  try {
+    const updated = await CallCockpitService.meetRefused(req.params._id, req.auth.user_id);
+    res.status(200).json(updated);
+  } catch (error) {
+    const status = error.status || 500;
+    const message = status === 500 ? "Server error" : error.message;
+    res.status(status).json({ message });
+  }
+};
+
 // POST /enquiry/:_id/call-complete
 const CompleteCall = async (req, res) => {
   try {
@@ -80,6 +92,7 @@ module.exports = {
   LogCall,
   AddFollowUp,
   UpdateQualification,
+  MeetRefused,
   CompleteCall,
   GetInternalEvents,
 };

--- a/controllers/enquiry.js
+++ b/controllers/enquiry.js
@@ -338,6 +338,10 @@ const GetAll = async (req, res) => {
         query.stage = "meeting_scheduled";
       } else if (view === "recycled") {
         query["recycled.isRecycled"] = true;
+      } else if (view === "triage") {
+        // MB5 Slice 4: the triage queue as a leads filter.
+        query.triagePending = true;
+        query["recycled.isRecycled"] = { $ne: true };
       }
     }
     if (date) {

--- a/controllers/google.js
+++ b/controllers/google.js
@@ -1,0 +1,73 @@
+const GoogleWorkspaceService = require("../services/GoogleWorkspaceService");
+
+const respond = (res, error) =>
+  res.status(error.status || 500).json({ message: error.message });
+
+const Start = async (req, res) => {
+  try {
+    res.status(200).json({ url: GoogleWorkspaceService.startUrl(req.auth.user_id) });
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// Browser redirect target — no Authorization header here; identity rides the
+// signed state. Renders a tiny self-closing page.
+const Callback = async (req, res) => {
+  try {
+    const { code, state } = req.query;
+    if (!code || !state) return res.status(400).send("Missing code/state");
+    const account = await GoogleWorkspaceService.handleCallback(code, state);
+    res
+      .status(200)
+      .send(
+        `<html><body style="font-family:sans-serif;padding:40px;text-align:center">` +
+          `<h2>Google connected ✓</h2><p>${account.email || ""} is linked to Wedsy OS.</p>` +
+          `<p>You can close this tab and head back.</p></body></html>`
+      );
+  } catch (error) {
+    res
+      .status(error.status || 500)
+      .send(`<html><body style="font-family:sans-serif;padding:40px;text-align:center"><h2>Link failed</h2><p>${error.message}</p></body></html>`);
+  }
+};
+
+const Status = async (req, res) => {
+  try {
+    res.status(200).json(await GoogleWorkspaceService.status(req.auth.user_id));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+const Disconnect = async (req, res) => {
+  try {
+    res.status(200).json(await GoogleWorkspaceService.disconnect(req.auth.user_id));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+const Availability = async (req, res) => {
+  try {
+    res.status(200).json(
+      await GoogleWorkspaceService.availability(req.query.leadId, {
+        from: req.query.from,
+        days: parseInt(req.query.days, 10) || 5,
+      })
+    );
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+const Book = async (req, res) => {
+  try {
+    const { leadId, start, end } = req.body || {};
+    res.status(200).json(await GoogleWorkspaceService.bookMeet(leadId, { start, end }, req.auth.user_id));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+module.exports = { Start, Callback, Status, Disconnect, Availability, Book };

--- a/controllers/savedViews.js
+++ b/controllers/savedViews.js
@@ -1,0 +1,94 @@
+const mongoose = require("mongoose");
+const SavedView = require("../models/SavedView");
+const { buildFilterConditions } = require("../utils/leadFilterBuilder");
+
+const respond = (res, error) =>
+  res.status(error.status || 500).json({ message: error.message });
+const httpError = (status, message) => Object.assign(new Error(message), { status });
+
+const LIFECYCLE_VIEWS = ["", "active", "meeting", "won", "recycled", "lost", "triage"];
+
+const validateBody = async ({ name, filters, view }) => {
+  if (name !== undefined && (typeof name !== "string" || !name.trim() || name.length > 60)) {
+    throw httpError(400, "name must be a string of 1–60 chars");
+  }
+  if (filters !== undefined) {
+    if (!Array.isArray(filters)) throw httpError(400, "filters must be an array");
+    await buildFilterConditions(filters); // strict whitelist — throws 400 on junk
+  }
+  if (view !== undefined && !LIFECYCLE_VIEWS.includes(view)) {
+    throw httpError(400, "Unknown view");
+  }
+};
+
+const List = async (req, res) => {
+  try {
+    const list = await SavedView.find({ adminId: req.auth.user_id }).sort({ createdAt: 1 }).lean();
+    res.status(200).json({ list });
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+const Create = async (req, res) => {
+  try {
+    const { name, filters = [], view = "", isDefault = false } = req.body || {};
+    if (!name) throw httpError(400, "name is required");
+    await validateBody({ name, filters, view });
+    if (isDefault) {
+      await SavedView.updateMany({ adminId: req.auth.user_id }, { $set: { isDefault: false } });
+    }
+    const created = await SavedView.create({
+      adminId: req.auth.user_id,
+      name: name.trim(),
+      filters,
+      view,
+      isDefault: !!isDefault,
+    });
+    res.status(201).json(created);
+  } catch (error) {
+    if (error.code === 11000) return res.status(409).json({ message: "You already have a view with that name" });
+    respond(res, error);
+  }
+};
+
+const Update = async (req, res) => {
+  try {
+    if (!mongoose.Types.ObjectId.isValid(req.params.id)) throw httpError(400, "Invalid id");
+    const { name, filters, view, isDefault } = req.body || {};
+    await validateBody({ name, filters, view });
+    const set = {};
+    if (name !== undefined) set.name = name.trim();
+    if (filters !== undefined) set.filters = filters;
+    if (view !== undefined) set.view = view;
+    if (isDefault !== undefined) {
+      if (isDefault) {
+        await SavedView.updateMany({ adminId: req.auth.user_id }, { $set: { isDefault: false } });
+      }
+      set.isDefault = !!isDefault;
+    }
+    const updated = await SavedView.findOneAndUpdate(
+      { _id: req.params.id, adminId: req.auth.user_id },
+      { $set: set },
+      { new: true }
+    );
+    if (!updated) throw httpError(404, "Saved view not found");
+    res.status(200).json(updated);
+  } catch (error) {
+    if (error.code === 11000) return res.status(409).json({ message: "You already have a view with that name" });
+    respond(res, error);
+  }
+};
+
+const Delete = async (req, res) => {
+  try {
+    if (!mongoose.Types.ObjectId.isValid(req.params.id)) throw httpError(400, "Invalid id");
+    const deleted = await SavedView.findOneAndDelete({ _id: req.params.id, adminId: req.auth.user_id });
+    if (!deleted) throw httpError(404, "Saved view not found");
+    res.status(200).json({ ok: true });
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+module.exports = { List, Create, Update, Delete };

--- a/controllers/settings.js
+++ b/controllers/settings.js
@@ -64,6 +64,12 @@ const GetPublic = async (req, res) => {
       "golden.windowMinutes",
       "golden.workStartHour",
       "golden.workEndHour",
+      // MB6 Slice 6: the cockpit reads these without settings permissions.
+      "services.available",
+      "cockpit.briefScript",
+      "cockpit.servicesScript",
+      "cockpit.budgetScript",
+      "cockpit.qualificationIntro",
     ]);
     res.status(200).json(values);
   } catch (error) {

--- a/controllers/triage.js
+++ b/controllers/triage.js
@@ -1,0 +1,31 @@
+const TriageService = require("../services/TriageService");
+
+const respond = (res, error) =>
+  res.status(error.status || 500).json({ message: error.message });
+
+const List = async (req, res) => {
+  try {
+    res.status(200).json({ list: await TriageService.listTriage() });
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+const Interns = async (req, res) => {
+  try {
+    res.status(200).json({ list: await TriageService.internsWithStatus() });
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+const Assign = async (req, res) => {
+  try {
+    const toAdminId = (req.body || {}).adminId || req.auth.user_id; // omitted → take it myself
+    res.status(200).json(await TriageService.assign(req.params._id, toAdminId, req.auth.user_id));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+module.exports = { List, Interns, Assign };

--- a/models/AdminNotification.js
+++ b/models/AdminNotification.js
@@ -1,0 +1,24 @@
+const mongoose = require("mongoose");
+const ObjectId = mongoose.Schema.Types.ObjectId;
+
+// In-OS dashboard notification entries for ADMINS (MB5). The OS notifies staff
+// here — no WhatsApp/SMS pings to staff in this build. Surfaced on the
+// dashboard bell/strip; read-state per recipient.
+const AdminNotificationSchema = new mongoose.Schema(
+  {
+    adminId: { type: ObjectId, ref: "Admin", required: true, index: true },
+    type: { type: String, required: true }, // e.g. meet_handoff, huddle_due, triage_escalation
+    title: { type: String, required: true },
+    message: { type: String, default: "" },
+    leadId: { type: ObjectId, ref: "Enquiry", default: null },
+    payload: { type: Object, default: {} },
+    read: { type: Boolean, default: false },
+  },
+  { timestamps: true }
+);
+
+AdminNotificationSchema.index({ adminId: 1, read: 1, createdAt: -1 });
+
+module.exports =
+  mongoose.models.AdminNotification ||
+  mongoose.model("AdminNotification", AdminNotificationSchema);

--- a/models/Attendance.js
+++ b/models/Attendance.js
@@ -1,0 +1,37 @@
+const mongoose = require("mongoose");
+const ObjectId = mongoose.Schema.Types.ObjectId;
+
+// HRMS brick #1 (MB5 Slice 2): one row per admin per IST day. Timestamps are
+// permanent — payroll inherits this later. Idle is DERIVED from activity
+// heartbeats (gaps > 5 min while checked in), in-OS activity only — no screen
+// capture, and the employee sees their own numbers (transparency rule).
+const AttendanceSchema = new mongoose.Schema(
+  {
+    adminId: { type: ObjectId, ref: "Admin", required: true, index: true },
+    // IST calendar day "YYYY-MM-DD" — the uniqueness key with adminId.
+    date: { type: String, required: true },
+    checkInAt: { type: Date, required: true },
+    checkOutAt: { type: Date, default: null },
+    // Last activity ping (60s cadence from an active tab). Drives idle derivation.
+    lastHeartbeatAt: { type: Date, default: null },
+    // Closed idle windows: gap > 5 min between heartbeats while checked in.
+    idleSegments: {
+      type: [
+        {
+          from: { type: Date, required: true },
+          to: { type: Date, required: true },
+        },
+      ],
+      default: [],
+    },
+    // Denormalized sum of idleSegments (ms) — cheap reads for lists/payroll.
+    idleMs: { type: Number, default: 0 },
+  },
+  { timestamps: true }
+);
+
+AttendanceSchema.index({ adminId: 1, date: 1 }, { unique: true });
+AttendanceSchema.index({ date: 1 });
+
+module.exports =
+  mongoose.models.Attendance || mongoose.model("Attendance", AttendanceSchema);

--- a/models/CalendarEvent.js
+++ b/models/CalendarEvent.js
@@ -1,0 +1,59 @@
+const mongoose = require("mongoose");
+const ObjectId = mongoose.Schema.Types.ObjectId;
+
+// Team calendar (MB5 Slice 3). One row per scheduled item on an employee's
+// calendar. Sources: meet/visit follow-ups mirror in automatically, manual
+// blocks, huddles (auto-created when a gmeet follow-up is booked), and
+// Google-created meets (googleEventId set, Slice 8).
+//
+// Meeting lifecycle: status stays "scheduled" while live/over; closing REQUIRES
+// notes (the meeting-notes gate). A past-end meeting still "scheduled" is an
+// UNCLOSED meeting — pinned on the owner's dashboard and blocking their next one.
+const CalendarEventSchema = new mongoose.Schema(
+  {
+    ownerId: { type: ObjectId, ref: "Admin", required: true, index: true },
+    type: {
+      type: String,
+      enum: ["meeting", "gmeet", "huddle", "visit", "block"],
+      required: true,
+    },
+    leadId: { type: ObjectId, ref: "Enquiry", default: null, index: true },
+    title: { type: String, required: true },
+    start: { type: Date, required: true },
+    end: { type: Date, required: true },
+    participantIds: { type: [{ type: ObjectId, ref: "Admin" }], default: [] },
+    googleEventId: { type: String, default: "" },
+    status: {
+      type: String,
+      enum: ["scheduled", "closed", "cancelled"],
+      default: "scheduled",
+    },
+    // Mirror linkage: the followUp subdoc id this event was created from.
+    followUpId: { type: ObjectId, default: null },
+    // Meeting-mode notes (draft while live, mandatory at close).
+    notes: { type: String, default: "" },
+    closedAt: { type: Date, default: null },
+    closedBy: { type: ObjectId, ref: "Admin", default: null },
+    // Huddle completion payload (type "huddle" only).
+    huddleOutcome: {
+      attendeeIds: { type: [{ type: ObjectId, ref: "Admin" }], default: [] },
+      eventTeam: {
+        type: [
+          {
+            adminId: { type: ObjectId, ref: "Admin", required: true },
+            label: { type: String, default: "" },
+          },
+        ],
+        default: [],
+      },
+    },
+  },
+  { timestamps: true }
+);
+
+CalendarEventSchema.index({ ownerId: 1, start: 1 });
+CalendarEventSchema.index({ leadId: 1, type: 1 });
+CalendarEventSchema.index({ status: 1, end: 1 });
+
+module.exports =
+  mongoose.models.CalendarEvent || mongoose.model("CalendarEvent", CalendarEventSchema);

--- a/models/Enquiry.js
+++ b/models/Enquiry.js
@@ -128,6 +128,13 @@ const EnquirySchema = new mongoose.Schema(
       emailNotWilling: { type: Boolean, default: false },
       whatsappSameNumber: { type: Boolean, default: true },
       whatsappNumber: { type: String, default: "" },
+      // ── MB6 Slice 6 (additive) — Cockpit v2 qualification fields ─────────
+      // Multi-select from the services.available master list.
+      servicesRequired: { type: [String], default: [] },
+      budgetAmount: { type: Number, default: null },
+      budgetNote: { type: String, default: "" },
+      // Partner/fiancé emails — Slice 8's calendar invites include these.
+      additionalEmails: { type: [String], default: [] },
     },
     // Outcome of the cockpit's complete-call action. gaps holds the missing items
     // acknowledged on an incomplete save (flagged on the lead, per the approved design).

--- a/models/Enquiry.js
+++ b/models/Enquiry.js
@@ -149,6 +149,12 @@ const EnquirySchema = new mongoose.Schema(
     unresponsiveFlaggedAt: { type: Date, default: null },
     // CSV import marker: historical imports are excluded from auto-assignment.
     importedAt: { type: Date, default: null },
+    // ── MB5 Slice 4 (additive only) — triage mode ───────────────────────────
+    // In assignment.mode='triage', new leads land here unassigned until a
+    // triage holder assigns them (or the escalation chain auto-assigns).
+    triagePending: { type: Boolean, default: false },
+    triageEnteredAt: { type: Date, default: null },
+    triageEscalatedAt: { type: Date, default: null },
     // ── MB5 Slice 3 (additive only) ─────────────────────────────────────────
     // Set-once credit: the intern who booked the meet that triggered the
     // handoff. Their stats keep this lead permanently.

--- a/models/Enquiry.js
+++ b/models/Enquiry.js
@@ -149,6 +149,20 @@ const EnquirySchema = new mongoose.Schema(
     unresponsiveFlaggedAt: { type: Date, default: null },
     // CSV import marker: historical imports are excluded from auto-assignment.
     importedAt: { type: Date, default: null },
+    // ── MB5 Slice 3 (additive only) ─────────────────────────────────────────
+    // Set-once credit: the intern who booked the meet that triggered the
+    // handoff. Their stats keep this lead permanently.
+    qualifiedBy: { type: ObjectId, ref: "Admin", default: null },
+    // Lightweight event-team assignments captured at huddle completion.
+    eventTeam: {
+      type: [
+        {
+          adminId: { type: ObjectId, ref: "Admin", required: true },
+          label: { type: String, default: "" },
+        },
+      ],
+      default: [],
+    },
     // Recycle — the third terminal state. Excluded from all active views while
     // isRecycled; lazily resurfaced (and reassigned) once revisitAt passes.
     recycled: {

--- a/models/Enquiry.js
+++ b/models/Enquiry.js
@@ -149,6 +149,11 @@ const EnquirySchema = new mongoose.Schema(
     unresponsiveFlaggedAt: { type: Date, default: null },
     // CSV import marker: historical imports are excluded from auto-assignment.
     importedAt: { type: Date, default: null },
+    // ── MB5 Slice 5 (additive only) — Kiara safety net engagement marker ────
+    // Set once when the safety net sends the welcome template (after-hours
+    // create or golden-window miss). Gates the once-per-lead rule and joins
+    // the lead into mission-quiet.
+    kiaraSafetyNetAt: { type: Date, default: null },
     // ── MB5 Slice 4 (additive only) — triage mode ───────────────────────────
     // In assignment.mode='triage', new leads land here unassigned until a
     // triage holder assigns them (or the escalation chain auto-assigns).

--- a/models/GoogleAccount.js
+++ b/models/GoogleAccount.js
@@ -1,0 +1,19 @@
+const mongoose = require("mongoose");
+const ObjectId = mongoose.Schema.Types.ObjectId;
+
+// MB6 Slice 8 — one linked Google account per admin (OAuth offline access).
+// The refresh token is the durable credential; access tokens are minted on
+// demand and never stored.
+const GoogleAccountSchema = new mongoose.Schema(
+  {
+    adminId: { type: ObjectId, ref: "Admin", required: true, unique: true },
+    email: { type: String, required: true },
+    refreshToken: { type: String, required: true },
+    scopes: { type: [String], default: [] },
+    linkedAt: { type: Date, default: Date.now },
+  },
+  { timestamps: true }
+);
+
+module.exports =
+  mongoose.models.GoogleAccount || mongoose.model("GoogleAccount", GoogleAccountSchema);

--- a/models/SavedView.js
+++ b/models/SavedView.js
@@ -1,0 +1,21 @@
+const mongoose = require("mongoose");
+const ObjectId = mongoose.Schema.Types.ObjectId;
+
+// MB6 Slice 9 — per-user named filter sets for the leads page. The filters
+// array is the same {field,op,value}[] shape the filter builder validates;
+// it is re-validated on save AND on every use (the builder runs at read time).
+const SavedViewSchema = new mongoose.Schema(
+  {
+    adminId: { type: ObjectId, ref: "Admin", required: true, index: true },
+    name: { type: String, required: true },
+    filters: { type: [Object], default: [] },
+    // Optional lifecycle chip ("active"|"meeting"|"won"|"recycled"|"lost"|"triage").
+    view: { type: String, default: "" },
+    isDefault: { type: Boolean, default: false },
+  },
+  { timestamps: true }
+);
+
+SavedViewSchema.index({ adminId: 1, name: 1 }, { unique: true });
+
+module.exports = mongoose.models.SavedView || mongoose.model("SavedView", SavedViewSchema);

--- a/models/WAConversation.js
+++ b/models/WAConversation.js
@@ -15,6 +15,10 @@ const WAConversationSchema = new mongoose.Schema(
   {
     phone: { type: String, required: true, unique: true },
     normalizedPhone: { type: String, default: "", index: true },
+    // MB6 Slice 7: conversation channel. Instagram rows key `phone` by the
+    // IG-scoped user id (the same key WAAgentMessage already uses for IG).
+    // Default keeps every existing row 'whatsapp' — migration-free.
+    channel: { type: String, enum: ["whatsapp", "instagram"], default: "whatsapp" },
     enquiryId: { type: ObjectId, ref: "Enquiry", default: null },
     mode: { type: String, enum: ["ai", "human"], default: "ai" },
     needsHuman: { type: Boolean, default: false },

--- a/repositories/WAConversationRepository.js
+++ b/repositories/WAConversationRepository.js
@@ -7,7 +7,7 @@ const findById = async (id) => WAConversation.findById(id);
 // Inbound message touch: create the conversation on first contact, bump the
 // freshness fields and the unread counter on every one after. Atomic upsert —
 // concurrent webhook deliveries can't double-create.
-const upsertOnInbound = async (phone, normalizedPhone, preview, at = new Date()) =>
+const upsertOnInbound = async (phone, normalizedPhone, preview, at = new Date(), channel = "whatsapp") =>
   WAConversation.findOneAndUpdate(
     { phone },
     {
@@ -17,6 +17,8 @@ const upsertOnInbound = async (phone, normalizedPhone, preview, at = new Date())
         lastMessageAt: at,
         lastMessagePreview: preview,
       },
+      // Channel is identity, not state — written once at creation.
+      $setOnInsert: { channel },
       $inc: { unreadCount: 1 },
     },
     { upsert: true, new: true, setDefaultsOnInsert: true }

--- a/routes/attendance.js
+++ b/routes/attendance.js
@@ -1,0 +1,24 @@
+const express = require("express");
+const router = express.Router();
+
+const controller = require("../controllers/attendance");
+const { CheckAdminLogin } = require("../middlewares/auth");
+const { requirePermission } = require("../middlewares/requirePermission");
+
+// Everyone manages their own check-in/heartbeat and sees their own status.
+router.post("/check-in", CheckAdminLogin, controller.CheckIn);
+router.post("/check-out", CheckAdminLogin, controller.CheckOut);
+router.post("/heartbeat", CheckAdminLogin, controller.Heartbeat);
+router.get("/me", CheckAdminLogin, controller.Me);
+
+// Team visibility follows the EXISTING lead-scope semantics (own/team/all),
+// keyed on the attendance row's adminId: own → self, team → subordinates,
+// all (Revenue Head / founder) → the whole daily list.
+router.get(
+  "/team",
+  CheckAdminLogin,
+  requirePermission("leads:view:own", { ownerField: "adminId" }),
+  controller.Team
+);
+
+module.exports = router;

--- a/routes/calendar.js
+++ b/routes/calendar.js
@@ -1,0 +1,42 @@
+const express = require("express");
+const router = express.Router();
+
+const controller = require("../controllers/calendar");
+const { CheckAdminLogin } = require("../middlewares/auth");
+const { requirePermission } = require("../middlewares/requirePermission");
+
+// Team calendar grid — visibility rides the lead-scope semantics keyed on the
+// event owner (own → my row, team → my people, all → everyone).
+router.get(
+  "/team",
+  CheckAdminLogin,
+  requirePermission("leads:view:own", { ownerField: "ownerId" }),
+  controller.Team
+);
+
+// Own calendar operations.
+router.post("/events", CheckAdminLogin, controller.Create);
+router.put("/events/:id/notes", CheckAdminLogin, controller.SaveNotes);
+router.post("/events/:id/close", CheckAdminLogin, controller.Close);
+router.get("/meeting-mode", CheckAdminLogin, controller.MeetingMode);
+
+// Unclosed-meetings oversight (Revenue Head / managers — team+ scope).
+router.get(
+  "/unclosed",
+  CheckAdminLogin,
+  requirePermission("leads:view:team", { ownerField: "ownerId" }),
+  controller.Unclosed
+);
+
+// Huddles.
+router.post("/huddles/:id/complete", CheckAdminLogin, controller.CompleteHuddle);
+
+// Calendar items for one lead (Client File chip).
+router.get(
+  "/lead/:leadId",
+  CheckAdminLogin,
+  requirePermission("leads:view:own", { ownerField: "assignedTo" }),
+  controller.LeadEvents
+);
+
+module.exports = router;

--- a/routes/enquiry.js
+++ b/routes/enquiry.js
@@ -25,6 +25,22 @@ router.get(
 // MB5 Slice 4: triage queue (literal paths above /:_id). leads:triage is the
 // new permission — seed-granted to sales-lead-class roles; founder wildcard covers.
 const triage = require("../controllers/triage");
+// MB6 Slice 10: intern/presales rollup (derived only, scope-aware).
+router.get(
+  "/intern-metrics",
+  CheckAdminLogin,
+  requirePermission("leads:view:own", { ownerField: "assignedTo" }),
+  async (req, res) => {
+    try {
+      const InternMetricsService = require("../services/InternMetricsService");
+      res
+        .status(200)
+        .json(await InternMetricsService.internMetrics({ period: req.query.period }, req.scopeFilter || {}));
+    } catch (error) {
+      res.status(error.status || 500).json({ message: error.message });
+    }
+  }
+);
 router.get("/triage", CheckAdminLogin, requirePermission("leads:triage:own"), triage.List);
 router.get("/triage/interns", CheckAdminLogin, requirePermission("leads:triage:own"), triage.Interns);
 router.post(

--- a/routes/enquiry.js
+++ b/routes/enquiry.js
@@ -22,6 +22,17 @@ router.get(
   requirePermission("leads:view:own", { ownerField: "assignedTo" }),
   lifecycle.Dashboard
 );
+// MB5 Slice 4: triage queue (literal paths above /:_id). leads:triage is the
+// new permission — seed-granted to sales-lead-class roles; founder wildcard covers.
+const triage = require("../controllers/triage");
+router.get("/triage", CheckAdminLogin, requirePermission("leads:triage:own"), triage.List);
+router.get("/triage/interns", CheckAdminLogin, requirePermission("leads:triage:own"), triage.Interns);
+router.post(
+  "/:_id/triage-assign",
+  CheckAdminLogin,
+  requirePermission("leads:triage:own"),
+  triage.Assign
+);
 // Lifecycle (Slice F): founder CSV import (the Zoho migration tool). Literal
 // paths above /:_id; multipart handled per-route via express-fileupload.
 router.get(

--- a/routes/enquiry.js
+++ b/routes/enquiry.js
@@ -105,6 +105,13 @@ router.put(
   requirePermission("leads:edit:own"),
   cockpit.UpdateQualification
 );
+// MB6 Slice 6: the lead refuses a meeting — tag, escalate, notify.
+router.post(
+  "/:_id/meet-refused",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own"),
+  cockpit.MeetRefused
+);
 router.post(
   "/:_id/call-complete",
   CheckAdminLogin,

--- a/routes/google.js
+++ b/routes/google.js
@@ -1,0 +1,31 @@
+const express = require("express");
+const router = express.Router();
+
+const controller = require("../controllers/google");
+const { CheckAdminLogin } = require("../middlewares/auth");
+const { requirePermission } = require("../middlewares/requirePermission");
+
+// OAuth — start needs a session; the callback is a bare browser redirect
+// (identity travels in the signed state).
+router.get("/oauth/start", CheckAdminLogin, controller.Start);
+router.get("/oauth/callback", controller.Callback);
+
+// Settings → My Account.
+router.get("/status", CheckAdminLogin, controller.Status);
+router.delete("/link", CheckAdminLogin, controller.Disconnect);
+
+// Booking flow (cockpit finale / meet scheduler).
+router.get(
+  "/availability",
+  CheckAdminLogin,
+  requirePermission("leads:view:own", { ownerField: "assignedTo" }),
+  controller.Availability
+);
+router.post(
+  "/book",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own", { ownerField: "assignedTo" }),
+  controller.Book
+);
+
+module.exports = router;

--- a/routes/notifications.js
+++ b/routes/notifications.js
@@ -1,0 +1,12 @@
+const express = require("express");
+const router = express.Router();
+
+const controller = require("../controllers/calendar");
+const { CheckAdminLogin } = require("../middlewares/auth");
+
+// In-OS dashboard notification entries — always own-only.
+router.get("/", CheckAdminLogin, controller.MyNotifications);
+router.put("/read-all", CheckAdminLogin, controller.MarkAllRead);
+router.put("/:id/read", CheckAdminLogin, controller.MarkRead);
+
+module.exports = router;

--- a/routes/router.js
+++ b/routes/router.js
@@ -81,5 +81,6 @@ router.use("/places", require("./places"));
 router.use("/venue-owner", require("./venueOwner"));
 router.use("/conversations", require("./conversation"));
 router.use("/wa", require("./waConversation")); // Kiara admin chat API
+router.use("/attendance", require("./attendance")); // HRMS brick #1 (MB5 Slice 2)
 
 module.exports = router;

--- a/routes/router.js
+++ b/routes/router.js
@@ -85,5 +85,6 @@ router.use("/attendance", require("./attendance")); // HRMS brick #1 (MB5 Slice 
 router.use("/calendar", require("./calendar")); // Team calendar + meeting mode + huddles (MB5 Slice 3)
 router.use("/admin-notifications", require("./notifications")); // in-OS staff notifications (MB5)
 router.use("/google", require("./google")); // Google Workspace (MB6 Slice 8 — dormant until env-wired)
+router.use("/saved-views", require("./savedViews")); // per-user leads filter sets (MB6 Slice 9)
 
 module.exports = router;

--- a/routes/router.js
+++ b/routes/router.js
@@ -84,5 +84,6 @@ router.use("/wa", require("./waConversation")); // Kiara admin chat API
 router.use("/attendance", require("./attendance")); // HRMS brick #1 (MB5 Slice 2)
 router.use("/calendar", require("./calendar")); // Team calendar + meeting mode + huddles (MB5 Slice 3)
 router.use("/admin-notifications", require("./notifications")); // in-OS staff notifications (MB5)
+router.use("/google", require("./google")); // Google Workspace (MB6 Slice 8 — dormant until env-wired)
 
 module.exports = router;

--- a/routes/router.js
+++ b/routes/router.js
@@ -82,5 +82,7 @@ router.use("/venue-owner", require("./venueOwner"));
 router.use("/conversations", require("./conversation"));
 router.use("/wa", require("./waConversation")); // Kiara admin chat API
 router.use("/attendance", require("./attendance")); // HRMS brick #1 (MB5 Slice 2)
+router.use("/calendar", require("./calendar")); // Team calendar + meeting mode + huddles (MB5 Slice 3)
+router.use("/admin-notifications", require("./notifications")); // in-OS staff notifications (MB5)
 
 module.exports = router;

--- a/routes/savedViews.js
+++ b/routes/savedViews.js
@@ -1,0 +1,13 @@
+const express = require("express");
+const router = express.Router();
+
+const controller = require("../controllers/savedViews");
+const { CheckAdminLogin } = require("../middlewares/auth");
+
+// Per-user named filter sets — always own-only.
+router.get("/", CheckAdminLogin, controller.List);
+router.post("/", CheckAdminLogin, controller.Create);
+router.put("/:id", CheckAdminLogin, controller.Update);
+router.delete("/:id", CheckAdminLogin, controller.Delete);
+
+module.exports = router;

--- a/scripts/backfill-whatsapp-leads.js
+++ b/scripts/backfill-whatsapp-leads.js
@@ -1,0 +1,95 @@
+/* MB5 Slice 1 — Bug A backfill.
+ *
+ * Patches existing source-whatsapp Enquiry docs that are missing the
+ * create-path fields a manually created lead always has (stage and the
+ * boolean flags). The board renders only configured stage columns, so a
+ * lead with a missing/empty stage silently disappears from it.
+ *
+ * Idempotent: only touches docs where a field is missing/null/empty; a
+ * second run finds nothing to do. READ-ONLY without --confirm.
+ *
+ * Usage:
+ *   node scripts/backfill-whatsapp-leads.js            # dry-run: report counts only
+ *   node scripts/backfill-whatsapp-leads.js --confirm  # apply the patch
+ */
+require("dotenv").config();
+const mongoose = require("mongoose");
+
+const CONFIRM = process.argv.includes("--confirm");
+
+// Field → { match: docs needing the patch, set: value to write }
+const PATCHES = {
+  stage: {
+    match: { $or: [{ stage: { $exists: false } }, { stage: null }, { stage: "" }] },
+    set: "new",
+  },
+  verified: {
+    match: { $or: [{ verified: { $exists: false } }, { verified: null }] },
+    set: false,
+  },
+  isInterested: {
+    match: { $or: [{ isInterested: { $exists: false } }, { isInterested: null }] },
+    set: false,
+  },
+  isLost: {
+    match: { $or: [{ isLost: { $exists: false } }, { isLost: null }] },
+    set: false,
+  },
+  additionalInfo: {
+    match: { $or: [{ additionalInfo: { $exists: false } }, { additionalInfo: null }] },
+    set: {},
+  },
+  lostStatus: {
+    match: { $or: [{ lostStatus: { $exists: false } }, { lostStatus: null }] },
+    set: "none",
+  },
+};
+
+(async () => {
+  if (!process.env.DATABASE_URL) {
+    console.error("DATABASE_URL missing — run from the repo root with .env present.");
+    process.exit(1);
+  }
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Enquiry = require("../models/Enquiry");
+
+  const base = { source: "whatsapp" };
+  const total = await Enquiry.countDocuments(base);
+  console.log(`source-whatsapp leads: ${total}`);
+
+  console.log("\n── BEFORE ──");
+  const before = {};
+  for (const [field, p] of Object.entries(PATCHES)) {
+    before[field] = await Enquiry.countDocuments({ ...base, ...p.match });
+    console.log(`missing ${field}: ${before[field]}`);
+  }
+  const anyToPatch = Object.values(before).some((n) => n > 0);
+
+  if (!anyToPatch) {
+    console.log("\nNothing to patch — all source-whatsapp leads already have the create-path fields.");
+    await mongoose.disconnect();
+    return;
+  }
+
+  if (!CONFIRM) {
+    console.log("\nDRY RUN — no writes performed. Re-run with --confirm to apply.");
+    await mongoose.disconnect();
+    process.exit(2);
+  }
+
+  console.log("\n── APPLYING ──");
+  for (const [field, p] of Object.entries(PATCHES)) {
+    if (before[field] === 0) continue;
+    const r = await Enquiry.updateMany({ ...base, ...p.match }, { $set: { [field]: p.set } });
+    console.log(`patched ${field}: ${r.modifiedCount}`);
+  }
+
+  console.log("\n── AFTER ──");
+  for (const [field, p] of Object.entries(PATCHES)) {
+    const n = await Enquiry.countDocuments({ ...base, ...p.match });
+    console.log(`missing ${field}: ${n}`);
+  }
+
+  await mongoose.disconnect();
+  console.log("\nDone.");
+})();

--- a/scripts/browser-e2e-fixtures.js
+++ b/scripts/browser-e2e-fixtures.js
@@ -1,0 +1,101 @@
+/* Browser-suite fixtures (wedsy-os Playwright e2e drives a real backend).
+ *
+ * setup    → creates a founder admin (all perms), a WhatsApp lead + live
+ *            ai-mode conversation with an open 24h window and two messages,
+ *            then prints ONE LINE of JSON: { token, leadId, conversationId }.
+ * teardown → removes everything the marker identifies. Idempotent.
+ *
+ * Usage: node scripts/browser-e2e-fixtures.js setup|teardown
+ */
+require("dotenv").config();
+const mongoose = require("mongoose");
+const jwt = require("jsonwebtoken");
+
+const MARKER = "BROWSER-E2E";
+const LEAD_PHONE = "919180000001";
+const ADMIN_PHONE = "919180000002";
+
+(async () => {
+  const cmd = process.argv[2];
+  if (!["setup", "teardown"].includes(cmd)) {
+    console.error("usage: node scripts/browser-e2e-fixtures.js setup|teardown");
+    process.exit(1);
+  }
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Enquiry = require("../models/Enquiry");
+  const WAConversation = require("../models/WAConversation");
+  const WAAgentMessage = require("../models/WAAgentMessage");
+  const LeadInternalEvent = require("../models/LeadInternalEvent");
+  const Admin = require("../models/Admin");
+  const Role = require("../models/Role");
+  const Department = require("../models/Department");
+
+  const teardown = async () => {
+    const lead = await Enquiry.findOne({ phone: LEAD_PHONE }).lean();
+    if (lead) await LeadInternalEvent.deleteMany({ leadId: lead._id });
+    await Enquiry.deleteMany({ phone: LEAD_PHONE });
+    await WAConversation.deleteMany({ phone: LEAD_PHONE });
+    await WAAgentMessage.deleteMany({ phone: LEAD_PHONE });
+    await Admin.deleteMany({ phone: ADMIN_PHONE });
+    await Role.deleteMany({ name: `${MARKER} Founder` });
+    await Department.deleteMany({ name: `${MARKER} Dept` });
+  };
+
+  if (cmd === "teardown") {
+    await teardown();
+    await mongoose.disconnect();
+    console.log(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  await teardown(); // clean slate even after a crashed previous run
+
+  const dept = await Department.create({ name: `${MARKER} Dept` });
+  const role = await Role.create({
+    name: `${MARKER} Founder`,
+    departmentId: dept._id,
+    permissions: ["*:*:all"],
+  });
+  const admin = await Admin.create({
+    name: "Browser Founder",
+    email: `browser-e2e-${Date.now()}@test.local`,
+    phone: ADMIN_PHONE,
+    password: "browser-e2e-not-a-real-password",
+    roles: ["crm"],
+    roleId: role._id,
+    departmentId: dept._id,
+    status: "active",
+  });
+  const token = jwt.sign({ _id: String(admin._id), isAdmin: true }, process.env.JWT_SECRET);
+
+  const lead = await Enquiry.create({
+    name: "Browser E2E Lead",
+    phone: LEAD_PHONE,
+    verified: false,
+    source: "whatsapp",
+    additionalInfo: {},
+    stage: "new",
+    assignedTo: admin._id,
+  });
+  const now = new Date();
+  const conversation = await WAConversation.create({
+    phone: LEAD_PHONE,
+    normalizedPhone: LEAD_PHONE.slice(-10),
+    enquiryId: lead._id,
+    mode: "ai",
+    status: "active",
+    lastInboundAt: now, // 24h window OPEN — the send flow must work
+    lastMessageAt: now,
+    lastMessagePreview: "Hi! Planning my wedding",
+    unreadCount: 1,
+  });
+  await WAAgentMessage.create([
+    { phone: LEAD_PHONE, role: "user", message: "Hi! Planning my wedding" },
+    { phone: LEAD_PHONE, role: "assistant", message: "How lovely! Tell me more ✦" },
+  ]);
+
+  await mongoose.disconnect();
+  console.log(
+    JSON.stringify({ token, leadId: String(lead._id), conversationId: String(conversation._id) })
+  );
+})();

--- a/scripts/e2e-kiara.js
+++ b/scripts/e2e-kiara.js
@@ -320,11 +320,28 @@ const inboundMedia = (phone, type = "image", profileName = "E2E Customer") => ({
     );
     ok(true, "Kiara resumed after handback");
 
+    // MB6 Slice 11: the extractor is SKIPPED until a conversation has 3 user
+    // messages — extraction sections prime with the decisive message first
+    // (firstMessage assertions depend on it), then two fillers.
+    const sendThree = async (p, decisiveText, profileName = "E2E Customer") => {
+      await signedWebhook(inboundText(p, decisiveText, profileName));
+      await waitFor(
+        async () => (await WAAgentMessage.countDocuments({ phone: p, role: "assistant" })) >= 1,
+        "priming reply 1"
+      );
+      await signedWebhook(inboundText(p, "ok — anything else you need from me?", profileName));
+      await waitFor(
+        async () => (await WAAgentMessage.countDocuments({ phone: p, role: "assistant" })) >= 2,
+        "priming reply 2"
+      );
+      await signedWebhook(inboundText(p, "that's everything from my side!", profileName));
+    };
+
     // ── (3) Escalation ───────────────────────────────────────────────────────
     section("3. Escalation JSON → needsHuman + mission card + journey");
     const p3 = phone(3);
     mock.extractor = { qualified: false, escalate: true, escalateReason: "Customer is frustrated", classification: "lead", data: {} };
-    await signedWebhook(inboundText(p3, "This is taking forever. Get me a human!"));
+    await sendThree(p3, "This is taking forever. Get me a human!");
     const conv3 = await waitFor(async () => {
       const c = await WAConversation.findOne({ phone: p3 }).lean();
       return c && c.needsHuman ? c : null;
@@ -370,7 +387,7 @@ const inboundMedia = (phone, type = "image", profileName = "E2E Customer") => ({
         weddingStyle: "South Indian",
       },
     };
-    await signedWebhook(inboundText(p4, "Thanks! All details shared.", "Asha Rao"));
+    await sendThree(p4, "Thanks! All details shared.", "Asha Rao");
     const ql4 = await waitFor(async () => {
       const q = await QualifiedLead.findOne({ phone: p4 }).lean();
       return q && q.crmSynced ? q : null;
@@ -417,7 +434,7 @@ const inboundMedia = (phone, type = "image", profileName = "E2E Customer") => ({
       classification: "vendor",
       data: { name: "Studio Lumière", servicesRequired: "wedding photography" },
     };
-    await signedWebhook(inboundText(p5, "Hi, I'm a photographer — can I work with Wedsy?", "Studio Lumiere"));
+    await sendThree(p5, "Hi, I'm a photographer — can I work with Wedsy?", "Studio Lumiere");
     const conv5 = await waitFor(async () => {
       const c = await WAConversation.findOne({ phone: p5 }).lean();
       return c && c.status === "closed" ? c : null;

--- a/scripts/e2e-mb56.js
+++ b/scripts/e2e-mb56.js
@@ -316,6 +316,18 @@ const inboundText = (phone, text, profileName = "MB56 Customer") => ({
     departmentId: dept._id,
     status: "active",
   });
+  // Created with the fixtures so the 5-min team-scope cache includes them (S10).
+  const metricsIntern = await Admin.create({
+    name: `${MARK} MetricsIntern`,
+    email: `mb56-mintern-${Date.now()}@test.local`,
+    phone: "919191000006",
+    password: "x",
+    roles: ["sales"],
+    roleId: internRole._id,
+    departmentId: dept._id,
+    reportingManagerId: salesLead._id,
+    status: "active",
+  });
 
   await new Promise((r) => mockServer.listen(MOCK_PORT, r));
   const child = spawn("node", ["server.js"], {
@@ -1409,6 +1421,113 @@ const inboundText = (phone, text, profileName = "MB56 Customer") => ({
     ok(svForeignDelete.status === 404, "cannot delete someone else's view");
     const svDelete = await api("DELETE", `/saved-views/${svCreate.data._id}`, { token: internToken });
     ok(svDelete.status === 200, "delete works");
+
+    // ════ SLICE 10 — Intern/presales metrics (math vs seeded fixtures) ════
+    section("S10: metrics math vs seeded fixtures");
+    const mToken = tok(metricsIntern);
+    // The metrics intern sat in the round-robin pool all suite — snapshot the
+    // baseline and assert exact DELTAS from the seeded fixtures below.
+    const metricsBefore = await api("GET", "/enquiry/intern-metrics?period=today", { token: founderToken });
+    const mBase = (metricsBefore.data.rows || []).find((r) => String(r.adminId) === String(metricsIntern._id)) || {
+      leadsReceived: 0,
+      qualified: 0,
+      meetsBooked: 0,
+    };
+    const mkLead = async (n, fields = {}) =>
+      Enquiry.create({
+        name: `${MARK} M${n}`,
+        phone: phone(700 + n),
+        verified: false,
+        source: "Website",
+        additionalInfo: {},
+        stage: "new",
+        ...fields,
+      });
+    const now10 = Date.now();
+    // A: received, called in 10min (in 15-min window), qualified incomplete.
+    const mA = await mkLead(1, { assignedTo: metricsIntern._id, qualified: true });
+    await Enquiry.collection.updateOne(
+      { _id: mA._id },
+      { $set: { createdAt: new Date(now10 - 2 * 3600 * 1000), firstCalledAt: new Date(now10 - 2 * 3600 * 1000 + 10 * 60 * 1000) } }
+    );
+    // B: received, called after 60min (window missed).
+    const mB = await mkLead(2, { assignedTo: metricsIntern._id });
+    await Enquiry.collection.updateOne(
+      { _id: mB._id },
+      { $set: { createdAt: new Date(now10 - 3 * 3600 * 1000), firstCalledAt: new Date(now10 - 3 * 3600 * 1000 + 60 * 60 * 1000) } }
+    );
+    // C: received, never called.
+    const mC = await mkLead(3, { assignedTo: metricsIntern._id });
+    // D: handoff credit only (qualifiedBy), owned by the sales lead now.
+    await mkLead(4, { assignedTo: salesLead._id, qualified: true, qualifiedBy: metricsIntern._id });
+    // Assignment journey events (what "received" derives from).
+    for (const leadId of [mA._id, mB._id, mC._id]) {
+      await LeadInternalEvent.create({
+        leadId,
+        type: "auto_assigned",
+        actorId: null,
+        payload: { assignedTo: String(metricsIntern._id) },
+      });
+    }
+    // Meets: 2 booked by the metrics intern; 1 completed (the show-up).
+    const meetA = await api("POST", `/enquiry/${mA._id}/follow-up`, {
+      token: mToken,
+      body: { type: "meet", scheduledAt: new Date(now10 + 24 * 3600 * 1000).toISOString() },
+    });
+    ok(meetA.status === 200 || meetA.status === 201, "metrics fixture meet 1 booked");
+    const meetC = await api("POST", `/enquiry/${mC._id}/follow-up`, {
+      token: mToken,
+      body: { type: "meet", scheduledAt: new Date(now10 - 3600 * 1000).toISOString() },
+    });
+    const mCDoc = await Enquiry.findById(mC._id).lean();
+    const meetCFu = (mCDoc.followUps || []).find((f) => f.type === "meet");
+    // Booking the meets handed mA/mC to the sales lead (the Slice-3 handoff),
+    // so the OWNER completes — with a next step (the zero-orphan gate).
+    const completeC = await api("PUT", `/enquiry/${mC._id}/follow-up/${meetCFu._id}/complete`, {
+      token: salesLeadToken,
+      body: {
+        outcome: "done",
+        notes: "met them",
+        nextFollowUp: { type: "call", scheduledAt: new Date(now10 + 2 * 24 * 3600 * 1000).toISOString() },
+      },
+    });
+    ok(completeC.status === 200, "metrics fixture meet completed");
+
+    const metrics = await api("GET", "/enquiry/intern-metrics?period=today", { token: founderToken });
+    ok(metrics.status === 200, "intern metrics endpoint loads");
+    const mRow = (metrics.data.rows || []).find((r) => String(r.adminId) === String(metricsIntern._id));
+    ok(!!mRow, "per-intern rollup row present");
+    ok(
+      mRow.leadsReceived === mBase.leadsReceived + 3,
+      `leads received +3 (base ${mBase.leadsReceived}, got ${mRow.leadsReceived})`
+    );
+    ok(mRow.contacted === 2 && mRow.contactedInWindowPct === 50, `contacted-in-window 50% (got ${mRow.contactedInWindowPct})`);
+    ok(mRow.avgFirstCallMinutes === 35, `avg time-to-first-call 35min (got ${mRow.avgFirstCallMinutes})`);
+    ok(
+      mRow.qualified === mBase.qualified + 2,
+      `qualified +2 incl. handoff credit (base ${mBase.qualified}, got ${mRow.qualified})`
+    );
+    ok(
+      mRow.meetsBooked === mBase.meetsBooked + 2,
+      `meets booked +2 (base ${mBase.meetsBooked}, got ${mRow.meetsBooked})`
+    );
+    ok(mRow.meetShowUpRatePct === 50, `meeting show-up rate 50% (got ${mRow.meetShowUpRatePct})`);
+    ok(mRow.incompleteDiscovery >= 2, `incomplete discovery counted (got ${mRow.incompleteDiscovery})`);
+
+    section("S10: scope + period");
+    const metricsLead = await api("GET", "/enquiry/intern-metrics?period=week", { token: salesLeadToken });
+    ok(
+      metricsLead.status === 200 &&
+        (metricsLead.data.rows || []).some((r) => String(r.adminId) === String(metricsIntern._id)),
+      "sales lead sees their subordinate's rollup (week period)"
+    );
+    const metricsOwn = await api("GET", "/enquiry/intern-metrics?period=today", { token: mToken });
+    ok(
+      (metricsOwn.data.rows || []).every((r) => String(r.adminId) === String(metricsIntern._id)),
+      "own-scope intern sees only themself"
+    );
+    const badPeriod = await api("GET", "/enquiry/intern-metrics?period=year", { token: founderToken });
+    ok(badPeriod.status === 400, "invalid period rejected (400)");
   } catch (e) {
     failed++;
     failures.push(`fatal: ${e.message}`);
@@ -1430,7 +1549,7 @@ const inboundText = (phone, text, profileName = "MB56 Customer") => ({
     const VendorContact = require("../models/VendorContact");
     await VendorContact.deleteMany({ phone: { $regex: `^(${PHONE_PREFIX}|MB56IG)` } });
     await Attendance.deleteMany({ adminId: { $in: [founder._id, salesLead._id, intern._id] } });
-    const allAdminIds = [founder._id, salesLead._id, intern._id, holder._id, revenueHead._id];
+    const allAdminIds = [founder._id, salesLead._id, intern._id, holder._id, revenueHead._id, metricsIntern._id];
     const GoogleAccountModel = require("../models/GoogleAccount");
     await GoogleAccountModel.deleteMany({ adminId: { $in: allAdminIds } });
     const SavedViewModel = require("../models/SavedView");

--- a/scripts/e2e-mb56.js
+++ b/scripts/e2e-mb56.js
@@ -186,6 +186,35 @@ const signedIgWebhook = async (instagramId, text) => {
   return res.status;
 };
 
+// MB6 Slice 11: extraction is skipped under 3 user messages — qualification/
+// escalation flows prime with the decisive message first, then two fillers.
+const waSendThree = async (WAAgentMessage, p, decisiveText, profileName = "MB56 Customer") => {
+  const replies = async () => WAAgentMessage.countDocuments({ phone: p, role: "assistant" });
+  const base = await replies();
+  await signedWebhook(inboundText(p, decisiveText, profileName));
+  await waitForCount(replies, base + 1);
+  await signedWebhook(inboundText(p, "ok — anything else you need?", profileName));
+  await waitForCount(replies, base + 2);
+  await signedWebhook(inboundText(p, "that's everything from me!", profileName));
+};
+const igSendThree = async (WAAgentMessage, igId, decisiveText) => {
+  const replies = async () => WAAgentMessage.countDocuments({ phone: igId, role: "assistant" });
+  const base = await replies();
+  await signedIgWebhook(igId, decisiveText);
+  await waitForCount(replies, base + 1);
+  await signedIgWebhook(igId, "ok — anything else you need?");
+  await waitForCount(replies, base + 2);
+  await signedIgWebhook(igId, "that's everything from me!");
+};
+const waitForCount = async (fn, n, timeoutMs = 20000) => {
+  const until = Date.now() + timeoutMs;
+  while (Date.now() < until) {
+    if ((await fn()) >= n) return;
+    await sleep(250);
+  }
+  throw new Error(`waitForCount timed out (wanted ${n})`);
+};
+
 const inboundText = (phone, text, profileName = "MB56 Customer") => ({
   entry: [
     {
@@ -988,7 +1017,7 @@ const inboundText = (phone, text, profileName = "MB56 Customer") => ({
       },
     };
     const pK = phone(402);
-    await signedWebhook(inboundText(pK, "We need help with our wedding!", "Kiara Mapped"));
+    await waSendThree(WAAgentMessage, pK, "We need help with our wedding!", "Kiara Mapped");
     const kLead = await waitFor(async () => {
       const c = await WAConversation.findOne({ phone: pK }).lean();
       if (!c || !c.enquiryId) return null;
@@ -1075,7 +1104,7 @@ const inboundText = (phone, text, profileName = "MB56 Customer") => ({
     section("S7: IG escalation contract");
     const IG2 = "MB56IG00000002";
     mock.extractor = { qualified: false, escalate: true, escalateReason: "Customer wants a human", classification: "lead", data: {} };
-    await signedIgWebhook(IG2, "I want to talk to a real person please");
+    await igSendThree(WAAgentMessage, IG2, "I want to talk to a real person please");
     const igConv2 = await waitFor(async () => {
       const c = await WAConversation.findOne({ phone: IG2 }).lean();
       return c && c.needsHuman ? c : null;
@@ -1099,7 +1128,7 @@ const inboundText = (phone, text, profileName = "MB56 Customer") => ({
         budget: "20 lakhs",
       },
     };
-    await signedIgWebhook(IG3, "Sure, my number is 9191000505");
+    await igSendThree(WAAgentMessage, IG3, "Sure, my number is 9191000505");
     const igConv3 = await waitFor(async () => {
       const c = await WAConversation.findOne({ phone: IG3 }).lean();
       return c && c.enquiryId ? c : null;
@@ -1528,6 +1557,49 @@ const inboundText = (phone, text, profileName = "MB56 Customer") => ({
     );
     const badPeriod = await api("GET", "/enquiry/intern-metrics?period=year", { token: founderToken });
     ok(badPeriod.status === 400, "invalid period rejected (400)");
+
+    // ════ SLICE 11 — Anthropic 429 mitigation ════
+    section("S11: <3-message qualification skip");
+    const extractorCalls = () =>
+      mock.anthropicCalls.filter((c) => String(c.system || "").startsWith("You are a data extractor")).length;
+    const pQ = phone(801);
+    const exBefore = extractorCalls();
+    await signedWebhook(inboundText(pQ, "Hi! First message", "Skip Test"));
+    await waitFor(async () => WAAgentMessage.findOne({ phone: pQ, role: "assistant" }).lean(), "skip reply 1");
+    await sleep(600);
+    ok(extractorCalls() === exBefore, "message 1: NO qualification-check call");
+    await signedWebhook(inboundText(pQ, "Second message", "Skip Test"));
+    await waitFor(
+      async () => (await WAAgentMessage.countDocuments({ phone: pQ, role: "assistant" })) >= 2,
+      "skip reply 2"
+    );
+    await sleep(600);
+    ok(extractorCalls() === exBefore, "message 2: still NO qualification-check call");
+    await signedWebhook(inboundText(pQ, "Third message", "Skip Test"));
+    await waitFor(
+      async () => (await WAAgentMessage.countDocuments({ phone: pQ, role: "assistant" })) >= 3,
+      "skip reply 3"
+    );
+    await waitFor(async () => extractorCalls() > exBefore, "extractor fires on message 3");
+    ok(extractorCalls() === exBefore + 1, "message 3: qualification check fires exactly once");
+
+    section("S11: 429 → exponential backoff, reply still lands");
+    const pR = phone(802);
+    mock.anthropic429s = 2; // the next two Anthropic calls 429
+    const t429 = Date.now();
+    await signedWebhook(inboundText(pR, "Hello despite rate limits!", "Backoff Test"));
+    await waitFor(
+      async () => WAAgentMessage.findOne({ phone: pR, role: "assistant" }).lean(),
+      "reply after backoff",
+      30000
+    );
+    const elapsed = Date.now() - t429;
+    ok(mock.anthropic429s === 0, "both 429s consumed by the queue");
+    ok(elapsed >= 2900, `exponential backoff respected (1s+2s — took ${elapsed}ms)`);
+    ok(
+      mock.metaCalls.some((m) => m.body.to === pR && m.body.type === "text"),
+      "customer still got Kiara's reply"
+    );
   } catch (e) {
     failed++;
     failures.push(`fatal: ${e.message}`);

--- a/scripts/e2e-mb56.js
+++ b/scripts/e2e-mb56.js
@@ -202,8 +202,47 @@ const inboundText = (phone, text, profileName = "MB56 Customer") => ({
   const salesLeadToken = tok(salesLead);
   const internToken = tok(intern);
 
-  const touchedKeys = ["assignment.poolRoles"];
+  const touchedKeys = [
+    "assignment.poolRoles",
+    "assignment.mode",
+    "triage.escalateAfterMinutes",
+    "golden.workStartHour",
+    "golden.workEndHour",
+  ];
   const settingsBefore = await Setting.find({ key: { $in: touchedKeys } }).lean();
+
+  // Triage-holder fixture (sales-lead-class role with the new permission).
+  const holderRole = await Role.create({
+    name: `${MARK} TriageHolder`,
+    departmentId: dept._id,
+    permissions: ["leads:view:all", "leads:edit:all", "leads:triage:all"],
+  });
+  const holder = await Admin.create({
+    name: `${MARK} Holder`,
+    email: `mb56-holder-${Date.now()}@test.local`,
+    phone: "919191000004",
+    password: "x",
+    roles: ["sales"],
+    roleId: holderRole._id,
+    departmentId: dept._id,
+    status: "active",
+  });
+  // Revenue Head: reuse the real role if the dev DB has it, else create one.
+  let rhRole = await Role.findOne({ name: "Revenue Head", deletedAt: null });
+  const rhRoleCreated = !rhRole;
+  if (!rhRole) {
+    rhRole = await Role.create({ name: "Revenue Head", departmentId: dept._id, permissions: ["leads:view:all"] });
+  }
+  const revenueHead = await Admin.create({
+    name: `${MARK} RevenueHead`,
+    email: `mb56-rh-${Date.now()}@test.local`,
+    phone: "919191000005",
+    password: "x",
+    roles: ["sales"],
+    roleId: rhRole._id,
+    departmentId: dept._id,
+    status: "active",
+  });
 
   await new Promise((r) => mockServer.listen(MOCK_PORT, r));
   const child = spawn("node", ["server.js"], {
@@ -485,6 +524,173 @@ const inboundText = (phone, text, profileName = "MB56 Customer") => ({
     );
     const lead2After = await Enquiry.findById(lead2._id).lean();
     ok(String(lead2After.assignedTo) === String(salesLead._id), "no handoff for a non-intern owner");
+
+    // ════ SLICE 4 — Triage & escalation ════
+    section("S4: triage mode — new leads land unassigned");
+    const holderToken = tok(holder);
+    // Force "working hours" deterministically for the sweep assertions.
+    await api("PUT", "/settings", { token: founderToken, body: { key: "golden.workStartHour", value: 0 } });
+    await api("PUT", "/settings", { token: founderToken, body: { key: "golden.workEndHour", value: 24 } });
+    const modePut = await api("PUT", "/settings", {
+      token: founderToken,
+      body: { key: "assignment.mode", value: "triage" },
+    });
+    ok(modePut.status === 200, "assignment.mode flips to triage in Settings");
+
+    const pT1 = phone(201);
+    await signedWebhook(inboundText(pT1, "Hi! Need wedding decor", "Triage One"));
+    const convT1 = await waitFor(async () => {
+      const c = await WAConversation.findOne({ phone: pT1 }).lean();
+      return c && c.enquiryId ? c : null;
+    }, "triage lead linked");
+    const leadT1 = await Enquiry.findById(convT1.enquiryId).lean();
+    ok(leadT1.assignedTo === null && leadT1.triagePending === true, "triage-mode lead lands UNASSIGNED in triage");
+    ok(
+      !!(await LeadInternalEvent.findOne({ leadId: leadT1._id, type: "triage_entered" }).lean()),
+      "journey event triage_entered"
+    );
+
+    section("S4: triage view — gated, transcript, golden freshness");
+    const deny = await api("GET", "/enquiry/triage", { token: internToken });
+    ok(deny.status === 403, "intern without leads:triage gets 403");
+    let queue = await api("GET", "/enquiry/triage", { token: holderToken });
+    ok(queue.status === 200, "triage holder can read the queue");
+    const qRow = (queue.data.list || []).find((r) => String(r._id) === String(leadT1._id));
+    ok(!!qRow && qRow.source === "whatsapp", "queue row carries source");
+    ok(qRow && qRow.transcript.length >= 1 && qRow.transcript[0].message.includes("decor"), "Kiara transcript preview attached");
+    ok(qRow && qRow.goldenWindow && typeof qRow.goldenWindow.inWindow === "boolean", "freshness vs golden window attached");
+    const viewTriage = await api("GET", "/enquiry?view=triage&limit=50", { token: holderToken });
+    ok(
+      (viewTriage.data.list || []).some((l) => String(l._id) === String(leadT1._id)),
+      "leads filter view=triage shows the queue"
+    );
+    const pickerResp = await api("GET", "/enquiry/triage/interns", { token: holderToken });
+    const pickerIntern = (pickerResp.data.list || []).find((i) => String(i._id) === String(intern._id));
+    ok(!!pickerIntern && typeof pickerIntern.status === "string", "intern picker shows live status");
+
+    section("S4: assign + take-it-myself");
+    const assignResp = await api("POST", `/enquiry/${leadT1._id}/triage-assign`, {
+      token: holderToken,
+      body: { adminId: String(intern._id) },
+    });
+    ok(assignResp.status === 200 && String(assignResp.data.assignedTo) === String(intern._id), "assign to intern works");
+    ok(
+      !!(await LeadInternalEvent.findOne({ leadId: leadT1._id, type: "triage_assigned" }).lean()),
+      "journey event triage_assigned"
+    );
+    ok(
+      !!(await AdminNotification.findOne({ adminId: intern._id, type: "triage_assigned" }).lean()),
+      "assignee notified"
+    );
+    const pT2 = phone(202);
+    await signedWebhook(inboundText(pT2, "Venue enquiry", "Triage Two"));
+    const convT2 = await waitFor(async () => {
+      const c = await WAConversation.findOne({ phone: pT2 }).lean();
+      return c && c.enquiryId ? c : null;
+    }, "triage lead 2 linked");
+    const takeResp = await api("POST", `/enquiry/${convT2.enquiryId}/triage-assign`, { token: holderToken });
+    ok(String(takeResp.data.assignedTo) === String(holder._id), "take-it-myself assigns to the caller");
+    const selfEv = await LeadInternalEvent.findOne({ leadId: convT2.enquiryId, type: "triage_assigned" }).lean();
+    ok(selfEv && selfEv.payload.self === true, "self-assign flagged in the journey");
+
+    section("S4: escalation — notify holders after N minutes");
+    // Holder is checked in and online — an available human, so NO auto-assign.
+    await api("POST", "/attendance/check-in", { token: holderToken });
+    const pT3 = phone(203);
+    await signedWebhook(inboundText(pT3, "Catering query", "Triage Three"));
+    const convT3 = await waitFor(async () => {
+      const c = await WAConversation.findOne({ phone: pT3 }).lean();
+      return c && c.enquiryId ? c : null;
+    }, "triage lead 3 linked");
+    // Mock the clock: rewind triageEnteredAt past the 10-min default.
+    await Enquiry.updateOne(
+      { _id: convT3.enquiryId },
+      { $set: { triageEnteredAt: new Date(Date.now() - 11 * 60 * 1000) } }
+    );
+    queue = await api("GET", "/enquiry/triage", { token: holderToken }); // sweep rides the read
+    const t3 = await Enquiry.findById(convT3.enquiryId).lean();
+    ok(!!t3.triageEscalatedAt, "lead escalated after escalateAfterMinutes");
+    ok(t3.triagePending === true && t3.assignedTo === null, "holders available → NOT auto-assigned");
+    ok(
+      !!(await AdminNotification.findOne({ adminId: holder._id, type: "triage_escalation", leadId: t3._id }).lean()),
+      "all triage holders notified"
+    );
+    const secondSweep = await api("GET", "/enquiry/triage", { token: holderToken });
+    const escalations = await AdminNotification.countDocuments({ adminId: holder._id, type: "triage_escalation", leadId: t3._id });
+    ok(secondSweep.status === 200 && escalations === 1, "escalation fires once per lead");
+
+    section("S4: all holders in_meeting → auto-assign to online intern");
+    // Holder goes into a live meeting; intern is checked in + online.
+    const holderMeeting = await api("POST", "/calendar/events", {
+      token: holderToken,
+      body: {
+        type: "meeting",
+        title: "MB56 holder busy",
+        start: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+        end: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
+      },
+    });
+    ok(holderMeeting.status === 201, "holder meeting live (fixture)");
+    await api("POST", "/attendance/check-in", { token: internToken });
+    const pT4 = phone(204);
+    await signedWebhook(inboundText(pT4, "Photography packages?", "Triage Four"));
+    const convT4 = await waitFor(async () => {
+      const c = await WAConversation.findOne({ phone: pT4 }).lean();
+      return c && c.enquiryId ? c : null;
+    }, "triage lead 4 linked");
+    await Enquiry.updateOne(
+      { _id: convT4.enquiryId },
+      { $set: { triageEnteredAt: new Date(Date.now() - 11 * 60 * 1000) } }
+    );
+    await api("GET", "/enquiry/dashboard", { token: founderToken }); // sweep also rides the dashboard
+    const t4 = await Enquiry.findById(convT4.enquiryId).lean();
+    ok(String(t4.assignedTo) === String(intern._id) && t4.triagePending === false, "auto-assigned to the online intern");
+    const autoEv = await LeadInternalEvent.findOne({ leadId: t4._id, type: "triage_auto_assigned" }).lean();
+    ok(autoEv && autoEv.payload.reason === "auto-assigned: triage was in meetings", "journey carries the reason");
+    ok(
+      !!(await AdminNotification.findOne({ adminId: revenueHead._id, type: "triage_auto_assigned", leadId: t4._id }).lean()),
+      "Revenue Head notified"
+    );
+    ok(
+      !!(await AdminNotification.findOne({ adminId: salesLead._id, type: "triage_auto_assigned", leadId: t4._id }).lean()),
+      "intern's sales lead notified with the reason"
+    );
+    ok(
+      !!(await AdminNotification.findOne({ adminId: intern._id, type: "triage_auto_assigned", leadId: t4._id }).lean()),
+      "intern notified"
+    );
+
+    section("S4: working-hours gate");
+    // Move "working hours" away from now → sweep must not escalate.
+    const istHourNow = new Date(Date.now() + 330 * 60 * 1000).getUTCHours();
+    const offStart = istHourNow >= 22 ? 0 : istHourNow + 1;
+    const offEnd = istHourNow >= 22 ? 1 : istHourNow + 2;
+    await api("PUT", "/settings", { token: founderToken, body: { key: "golden.workStartHour", value: offStart } });
+    await api("PUT", "/settings", { token: founderToken, body: { key: "golden.workEndHour", value: offEnd } });
+    const pT5 = phone(205);
+    await signedWebhook(inboundText(pT5, "Mehendi artists?", "Triage Five"));
+    const convT5 = await waitFor(async () => {
+      const c = await WAConversation.findOne({ phone: pT5 }).lean();
+      return c && c.enquiryId ? c : null;
+    }, "triage lead 5 linked");
+    await Enquiry.updateOne(
+      { _id: convT5.enquiryId },
+      { $set: { triageEnteredAt: new Date(Date.now() - 11 * 60 * 1000) } }
+    );
+    await api("GET", "/enquiry/triage", { token: holderToken });
+    const t5 = await Enquiry.findById(convT5.enquiryId).lean();
+    ok(!t5.triageEscalatedAt, "outside working hours → no escalation (morning pile)");
+    // Restore working hours + close the holder's meeting + flip back to auto.
+    await api("PUT", "/settings", { token: founderToken, body: { key: "golden.workStartHour", value: 0 } });
+    await api("PUT", "/settings", { token: founderToken, body: { key: "golden.workEndHour", value: 24 } });
+    await api("POST", `/calendar/events/${holderMeeting.data._id}/close`, { token: holderToken, body: { notes: "done" } });
+    await api("POST", "/attendance/check-out", { token: internToken });
+    await api("POST", "/attendance/check-out", { token: holderToken });
+    const backToAuto = await api("PUT", "/settings", {
+      token: founderToken,
+      body: { key: "assignment.mode", value: "auto" },
+    });
+    ok(backToAuto.status === 200, "assignment.mode back to auto (zero-change default)");
   } catch (e) {
     failed++;
     failures.push(`fatal: ${e.message}`);
@@ -501,12 +707,15 @@ const inboundText = (phone, text, profileName = "MB56 Customer") => ({
     await QualifiedLead.deleteMany({ phone: { $regex: `^${PHONE_PREFIX}` } });
     await NotificationFailureLog.deleteMany({ phone: { $regex: `^${PHONE_PREFIX}` } });
     await Attendance.deleteMany({ adminId: { $in: [founder._id, salesLead._id, intern._id] } });
+    const allAdminIds = [founder._id, salesLead._id, intern._id, holder._id, revenueHead._id];
     const CalendarEventModel = require("../models/CalendarEvent");
     const AdminNotificationModel = require("../models/AdminNotification");
-    await CalendarEventModel.deleteMany({ ownerId: { $in: [founder._id, salesLead._id, intern._id] } });
-    await AdminNotificationModel.deleteMany({ adminId: { $in: [founder._id, salesLead._id, intern._id] } });
-    await Admin.deleteMany({ _id: { $in: [founder._id, salesLead._id, intern._id] } });
-    await Role.deleteMany({ _id: { $in: [founderRole._id, salesLeadRole._id, internRole._id] } });
+    await CalendarEventModel.deleteMany({ ownerId: { $in: allAdminIds } });
+    await AdminNotificationModel.deleteMany({ adminId: { $in: allAdminIds } });
+    await Attendance.deleteMany({ adminId: { $in: allAdminIds } });
+    await Admin.deleteMany({ _id: { $in: allAdminIds } });
+    await Role.deleteMany({ _id: { $in: [founderRole._id, salesLeadRole._id, internRole._id, holderRole._id] } });
+    if (rhRoleCreated) await Role.deleteMany({ _id: rhRole._id });
     await Department.deleteMany({ _id: dept._id });
     await Setting.deleteMany({ key: { $in: touchedKeys } });
     if (settingsBefore.length) await Setting.insertMany(settingsBefore.map(({ _id, ...rest }) => rest));

--- a/scripts/e2e-mb56.js
+++ b/scripts/e2e-mb56.js
@@ -824,6 +824,120 @@ const inboundText = (phone, text, profileName = "MB56 Customer") => ({
     );
     // Disarm for the remaining slices.
     await api("PUT", "/settings", { token: founderToken, body: { key: "kiara.welcomeTemplateName", value: "" } });
+
+    // ════ SLICE 6 — Cockpit v2 + scripts-in-settings ════
+    section("S6: public settings expose services + scripts");
+    const pub = await api("GET", "/settings/public", { token: internToken });
+    ok(
+      Array.isArray(pub.data["services.available"]) && pub.data["services.available"].includes("Mehendi") && pub.data["services.available"].length === 8,
+      "services.available seeded with the 8 services"
+    );
+    ok(
+      ["cockpit.briefScript", "cockpit.servicesScript", "cockpit.budgetScript", "cockpit.qualificationIntro"].every(
+        (k) => typeof pub.data[k] === "string" && pub.data[k].length > 50
+      ),
+      "all four cockpit scripts drafted + readable without settings perms"
+    );
+
+    section("S6: qualification v2 fields");
+    const leadQ = await Enquiry.create({
+      name: `${MARK} CockpitLead`,
+      phone: phone(401),
+      verified: false,
+      source: "Website",
+      additionalInfo: {},
+      stage: "new",
+      assignedTo: intern._id,
+    });
+    const qPut = await api("PUT", `/enquiry/${leadQ._id}/qualification`, {
+      token: internToken,
+      body: {
+        servicesRequired: ["Decor", "Photography", "Decor"],
+        budgetAmount: 1500000,
+        budgetNote: "15L ±, flexible for the right venue",
+        additionalEmails: ["partner@example.com", "PARTNER@example.com"],
+        groomName: "Arjun",
+      },
+    });
+    ok(qPut.status === 200, "qualification PUT accepts the v2 fields");
+    const leadQAfter = await Enquiry.findById(leadQ._id).lean();
+    ok(
+      JSON.stringify(leadQAfter.qualificationData.servicesRequired) === JSON.stringify(["Decor", "Photography"]),
+      "servicesRequired deduped + stored"
+    );
+    ok(leadQAfter.qualificationData.budgetAmount === 1500000 && leadQAfter.qualificationData.budgetNote.includes("15L"), "budget stored (number + note)");
+    ok(
+      JSON.stringify(leadQAfter.qualificationData.additionalEmails) === JSON.stringify(["partner@example.com"]),
+      "additionalEmails lowercased + deduped"
+    );
+    const qBad = await api("PUT", `/enquiry/${leadQ._id}/qualification`, {
+      token: internToken,
+      body: { additionalEmails: ["not-an-email"] },
+    });
+    ok(qBad.status === 400, "invalid additionalEmails rejected (400)");
+
+    section("S6: Kiara servicesRequired/budget map into cockpit fields");
+    mock.extractor = {
+      qualified: true,
+      escalate: false,
+      escalateReason: "",
+      classification: "lead",
+      data: {
+        name: "Kiara Mapped",
+        eventDate: "",
+        servicesRequired: "decor and photography, maybe mehendi",
+        budget: "around 12 lakhs",
+      },
+    };
+    const pK = phone(402);
+    await signedWebhook(inboundText(pK, "We need help with our wedding!", "Kiara Mapped"));
+    const kLead = await waitFor(async () => {
+      const c = await WAConversation.findOne({ phone: pK }).lean();
+      if (!c || !c.enquiryId) return null;
+      const l = await Enquiry.findById(c.enquiryId).lean();
+      return l && l.qualified && (l.qualificationData.servicesRequired || []).length ? l : null;
+    }, "kiara qualified sync", 40000);
+    const mappedServices = kLead.qualificationData.servicesRequired;
+    ok(
+      mappedServices.includes("Decor") && mappedServices.includes("Photography") && mappedServices.includes("Mehendi"),
+      `Kiara services mapped best-effort (${mappedServices.join(",")})`
+    );
+    ok(kLead.qualificationData.budgetAmount === 1200000, `Kiara budget parsed to 1200000 (got ${kLead.qualificationData.budgetAmount})`);
+    ok(kLead.qualificationData.budgetNote === "around 12 lakhs", "raw budget kept as the note");
+    mock.extractor = { qualified: false, escalate: false, escalateReason: "", classification: "lead", data: {} };
+
+    section("S6: meet-refuser");
+    const refuse = await api("POST", `/enquiry/${leadQ._id}/meet-refused`, { token: internToken });
+    ok(refuse.status === 200 && (refuse.data.tags || []).includes("no-meet"), "lead tagged no-meet");
+    ok(
+      !!(await LeadInternalEvent.findOne({ leadId: leadQ._id, type: "meet_refused" }).lean()),
+      "journey event meet_refused"
+    );
+    ok(
+      !!(await AdminNotification.findOne({ adminId: salesLead._id, type: "meet_refused", leadId: leadQ._id }).lean()),
+      "sales lead (reporting manager) escalated"
+    );
+    ok(
+      !!(await AdminNotification.findOne({ adminId: revenueHead._id, type: "meet_refused", leadId: leadQ._id }).lean()),
+      "Revenue Head notified"
+    );
+
+    section("S6: settings_scripts gating");
+    const scriptsDenied = await api("GET", "/settings?category=settings_scripts", { token: holderToken });
+    ok(scriptsDenied.status === 403, "settings_scripts denied without the permission");
+    const scriptsCat = await api("GET", "/settings?category=settings_scripts", { token: founderToken });
+    ok(
+      scriptsCat.status === 200 && Object.keys(scriptsCat.data.values || {}).length === 4,
+      "founder reads the scripts category (4 keys)"
+    );
+    const scriptPut = await api("PUT", "/settings", {
+      token: founderToken,
+      body: { key: "cockpit.briefScript", value: "Hi {{name}}, this is {{caller}} — quick test script." },
+    });
+    ok(scriptPut.status === 200, "script saves through the standard settings PUT");
+    const pub2 = await api("GET", "/settings/public", { token: internToken });
+    ok(String(pub2.data["cockpit.briefScript"]).includes("quick test script"), "cockpit renders the edited script via settings");
+    await Setting.deleteMany({ key: "cockpit.briefScript" }); // restore default
   } catch (e) {
     failed++;
     failures.push(`fatal: ${e.message}`);

--- a/scripts/e2e-mb56.js
+++ b/scripts/e2e-mb56.js
@@ -53,6 +53,7 @@ const waitFor = async (fn, label, timeoutMs = 20000, everyMs = 300) => {
 const mock = {
   anthropicCalls: [],
   metaCalls: [],
+  igCalls: [], // Instagram DM sends (Slice 7)
   replyText: "Lovely! Tell me more 😊",
   extractor: { qualified: false, escalate: false, escalateReason: "", classification: "lead", data: {} },
   anthropic429s: 0, // consume N 429s before answering (Slice 11)
@@ -82,6 +83,12 @@ const mockServer = http.createServer((req, res) => {
       mock.metaCalls.push({ phoneNumberId: graph[1], body });
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ messaging_product: "whatsapp", messages: [{ id: "wamid.mb56" }] }));
+      return;
+    }
+    if (req.url === "/iggraph/me/messages") {
+      mock.igCalls.push({ body });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ recipient_id: body.recipient && body.recipient.id, message_id: "igm.mb56" }));
       return;
     }
     res.writeHead(404);
@@ -115,6 +122,20 @@ const signedWebhook = async (payload) => {
   });
   return res.status;
 };
+const signedIgWebhook = async (instagramId, text) => {
+  const payload = {
+    entry: [{ messaging: [{ sender: { id: instagramId }, message: { text } }] }],
+  };
+  const raw = JSON.stringify(payload);
+  const sig = "sha256=" + crypto.createHmac("sha256", "mb56-ig-secret").update(raw).digest("hex");
+  const res = await fetch(`${BASE}/webhook/instagram-agent`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-hub-signature-256": sig },
+    body: raw,
+  });
+  return res.status;
+};
+
 const inboundText = (phone, text, profileName = "MB56 Customer") => ({
   entry: [
     {
@@ -258,6 +279,9 @@ const inboundText = (phone, text, profileName = "MB56 Customer") => ({
       WHATSAPP_AGENT_APP_SECRET: APP_SECRET,
       META_WA_AGENT_ACCESS_TOKEN: "mb56-token",
       GOOGLE_SHEETS_KEY_PATH: "/nonexistent/mb56-keyfile.json",
+      INSTAGRAM_AGENT_APP_SECRET: "mb56-ig-secret",
+      INSTAGRAM_AGENT_PAGE_ACCESS_TOKEN: "mb56-ig-token",
+      INSTAGRAM_GRAPH_BASE_URL: `http://localhost:${MOCK_PORT}/iggraph`,
     },
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -938,6 +962,98 @@ const inboundText = (phone, text, profileName = "MB56 Customer") => ({
     const pub2 = await api("GET", "/settings/public", { token: internToken });
     ok(String(pub2.data["cockpit.briefScript"]).includes("quick test script"), "cockpit renders the edited script via settings");
     await Setting.deleteMany({ key: "cockpit.briefScript" }); // restore default
+
+    // ════ SLICE 7 — Instagram hooks (MB4 pattern adapted) ════
+    section("S7: IG inbound → channel:'instagram' conversation, unlinked");
+    const IG1 = "MB56IG00000001";
+    ok((await signedIgWebhook(IG1, "Hi! Do you do engagement decor?")) === 200, "IG webhook accepts signed payload");
+    const igConv1 = await waitFor(async () => WAConversation.findOne({ phone: IG1 }).lean(), "IG conversation created");
+    ok(igConv1.channel === "instagram", "conversation carries channel:'instagram'");
+    ok(igConv1.enquiryId === null, "no phone yet → conversation lives UNLINKED");
+    await waitFor(async () => WAAgentMessage.findOne({ phone: IG1, role: "assistant" }).lean(), "IG Kiara replied");
+    ok(mock.igCalls.some((c) => c.body.recipient.id === IG1), "reply delivered as an Instagram DM (mock)");
+    const igInbox = await api("GET", "/wa/conversations?status=active&limit=100", { token: founderToken });
+    const igRow = (igInbox.data.list || []).find((c) => c.phone === IG1);
+    ok(!!igRow && igRow.channel === "instagram" && igRow.lead === null, "unlinked IG thread surfaces in the inbox, badged by channel");
+
+    section("S7: IG mode gate — takeover silences the bot identically");
+    const takeIg = await api("POST", `/wa/conversations/${igConv1._id}/takeover`, { token: founderToken });
+    ok(takeIg.status === 200 && takeIg.data.mode === "human", "takeover works on IG threads");
+    const igCallsBefore = mock.anthropicCalls.length;
+    const igMsgsBefore = await WAAgentMessage.countDocuments({ phone: IG1, role: "assistant" });
+    await signedIgWebhook(IG1, "hello? anyone there?");
+    await waitFor(async () => WAAgentMessage.findOne({ phone: IG1, message: "hello? anyone there?" }).lean(), "human-mode IG inbound stored");
+    await sleep(1200);
+    ok(mock.anthropicCalls.length === igCallsBefore, "NO Anthropic call in human mode (IG)");
+    ok((await WAAgentMessage.countDocuments({ phone: IG1, role: "assistant" })) === igMsgsBefore, "NO auto-reply in human mode (IG)");
+    const igDmsBefore = mock.igCalls.length;
+    const igSend = await api("POST", `/wa/conversations/${igConv1._id}/send`, {
+      token: founderToken,
+      body: { text: "Hi! This is the Wedsy team — happy to help directly." },
+    });
+    ok(igSend.status === 200, "admin send works on IG threads");
+    ok(mock.igCalls.length === igDmsBefore + 1 && mock.metaCalls.every((m) => m.body.to !== IG1), "admin send goes out as an IG DM, never WhatsApp");
+    const igTpl = await api("POST", `/wa/conversations/${igConv1._id}/send-template`, { token: founderToken });
+    ok(igTpl.status === 422, "re-engage template blocked on IG (WhatsApp-only feature)");
+    const backIg = await api("POST", `/wa/conversations/${igConv1._id}/handback`, { token: founderToken });
+    ok(backIg.status === 200 && backIg.data.mode === "ai", "handback resumes the IG bot");
+
+    section("S7: IG escalation contract");
+    const IG2 = "MB56IG00000002";
+    mock.extractor = { qualified: false, escalate: true, escalateReason: "Customer wants a human", classification: "lead", data: {} };
+    await signedIgWebhook(IG2, "I want to talk to a real person please");
+    const igConv2 = await waitFor(async () => {
+      const c = await WAConversation.findOne({ phone: IG2 }).lean();
+      return c && c.needsHuman ? c : null;
+    }, "IG escalation flips needsHuman");
+    ok(igConv2.needsHuman && igConv2.needsHumanReason === "Customer wants a human", "escalation reason recorded");
+    mock.extractor = { qualified: false, escalate: false, escalateReason: "", classification: "lead", data: {} };
+
+    section("S7: IG phone capture → CRM linkage + qualified sync");
+    const IG3 = "MB56IG00000003";
+    mock.extractor = {
+      qualified: true,
+      escalate: true,
+      escalateReason: "Qualified — ready for your call",
+      classification: "lead",
+      data: {
+        name: "Insta Bride",
+        phoneNumber: "9191000505",
+        eventType: "wedding",
+        city: "Bengaluru",
+        servicesRequired: "decor and catering",
+        budget: "20 lakhs",
+      },
+    };
+    await signedIgWebhook(IG3, "Sure, my number is 9191000505");
+    const igConv3 = await waitFor(async () => {
+      const c = await WAConversation.findOne({ phone: IG3 }).lean();
+      return c && c.enquiryId ? c : null;
+    }, "IG conversation linked once phone captured", 40000);
+    const igLead = await Enquiry.findById(igConv3.enquiryId).lean();
+    ok(igLead.source === "instagram" && igLead.phone === "919191000505", "CRM lead created with source instagram + real phone");
+    ok(
+      !!(await LeadInternalEvent.findOne({ leadId: igLead._id, type: "ig_conversation_linked" }).lean()),
+      "journey event ig_conversation_linked"
+    );
+    await waitFor(async () => {
+      const l = await Enquiry.findById(igLead._id).lean();
+      return l.qualified ? l : null;
+    }, "IG qualified sync");
+    ok(
+      !!(await LeadInternalEvent.findOne({ leadId: igLead._id, type: "ig_qualified_by_kiara" }).lean()),
+      "journey event ig_qualified_by_kiara"
+    );
+    const igLeadFinal = await Enquiry.findById(igLead._id).lean();
+    ok(
+      (igLeadFinal.qualificationData.servicesRequired || []).includes("Decor") &&
+        (igLeadFinal.qualificationData.servicesRequired || []).includes("Catering"),
+      "IG services mapped into cockpit fields"
+    );
+    ok(igLeadFinal.qualificationData.budgetAmount === 2000000, "IG budget parsed (20 lakhs → 2000000)");
+    const igQl = await QualifiedLead.findOne({ phone: IG3 }).lean();
+    ok(!!igQl && igQl.crmSynced === true, "QualifiedLead.crmSynced mirrors the WA idiom");
+    mock.extractor = { qualified: false, escalate: false, escalateReason: "", classification: "lead", data: {} };
   } catch (e) {
     failed++;
     failures.push(`fatal: ${e.message}`);
@@ -945,14 +1061,19 @@ const inboundText = (phone, text, profileName = "MB56 Customer") => ({
     console.error("server log tail:", serverLog.slice(-2000));
   } finally {
     section("Cleanup");
-    const leads = await Enquiry.find({ phone: { $regex: `^${PHONE_PREFIX}` } }, { _id: 1 }).lean();
+    const leads = await Enquiry.find(
+      { phone: { $regex: `^(${PHONE_PREFIX}|919191000)` } },
+      { _id: 1 }
+    ).lean();
     const leadIds = leads.map((l) => l._id);
     await LeadInternalEvent.deleteMany({ leadId: { $in: leadIds } });
-    await Enquiry.deleteMany({ phone: { $regex: `^${PHONE_PREFIX}` } });
-    await WAConversation.deleteMany({ phone: { $regex: `^${PHONE_PREFIX}` } });
-    await WAAgentMessage.deleteMany({ phone: { $regex: `^${PHONE_PREFIX}` } });
-    await QualifiedLead.deleteMany({ phone: { $regex: `^${PHONE_PREFIX}` } });
-    await NotificationFailureLog.deleteMany({ phone: { $regex: `^${PHONE_PREFIX}` } });
+    await Enquiry.deleteMany({ phone: { $regex: `^(${PHONE_PREFIX}|919191000)` } });
+    await WAConversation.deleteMany({ phone: { $regex: `^(${PHONE_PREFIX}|MB56IG)` } });
+    await WAAgentMessage.deleteMany({ phone: { $regex: `^(${PHONE_PREFIX}|MB56IG)` } });
+    await QualifiedLead.deleteMany({ phone: { $regex: `^(${PHONE_PREFIX}|MB56IG)` } });
+    await NotificationFailureLog.deleteMany({ phone: { $regex: `^(${PHONE_PREFIX}|MB56IG)` } });
+    const VendorContact = require("../models/VendorContact");
+    await VendorContact.deleteMany({ phone: { $regex: `^(${PHONE_PREFIX}|MB56IG)` } });
     await Attendance.deleteMany({ adminId: { $in: [founder._id, salesLead._id, intern._id] } });
     const allAdminIds = [founder._id, salesLead._id, intern._id, holder._id, revenueHead._id];
     const CalendarEventModel = require("../models/CalendarEvent");

--- a/scripts/e2e-mb56.js
+++ b/scripts/e2e-mb56.js
@@ -1286,6 +1286,129 @@ const inboundText = (phone, text, profileName = "MB56 Customer") => ({
     } finally {
       dormantChild.kill();
     }
+
+    // ════ SLICE 9 — Filters + saved views ════
+    section("S9: new filter keys");
+    const fLead = await Enquiry.create({
+      name: `${MARK} FilterLead`,
+      phone: phone(601),
+      verified: false,
+      source: "Website",
+      additionalInfo: { eventMonth: "December" },
+      stage: "new",
+      assignedTo: salesLead._id,
+      qualified: true,
+    });
+    await api("PUT", `/enquiry/${fLead._id}/qualification`, {
+      token: salesLeadToken,
+      body: {
+        servicesRequired: ["Decor", "Catering"],
+        budgetAmount: 1800000,
+        email: "filter@example.com",
+        venueStatus: "booked",
+      },
+    });
+    await api("POST", `/enquiry/${fLead._id}/follow-up`, {
+      token: salesLeadToken,
+      body: { type: "meet", scheduledAt: new Date(Date.now() + 3 * 24 * 3600 * 1000).toISOString() },
+    });
+    const fLead2 = await Enquiry.create({
+      name: `${MARK} FilterLead2`,
+      phone: phone(602),
+      verified: false,
+      source: "Website",
+      additionalInfo: {},
+      stage: "new",
+      assignedTo: salesLead._id,
+      reEnquiredAt: new Date(),
+      followUps: [{ type: "call", scheduledAt: new Date(Date.now() - 24 * 3600 * 1000) }],
+    });
+
+    const filterQuery = async (filters, token = salesLeadToken) =>
+      api("GET", `/enquiry?limit=200&filters=${encodeURIComponent(JSON.stringify(filters))}`, { token });
+    const hits = (resp, id) => (resp.data.list || []).some((l) => String(l._id) === String(id));
+
+    let r = await filterQuery([{ field: "qualificationData.servicesRequired", op: "in", value: ["Decor", "Venue"] }]);
+    ok(r.status === 200 && hits(r, fLead._id) && !hits(r, fLead2._id), "servicesRequired any-of");
+    r = await filterQuery([
+      { field: "qualificationData.budgetAmount", op: "gte", value: 1000000 },
+      { field: "qualificationData.budgetAmount", op: "lte", value: 2000000 },
+    ]);
+    ok(hits(r, fLead._id), "budget range (gte+lte)");
+    r = await filterQuery([{ field: "healthBand", op: "eq", value: "Hot" }]);
+    ok(hits(r, fLead._id) && !hits(r, fLead2._id), "healthBand Hot (qualified + venue + email + next step)");
+    r = await filterQuery([{ field: "healthBand", op: "eq", value: "Cold" }]);
+    ok(hits(r, fLead2._id) && !hits(r, fLead._id), "healthBand Cold (unqualified)");
+    r = await filterQuery([{ field: "hasMeetingBooked", op: "eq", value: true }]);
+    ok(hits(r, fLead._id) && !hits(r, fLead2._id), "hasMeetingBooked");
+    r = await filterQuery([{ field: "overdueFollowUps", op: "eq", value: true }]);
+    ok(hits(r, fLead2._id) && !hits(r, fLead._id), "overdueFollowUps");
+    r = await filterQuery([{ field: "reEnquired", op: "eq", value: true }]);
+    ok(hits(r, fLead2._id) && !hits(r, fLead._id), "reEnquired y/n");
+    r = await filterQuery([{ field: "additionalInfo.eventMonth", op: "eq", value: "December" }]);
+    ok(hits(r, fLead._id) && !hits(r, fLead2._id), "eventMonth");
+    r = await filterQuery([{ field: "qualificationData.venueStatus", op: "eq", value: "booked" }]);
+    ok(hits(r, fLead._id), "venueStatus");
+    r = await filterQuery([{ field: "updatedAt", op: "gte", value: new Date(Date.now() - 3600 * 1000).toISOString() }]);
+    ok(hits(r, fLead._id), "lastActivity recency (updatedAt gte)");
+    // Kiara-derived: reuse a fresh webhook lead.
+    const pF = phone(603);
+    await signedWebhook(inboundText(pF, "Hi, planning!", "Filter Kiara"));
+    const fConv = await waitFor(async () => {
+      const c = await WAConversation.findOne({ phone: pF }).lean();
+      return c && c.enquiryId ? c : null;
+    }, "filter kiara lead");
+    r = await filterQuery([{ field: "kiaraChatting", op: "eq", value: true }], founderToken);
+    ok(hits(r, fConv.enquiryId) && !hits(r, fLead._id), "kiaraChatting (live ai conversation)");
+    r = await filterQuery([{ field: "needsHuman", op: "eq", value: true }], founderToken);
+    ok(!hits(r, fConv.enquiryId), "needsHuman false until escalation");
+    const badField = await filterQuery([{ field: "hacked", op: "eq", value: 1 }]);
+    ok(badField.status === 400, "unknown filter field still 400 (strict whitelist)");
+
+    section("S9: scope is preserved under the new filters");
+    const internView = await filterQuery([{ field: "healthBand", op: "eq", value: "Hot" }], internToken);
+    ok(internView.status === 200 && !hits(internView, fLead._id), "own-scope intern can't see another owner's Hot lead");
+
+    section("S9: saved views CRUD");
+    const svCreate = await api("POST", "/saved-views", {
+      token: internToken,
+      body: {
+        name: "My hot meets",
+        filters: [
+          { field: "healthBand", op: "eq", value: "Hot" },
+          { field: "hasMeetingBooked", op: "eq", value: true },
+        ],
+        view: "active",
+        isDefault: true,
+      },
+    });
+    ok(svCreate.status === 201 && svCreate.data.isDefault === true, "saved view created (default)");
+    const svJunk = await api("POST", "/saved-views", {
+      token: internToken,
+      body: { name: "junk", filters: [{ field: "hacked", op: "eq", value: 1 }] },
+    });
+    ok(svJunk.status === 400, "saved view filters re-validated (junk → 400)");
+    const svDup = await api("POST", "/saved-views", {
+      token: internToken,
+      body: { name: "My hot meets", filters: [] },
+    });
+    ok(svDup.status === 409, "duplicate name rejected (409)");
+    const svRename = await api("PUT", `/saved-views/${svCreate.data._id}`, {
+      token: internToken,
+      body: { name: "Hot meets v2" },
+    });
+    ok(svRename.status === 200 && svRename.data.name === "Hot meets v2", "rename works");
+    const svListIntern = await api("GET", "/saved-views", { token: internToken });
+    ok((svListIntern.data.list || []).length === 1, "owner lists their views");
+    const svListOther = await api("GET", "/saved-views", { token: salesLeadToken });
+    ok(
+      !(svListOther.data.list || []).some((v) => String(v._id) === String(svCreate.data._id)),
+      "views are strictly per-user"
+    );
+    const svForeignDelete = await api("DELETE", `/saved-views/${svCreate.data._id}`, { token: salesLeadToken });
+    ok(svForeignDelete.status === 404, "cannot delete someone else's view");
+    const svDelete = await api("DELETE", `/saved-views/${svCreate.data._id}`, { token: internToken });
+    ok(svDelete.status === 200, "delete works");
   } catch (e) {
     failed++;
     failures.push(`fatal: ${e.message}`);
@@ -1310,6 +1433,8 @@ const inboundText = (phone, text, profileName = "MB56 Customer") => ({
     const allAdminIds = [founder._id, salesLead._id, intern._id, holder._id, revenueHead._id];
     const GoogleAccountModel = require("../models/GoogleAccount");
     await GoogleAccountModel.deleteMany({ adminId: { $in: allAdminIds } });
+    const SavedViewModel = require("../models/SavedView");
+    await SavedViewModel.deleteMany({ adminId: { $in: allAdminIds } });
     const CalendarEventModel = require("../models/CalendarEvent");
     const AdminNotificationModel = require("../models/AdminNotification");
     await CalendarEventModel.deleteMany({ ownerId: { $in: allAdminIds } });

--- a/scripts/e2e-mb56.js
+++ b/scripts/e2e-mb56.js
@@ -1,0 +1,336 @@
+/* MEGA-BUILD 5+6 — end-to-end suite (grows slice by slice).
+ *
+ * Boots the real server on TEST ports with Anthropic/Meta mocked (same seams
+ * as e2e-kiara) and drives the new surfaces: attendance, calendar/meeting
+ * mode/huddles, triage, safety net, cockpit v2, Google (mocked), filters,
+ * metrics, 429 queue. Local DB only; cleans every fixture it creates.
+ *
+ * Run: node scripts/e2e-mb56.js
+ */
+require("dotenv").config();
+const http = require("http");
+const crypto = require("crypto");
+const { spawn } = require("child_process");
+const mongoose = require("mongoose");
+const jwt = require("jsonwebtoken");
+
+const APP_PORT = 8127;
+const MOCK_PORT = 8128;
+const BASE = `http://localhost:${APP_PORT}`;
+const APP_SECRET = process.env.WHATSAPP_AGENT_APP_SECRET || "kiara-e2e-secret";
+const PHONE_PREFIX = "9191000"; // every mb56 test phone starts with this
+const MARK = "MB56-E2E";
+
+// ── Tiny harness ──────────────────────────────────────────────────────────────
+let passed = 0;
+let failed = 0;
+const failures = [];
+const ok = (cond, label) => {
+  if (cond) {
+    passed++;
+    console.log(`  ✓ ${label}`);
+  } else {
+    failed++;
+    failures.push(label);
+    console.error(`  ✗ ${label}`);
+  }
+};
+const section = (t) => console.log(`\n── ${t} ──`);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const waitFor = async (fn, label, timeoutMs = 20000, everyMs = 300) => {
+  const until = Date.now() + timeoutMs;
+  while (Date.now() < until) {
+    try {
+      const v = await fn();
+      if (v) return v;
+    } catch (_) {}
+    await sleep(everyMs);
+  }
+  throw new Error(`waitFor timed out: ${label}`);
+};
+
+// ── Mock Anthropic + Meta ─────────────────────────────────────────────────────
+const mock = {
+  anthropicCalls: [],
+  metaCalls: [],
+  replyText: "Lovely! Tell me more 😊",
+  extractor: { qualified: false, escalate: false, escalateReason: "", classification: "lead", data: {} },
+  anthropic429s: 0, // consume N 429s before answering (Slice 11)
+};
+const mockServer = http.createServer((req, res) => {
+  let raw = "";
+  req.on("data", (c) => (raw += c));
+  req.on("end", () => {
+    const body = raw ? JSON.parse(raw) : {};
+    if (req.url === "/v1/messages") {
+      if (mock.anthropic429s > 0) {
+        mock.anthropic429s--;
+        res.writeHead(429, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ type: "error", error: { type: "rate_limit_error" } }));
+        return;
+      }
+      mock.anthropicCalls.push({ system: body.system, messages: body.messages });
+      const content = String(body.system || "").startsWith("You are a data extractor")
+        ? [{ type: "text", text: JSON.stringify(mock.extractor) }]
+        : [{ type: "text", text: mock.replyText }];
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ id: "msg_mb56", content, stop_reason: "end_turn" }));
+      return;
+    }
+    const graph = req.url.match(/^\/graph\/([^/]+)\/messages$/);
+    if (graph) {
+      mock.metaCalls.push({ phoneNumberId: graph[1], body });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ messaging_product: "whatsapp", messages: [{ id: "wamid.mb56" }] }));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+});
+
+// ── HTTP helpers ──────────────────────────────────────────────────────────────
+const api = async (method, path, { token, body } = {}) => {
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(body ? { "Content-Type": "application/json" } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  let data = null;
+  try {
+    data = await res.json();
+  } catch (_) {}
+  return { status: res.status, data };
+};
+const signedWebhook = async (payload) => {
+  const raw = JSON.stringify(payload);
+  const sig = "sha256=" + crypto.createHmac("sha256", APP_SECRET).update(raw).digest("hex");
+  const res = await fetch(`${BASE}/webhook/whatsapp-agent`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-hub-signature-256": sig },
+    body: raw,
+  });
+  return res.status;
+};
+const inboundText = (phone, text, profileName = "MB56 Customer") => ({
+  entry: [
+    {
+      changes: [
+        {
+          value: {
+            contacts: [{ profile: { name: profileName }, wa_id: phone }],
+            messages: [{ from: phone, id: `wamid.in.${Date.now()}.${Math.floor(Math.random() * 1e6)}`, type: "text", text: { body: text } }],
+          },
+        },
+      ],
+    },
+  ],
+});
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+(async () => {
+  if (!process.env.DATABASE_URL || !process.env.JWT_SECRET) {
+    console.error("DATABASE_URL / JWT_SECRET missing.");
+    process.exit(1);
+  }
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Enquiry = require("../models/Enquiry");
+  const WAConversation = require("../models/WAConversation");
+  const WAAgentMessage = require("../models/WAAgentMessage");
+  const QualifiedLead = require("../models/QualifiedLead");
+  const LeadInternalEvent = require("../models/LeadInternalEvent");
+  const NotificationFailureLog = require("../models/NotificationFailureLog");
+  const Setting = require("../models/Setting");
+  const Admin = require("../models/Admin");
+  const Role = require("../models/Role");
+  const Department = require("../models/Department");
+  const Attendance = require("../models/Attendance");
+
+  // ── Fixtures ────────────────────────────────────────────────────────────────
+  const dept = await Department.create({ name: `${MARK} Dept` });
+  const founderRole = await Role.create({
+    name: `${MARK} Founder`,
+    departmentId: dept._id,
+    permissions: ["*:*:all"],
+  });
+  const salesLeadRole = await Role.create({
+    name: `${MARK} SalesLead`,
+    departmentId: dept._id,
+    permissions: ["leads:view:team", "leads:edit:team"],
+  });
+  const internRole = await Role.create({
+    name: `${MARK} Intern`,
+    departmentId: dept._id,
+    permissions: ["leads:view:own", "leads:edit:own"],
+  });
+  const founder = await Admin.create({
+    name: `${MARK} Founder`,
+    email: `mb56-founder-${Date.now()}@test.local`,
+    phone: "919191000001",
+    password: "x",
+    roles: ["crm", "owner"],
+    roleId: founderRole._id,
+    departmentId: dept._id,
+    status: "active",
+  });
+  const salesLead = await Admin.create({
+    name: `${MARK} SalesLead`,
+    email: `mb56-saleslead-${Date.now()}@test.local`,
+    phone: "919191000002",
+    password: "x",
+    roles: ["sales"],
+    roleId: salesLeadRole._id,
+    departmentId: dept._id,
+    status: "active",
+  });
+  const intern = await Admin.create({
+    name: `${MARK} Intern`,
+    email: `mb56-intern-${Date.now()}@test.local`,
+    phone: "919191000003",
+    password: "x",
+    roles: ["sales"],
+    roleId: internRole._id,
+    departmentId: dept._id,
+    reportingManagerId: salesLead._id,
+    status: "active",
+  });
+  const tok = (a) => jwt.sign({ _id: String(a._id), isAdmin: true }, process.env.JWT_SECRET);
+  const founderToken = tok(founder);
+  const salesLeadToken = tok(salesLead);
+  const internToken = tok(intern);
+
+  const touchedKeys = ["assignment.poolRoles"];
+  const settingsBefore = await Setting.find({ key: { $in: touchedKeys } }).lean();
+
+  await new Promise((r) => mockServer.listen(MOCK_PORT, r));
+  const child = spawn("node", ["server.js"], {
+    cwd: `${__dirname}/..`,
+    env: {
+      ...process.env,
+      PORT: String(APP_PORT),
+      ANTHROPIC_API_URL: `http://localhost:${MOCK_PORT}/v1/messages`,
+      META_GRAPH_BASE_URL: `http://localhost:${MOCK_PORT}/graph`,
+      WHATSAPP_AGENT_PHONE_NUMBER_ID: "MB56_AGENT",
+      WHATSAPP_AGENT_APP_SECRET: APP_SECRET,
+      META_WA_AGENT_ACCESS_TOKEN: "mb56-token",
+      GOOGLE_SHEETS_KEY_PATH: "/nonexistent/mb56-keyfile.json",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let serverLog = "";
+  child.stdout.on("data", (d) => (serverLog += d));
+  child.stderr.on("data", (d) => (serverLog += d));
+
+  const phones = [];
+  const phone = (n) => {
+    const p = `${PHONE_PREFIX}${String(n).padStart(5, "0")}`;
+    if (!phones.includes(p)) phones.push(p);
+    return p;
+  };
+
+  try {
+    await waitFor(() => fetch(`${BASE}/`).then((r) => r.ok).catch(() => false), "server boot", 30000);
+    await api("PUT", "/settings", {
+      token: founderToken,
+      body: { key: "assignment.poolRoles", value: [`${MARK} Intern`] },
+    });
+
+    // ════ SLICE 2 — Attendance & employee status ════
+    section("S2: check-in / heartbeat / idle / check-out");
+    let me = await api("GET", "/attendance/me", { token: internToken });
+    ok(me.status === 200 && me.data.status === "checked_out", "fresh day starts checked_out");
+
+    let ci = await api("POST", "/attendance/check-in", { token: internToken });
+    ok(ci.status === 200 && ci.data.status === "online" && ci.data.checkInAt, "check-in → online");
+
+    const ciAgain = await api("POST", "/attendance/check-in", { token: internToken });
+    ok(ciAgain.status === 200, "check-in is idempotent");
+
+    let hb = await api("POST", "/attendance/heartbeat", { token: internToken });
+    ok(hb.status === 200, "heartbeat accepted while checked in");
+
+    // Simulate 6 minutes of silence by rewinding lastHeartbeatAt in the DB.
+    await Attendance.updateOne(
+      { adminId: intern._id },
+      { $set: { lastHeartbeatAt: new Date(Date.now() - 6 * 60 * 1000) } }
+    );
+    me = await api("GET", "/attendance/me", { token: internToken });
+    ok(me.data.status === "idle", "5-min heartbeat gap derives idle");
+
+    hb = await api("POST", "/attendance/heartbeat", { token: internToken });
+    me = await api("GET", "/attendance/me", { token: internToken });
+    ok(me.data.status === "online", "heartbeat after gap → back online");
+    ok(me.data.idleMs >= 6 * 60 * 1000 - 5000, `gap recorded as idle (idleMs=${me.data.idleMs})`);
+    const att = await Attendance.findOne({ adminId: intern._id }).lean();
+    ok(att.idleSegments.length === 1, "idle segment persisted");
+
+    section("S2: transparency + team scope");
+    ok(typeof me.data.idleMs === "number" && me.data.checkInAt, "employee sees own status + idle total");
+
+    const teamFounder = await api("GET", "/attendance/team", { token: founderToken });
+    ok(teamFounder.status === 200, "founder team list loads");
+    const fNames = (teamFounder.data.list || []).map((r) => r.name);
+    ok(fNames.includes(`${MARK} Intern`) && fNames.includes(`${MARK} Founder`), "founder sees everyone");
+
+    const teamIntern = await api("GET", "/attendance/team", { token: internToken });
+    const iRows = (teamIntern.data.list || []).filter((r) => String(r.name).startsWith(MARK));
+    ok(iRows.length === 1 && iRows[0].name === `${MARK} Intern`, "own-scope intern sees only self");
+
+    const teamLead = await api("GET", "/attendance/team", { token: salesLeadToken });
+    const lNames = (teamLead.data.list || []).map((r) => r.name);
+    ok(
+      lNames.includes(`${MARK} Intern`) && lNames.includes(`${MARK} SalesLead`) && !lNames.includes(`${MARK} Founder`),
+      "team-scope sales lead sees self + subordinate, not founder"
+    );
+    const internRow = (teamLead.data.list || []).find((r) => r.name === `${MARK} Intern`);
+    ok(internRow && internRow.status === "online" && internRow.idleMs >= 0, "team row carries live status + idle");
+
+    section("S2: check-out");
+    let co = await api("POST", "/attendance/check-out", { token: internToken });
+    ok(co.status === 200 && co.data.status === "checked_out" && co.data.checkOutAt, "check-out → checked_out");
+    co = await api("POST", "/attendance/check-out", { token: internToken });
+    ok(co.status === 409, "double check-out rejected (409)");
+    ci = await api("POST", "/attendance/check-in", { token: internToken });
+    ok(ci.status === 200 && ci.data.status === "online" && !ci.data.checkOutAt, "re-check-in re-opens the day");
+    const att2 = await Attendance.findOne({ adminId: intern._id }).lean();
+    ok(att2.idleSegments.length >= 1 && att2.checkInAt, "timestamps persist across the day (payroll-safe)");
+    await api("POST", "/attendance/check-out", { token: internToken });
+  } catch (e) {
+    failed++;
+    failures.push(`fatal: ${e.message}`);
+    console.error("FATAL:", e);
+    console.error("server log tail:", serverLog.slice(-2000));
+  } finally {
+    section("Cleanup");
+    const leads = await Enquiry.find({ phone: { $regex: `^${PHONE_PREFIX}` } }, { _id: 1 }).lean();
+    const leadIds = leads.map((l) => l._id);
+    await LeadInternalEvent.deleteMany({ leadId: { $in: leadIds } });
+    await Enquiry.deleteMany({ phone: { $regex: `^${PHONE_PREFIX}` } });
+    await WAConversation.deleteMany({ phone: { $regex: `^${PHONE_PREFIX}` } });
+    await WAAgentMessage.deleteMany({ phone: { $regex: `^${PHONE_PREFIX}` } });
+    await QualifiedLead.deleteMany({ phone: { $regex: `^${PHONE_PREFIX}` } });
+    await NotificationFailureLog.deleteMany({ phone: { $regex: `^${PHONE_PREFIX}` } });
+    await Attendance.deleteMany({ adminId: { $in: [founder._id, salesLead._id, intern._id] } });
+    await Admin.deleteMany({ _id: { $in: [founder._id, salesLead._id, intern._id] } });
+    await Role.deleteMany({ _id: { $in: [founderRole._id, salesLeadRole._id, internRole._id] } });
+    await Department.deleteMany({ _id: dept._id });
+    await Setting.deleteMany({ key: { $in: touchedKeys } });
+    if (settingsBefore.length) await Setting.insertMany(settingsBefore.map(({ _id, ...rest }) => rest));
+    const leftovers = await Promise.all([
+      Enquiry.countDocuments({ phone: { $regex: `^${PHONE_PREFIX}` } }),
+      WAConversation.countDocuments({ phone: { $regex: `^${PHONE_PREFIX}` } }),
+      Admin.countDocuments({ email: { $regex: "^mb56-" } }),
+      Attendance.countDocuments({ adminId: { $in: [founder._id, salesLead._id, intern._id] } }),
+    ]);
+    console.log(`  cleanup leftovers (should be all 0): ${leftovers.join(", ")}`);
+    child.kill();
+    mockServer.close();
+    await mongoose.disconnect();
+    console.log(`\n══ RESULT: ${passed} passed, ${failed} failed ══`);
+    if (failures.length) console.log("failures:", failures.join(" | "));
+    process.exit(failed === 0 ? 0 : 1);
+  }
+})();

--- a/scripts/e2e-mb56.js
+++ b/scripts/e2e-mb56.js
@@ -298,6 +298,193 @@ const inboundText = (phone, text, profileName = "MB56 Customer") => ({
     const att2 = await Attendance.findOne({ adminId: intern._id }).lean();
     ok(att2.idleSegments.length >= 1 && att2.checkInAt, "timestamps persist across the day (payroll-safe)");
     await api("POST", "/attendance/check-out", { token: internToken });
+
+    // ════ SLICE 3 — Calendar, meeting mode, huddle, handoff ════
+    section("S3: handoff — meet booked on intern-owned lead");
+    const lead1 = await Enquiry.create({
+      name: `${MARK} HandoffLead`,
+      phone: phone(101),
+      verified: false,
+      source: "Website",
+      additionalInfo: {},
+      stage: "new",
+      assignedTo: intern._id,
+    });
+    const meetAt = new Date(Date.now() + 2 * 24 * 60 * 60 * 1000); // +2 days
+    const bookMeet = await api("POST", `/enquiry/${lead1._id}/follow-up`, {
+      token: internToken,
+      body: { type: "meet", scheduledAt: meetAt.toISOString(), promiseNote: "demo" },
+    });
+    ok(bookMeet.status === 200 || bookMeet.status === 201, "meet follow-up booked");
+    const lead1After = await Enquiry.findById(lead1._id).lean();
+    ok(String(lead1After.assignedTo) === String(salesLead._id), "lead auto-transferred to reportingManager");
+    ok(String(lead1After.qualifiedBy) === String(intern._id), "intern permanently credited (qualifiedBy)");
+    ok(
+      !!(await LeadInternalEvent.findOne({ leadId: lead1._id, type: "meet_handoff" }).lean()),
+      "journey event meet_handoff"
+    );
+    ok(
+      !!(await LeadInternalEvent.findOne({ leadId: lead1._id, type: "transferred", "payload.reason": "meet_handoff" }).lean()),
+      "journey event transferred (reason meet_handoff)"
+    );
+    const AdminNotification = require("../models/AdminNotification");
+    ok(
+      !!(await AdminNotification.findOne({ adminId: intern._id, type: "meet_handoff" }).lean()) &&
+        !!(await AdminNotification.findOne({ adminId: salesLead._id, type: "meet_handoff" }).lean()),
+      "both intern and manager notified"
+    );
+    const CalendarEvent = require("../models/CalendarEvent");
+    const gmeetEv = await CalendarEvent.findOne({ leadId: lead1._id, type: "gmeet" }).lean();
+    ok(!!gmeetEv && String(gmeetEv.ownerId) === String(salesLead._id), "gmeet mirrored onto the manager's calendar");
+    const huddleEv = await CalendarEvent.findOne({ leadId: lead1._id, type: "huddle", status: "scheduled" }).lean();
+    ok(!!huddleEv && String(huddleEv.ownerId) === String(salesLead._id), "huddle auto-created for the sales lead");
+
+    section("S3: huddle countdown chip + completion");
+    let leadCal = await api("GET", `/calendar/lead/${lead1._id}`, { token: salesLeadToken });
+    ok(
+      leadCal.status === 200 && leadCal.data.huddle && leadCal.data.huddle.pending && leadCal.data.huddle.msToMeet > 0,
+      "client-file chip: huddle pending with countdown"
+    );
+    const noNotes = await api("POST", `/calendar/huddles/${huddleEv._id}/complete`, {
+      token: salesLeadToken,
+      body: { attendeeIds: [String(salesLead._id)], eventTeam: [] },
+    });
+    ok(noNotes.status === 422, "huddle completion requires notes (422)");
+    const huddleDone = await api("POST", `/calendar/huddles/${huddleEv._id}/complete`, {
+      token: salesLeadToken,
+      body: {
+        attendeeIds: [String(salesLead._id), String(intern._id)],
+        eventTeam: [{ adminId: String(intern._id), label: "Decor" }],
+        notes: "Aligned on decor budget and venue pitch",
+      },
+    });
+    ok(huddleDone.status === 200 && huddleDone.data.status === "closed", "huddle completed");
+    const lead1Team = await Enquiry.findById(lead1._id).lean();
+    ok(
+      (lead1Team.eventTeam || []).length === 1 && lead1Team.eventTeam[0].label === "Decor",
+      "eventTeam written onto the lead"
+    );
+    ok(
+      !!(await LeadInternalEvent.findOne({ leadId: lead1._id, type: "huddle_completed" }).lean()),
+      "journey event huddle_completed"
+    );
+    leadCal = await api("GET", `/calendar/lead/${lead1._id}`, { token: salesLeadToken });
+    ok(leadCal.data.huddle && leadCal.data.huddle.pending === false, "chip flips to huddle-complete");
+
+    section("S3: meeting-notes gate + blocking");
+    // A meeting that is already over (unclosed).
+    const pastMeeting = await api("POST", "/calendar/events", {
+      token: internToken,
+      body: {
+        type: "meeting",
+        title: "MB56 past client meeting",
+        start: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+        end: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+        leadId: String(lead1._id),
+      },
+    });
+    ok(pastMeeting.status === 201, "past meeting created (test fixture)");
+    const closeNoNotes = await api("POST", `/calendar/events/${pastMeeting.data._id}/close`, {
+      token: internToken,
+      body: {},
+    });
+    ok(closeNoNotes.status === 422, "meeting cannot be closed without notes (422)");
+    const blockedNext = await api("POST", "/calendar/events", {
+      token: internToken,
+      body: {
+        type: "meeting",
+        title: "MB56 next meeting",
+        start: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        end: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
+      },
+    });
+    ok(blockedNext.status === 422, "unclosed meeting BLOCKS starting the next one (422)");
+    let mm = await api("GET", "/calendar/meeting-mode", { token: internToken });
+    ok(mm.status === 200 && mm.data.blocked && mm.data.unclosed.length === 1, "meeting-mode: unclosed pinned + blocked");
+    const unclosedRH = await api("GET", "/calendar/unclosed", { token: salesLeadToken });
+    ok(
+      unclosedRH.status === 200 &&
+        (unclosedRH.data.list || []).some((u) => String(u._id) === String(pastMeeting.data._id)),
+      "Revenue-Head view lists the team's unclosed meetings"
+    );
+    const draftNotes = await api("PUT", `/calendar/events/${pastMeeting.data._id}/notes`, {
+      token: internToken,
+      body: { notes: "Client wants pastel decor, budget 12L" },
+    });
+    ok(draftNotes.status === 200, "live notes pane saves a draft");
+    const closeOk = await api("POST", `/calendar/events/${pastMeeting.data._id}/close`, {
+      token: internToken,
+      body: {},
+    });
+    ok(closeOk.status === 200 && closeOk.data.status === "closed", "close succeeds using the captured notes");
+    ok(
+      !!(await LeadInternalEvent.findOne({ leadId: lead1._id, type: "meeting_closed" }).lean()),
+      "journey event meeting_closed"
+    );
+    const unblocked = await api("POST", "/calendar/events", {
+      token: internToken,
+      body: {
+        type: "meeting",
+        title: "MB56 live meeting",
+        start: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+        end: new Date(Date.now() + 50 * 60 * 1000).toISOString(),
+        leadId: String(lead1._id),
+      },
+    });
+    ok(unblocked.status === 201, "after closing, the next meeting can start");
+
+    section("S3: live meeting → banner + in_meeting status");
+    mm = await api("GET", "/calendar/meeting-mode", { token: internToken });
+    ok(
+      mm.data.live && String(mm.data.live._id) === String(unblocked.data._id) && mm.data.live.lead,
+      "meeting banner: live meeting with lead attached"
+    );
+    await api("POST", "/attendance/check-in", { token: internToken });
+    me = await api("GET", "/attendance/me", { token: internToken });
+    ok(me.data.status === "in_meeting", "status derives in_meeting while a meeting is live");
+    const grid = await api(
+      "GET",
+      `/calendar/team?from=${new Date(Date.now() - 24 * 3600 * 1000).toISOString()}&to=${new Date(Date.now() + 5 * 24 * 3600 * 1000).toISOString()}`,
+      { token: founderToken }
+    );
+    const internRowCal = (grid.data.rows || []).find((r) => r.name === `${MARK} Intern`);
+    ok(
+      grid.status === 200 && internRowCal && internRowCal.events.some((e) => e.live) && internRowCal.status === "in_meeting",
+      "team calendar: per-employee row with live event + status dot"
+    );
+    const slRow = (grid.data.rows || []).find((r) => r.name === `${MARK} SalesLead`);
+    ok(slRow && slRow.events.some((e) => e.type === "gmeet"), "team calendar: mirrored gmeet visible on manager row");
+    // Close the live meeting so later slices aren't blocked.
+    await api("POST", `/calendar/events/${unblocked.data._id}/close`, {
+      token: internToken,
+      body: { notes: "wrap" },
+    });
+    await api("POST", "/attendance/check-out", { token: internToken });
+
+    section("S3: visit mirror (no huddle, no handoff)");
+    const lead2 = await Enquiry.create({
+      name: `${MARK} VisitLead`,
+      phone: phone(102),
+      verified: false,
+      source: "Website",
+      additionalInfo: {},
+      stage: "new",
+      assignedTo: salesLead._id,
+    });
+    await api("POST", `/enquiry/${lead2._id}/follow-up`, {
+      token: salesLeadToken,
+      body: { type: "visit", scheduledAt: new Date(Date.now() + 24 * 3600 * 1000).toISOString() },
+    });
+    ok(
+      !!(await CalendarEvent.findOne({ leadId: lead2._id, type: "visit" }).lean()),
+      "visit follow-up mirrors as a visit event"
+    );
+    ok(
+      !(await CalendarEvent.findOne({ leadId: lead2._id, type: "huddle" }).lean()),
+      "no huddle for a visit"
+    );
+    const lead2After = await Enquiry.findById(lead2._id).lean();
+    ok(String(lead2After.assignedTo) === String(salesLead._id), "no handoff for a non-intern owner");
   } catch (e) {
     failed++;
     failures.push(`fatal: ${e.message}`);
@@ -314,6 +501,10 @@ const inboundText = (phone, text, profileName = "MB56 Customer") => ({
     await QualifiedLead.deleteMany({ phone: { $regex: `^${PHONE_PREFIX}` } });
     await NotificationFailureLog.deleteMany({ phone: { $regex: `^${PHONE_PREFIX}` } });
     await Attendance.deleteMany({ adminId: { $in: [founder._id, salesLead._id, intern._id] } });
+    const CalendarEventModel = require("../models/CalendarEvent");
+    const AdminNotificationModel = require("../models/AdminNotification");
+    await CalendarEventModel.deleteMany({ ownerId: { $in: [founder._id, salesLead._id, intern._id] } });
+    await AdminNotificationModel.deleteMany({ adminId: { $in: [founder._id, salesLead._id, intern._id] } });
     await Admin.deleteMany({ _id: { $in: [founder._id, salesLead._id, intern._id] } });
     await Role.deleteMany({ _id: { $in: [founderRole._id, salesLeadRole._id, internRole._id] } });
     await Department.deleteMany({ _id: dept._id });

--- a/scripts/e2e-mb56.js
+++ b/scripts/e2e-mb56.js
@@ -208,6 +208,8 @@ const inboundText = (phone, text, profileName = "MB56 Customer") => ({
     "triage.escalateAfterMinutes",
     "golden.workStartHour",
     "golden.workEndHour",
+    "golden.windowMinutes",
+    "kiara.welcomeTemplateName",
   ];
   const settingsBefore = await Setting.find({ key: { $in: touchedKeys } }).lean();
 
@@ -691,6 +693,137 @@ const inboundText = (phone, text, profileName = "MB56 Customer") => ({
       body: { key: "assignment.mode", value: "auto" },
     });
     ok(backToAuto.status === 200, "assignment.mode back to auto (zero-change default)");
+
+    // ════ SLICE 5 — Golden window 15 + Kiara safety net ════
+    section("S5: new defaults (code-level, no stored override)");
+    {
+      // In THIS process (fresh SettingsService cache), with no stored rows the
+      // defaults must be 15 / 11 / 19.
+      const stored = await Setting.find({
+        key: { $in: ["golden.windowMinutes", "golden.workStartHour", "golden.workEndHour"] },
+      }).lean();
+      await Setting.deleteMany({
+        key: { $in: ["golden.windowMinutes", "golden.workStartHour", "golden.workEndHour"] },
+      });
+      const SettingsServiceLocal = require("../services/SettingsService");
+      SettingsServiceLocal.invalidate ? SettingsServiceLocal.invalidate() : null;
+      ok((await SettingsServiceLocal.get("golden.windowMinutes")) === 15, "default golden window is 15 minutes");
+      ok((await SettingsServiceLocal.get("golden.workStartHour")) === 11, "default working hours start 11:00 IST");
+      ok((await SettingsServiceLocal.get("golden.workEndHour")) === 19, "default working hours end 19:00 IST");
+      ok((await SettingsServiceLocal.get("kiara.welcomeTemplateName")) === "", "safety net ships DORMANT (no template)");
+      if (stored.length) await Setting.insertMany(stored.map(({ _id, ...rest }) => rest));
+      SettingsServiceLocal.invalidate ? SettingsServiceLocal.invalidate() : null;
+    }
+
+    section("S5: dormant when unset");
+    // Force "outside working hours" so the after-hours branch WOULD fire if armed.
+    const istHr = new Date(Date.now() + 330 * 60 * 1000).getUTCHours();
+    const offS = istHr >= 22 ? 0 : istHr + 1;
+    const offE = istHr >= 22 ? 1 : istHr + 2;
+    await api("PUT", "/settings", { token: founderToken, body: { key: "golden.workStartHour", value: offS } });
+    await api("PUT", "/settings", { token: founderToken, body: { key: "golden.workEndHour", value: offE } });
+    const metaBefore = mock.metaCalls.length;
+    const pS1 = phone(301);
+    const dormantCreate = await api("POST", "/enquiry", {
+      body: { name: "MB56 Dormant Lead", phone: pS1, source: "Website", verified: false },
+    });
+    ok(dormantCreate.status === 201, "after-hours lead created (safety net unset)");
+    await sleep(1200);
+    ok(mock.metaCalls.length === metaBefore, "DORMANT: no template sent when kiara.welcomeTemplateName is unset");
+    ok(!(await WAConversation.findOne({ phone: `91${pS1.slice(-10)}` }).lean()) &&
+       !(await WAConversation.findOne({ phone: pS1 }).lean()),
+       "DORMANT: no conversation opened");
+
+    section("S5: after-hours create → welcome template + conversation");
+    await api("PUT", "/settings", {
+      token: founderToken,
+      body: { key: "kiara.welcomeTemplateName", value: "wedsy_welcome_v1" },
+    });
+    const pS2 = phone(302);
+    const ahCreate = await api("POST", "/enquiry", {
+      body: { name: "MB56 AfterHours Lead", phone: pS2, source: "Website", verified: false },
+    });
+    ok(ahCreate.status === 201, "after-hours lead created (armed)");
+    const ahLead = await waitFor(async () => {
+      const l = await Enquiry.findOne({ phone: pS2 }).lean();
+      return l && l.kiaraSafetyNetAt ? l : null;
+    }, "safety net engaged");
+    ok(!!ahLead.kiaraSafetyNetAt, "kiaraSafetyNetAt stamped (once-per-lead marker)");
+    const tplCall = mock.metaCalls.find(
+      (m) => m.body.type === "template" && m.body.template && m.body.template.name === "wedsy_welcome_v1" && m.body.to === pS2
+    );
+    ok(!!tplCall && tplCall.phoneNumberId === "MB56_AGENT", "welcome template sent from KIARA's number");
+    const ahConv = await WAConversation.findOne({ phone: pS2 }).lean();
+    ok(!!ahConv && ahConv.mode === "ai" && String(ahConv.enquiryId) === String(ahLead._id), "ai-mode conversation opened + linked");
+    ok(
+      !!(await LeadInternalEvent.findOne({ leadId: ahLead._id, type: "kiara_safety_net_engaged", "payload.reason": "after_hours_create" }).lean()),
+      "journey event kiara_safety_net_engaged (after_hours_create)"
+    );
+    ok(
+      !!(await WAAgentMessage.findOne({ phone: pS2, message: "[template: wedsy_welcome_v1]" }).lean()),
+      "template placeholder stored in the thread"
+    );
+
+    section("S5: morning pile — after-hours lead in triage with transcript");
+    await api("PUT", "/settings", { token: founderToken, body: { key: "assignment.mode", value: "triage" } });
+    // The after-hours lead was created in AUTO mode (assigned via round-robin);
+    // create a fresh one to verify the triage+transcript path.
+    const pS3 = phone(303);
+    await api("POST", "/enquiry", {
+      body: { name: "MB56 MorningPile Lead", phone: pS3, source: "Website", verified: false },
+    });
+    const mpLead = await waitFor(async () => {
+      const l = await Enquiry.findOne({ phone: pS3 }).lean();
+      return l && l.kiaraSafetyNetAt ? l : null;
+    }, "morning-pile lead engaged");
+    ok(mpLead.triagePending === true && mpLead.assignedTo === null, "after-hours lead waits in triage");
+    // Back to working hours = "the morning": the pile is visible with transcript.
+    await api("PUT", "/settings", { token: founderToken, body: { key: "golden.workStartHour", value: 0 } });
+    await api("PUT", "/settings", { token: founderToken, body: { key: "golden.workEndHour", value: 24 } });
+    const morningQueue = await api("GET", "/enquiry/triage", { token: holderToken });
+    const mpRow = (morningQueue.data.list || []).find((r) => String(r._id) === String(mpLead._id));
+    ok(!!mpRow, "morning pile: lead appears in triage at open");
+    ok(mpRow && mpRow.transcript.length >= 1 && mpRow.transcript[0].message.includes("wedsy_welcome_v1"),
+       "Kiara transcript attached to the pile row");
+    await api("POST", `/enquiry/${mpLead._id}/triage-assign`, { token: holderToken });
+    await api("PUT", "/settings", { token: founderToken, body: { key: "assignment.mode", value: "auto" } });
+
+    section("S5: in-hours golden-window miss → engage once");
+    const pS4 = phone(304);
+    await api("POST", "/enquiry", {
+      body: { name: "MB56 GW Miss Lead", phone: pS4, source: "Website", verified: false },
+    });
+    const gwLead = await waitFor(async () => Enquiry.findOne({ phone: pS4 }).lean(), "gw lead created");
+    ok(!gwLead.kiaraSafetyNetAt, "in-hours lead NOT engaged at create");
+    // Clock-mock: age the lead past the 15-min window (raw collection write —
+    // mongoose treats createdAt as immutable and silently strips it).
+    await Enquiry.collection.updateOne(
+      { _id: gwLead._id },
+      { $set: { createdAt: new Date(Date.now() - 30 * 60 * 1000) } }
+    );
+    await api("GET", "/enquiry/dashboard", { token: founderToken }); // sweep rides the dashboard
+    const gwAfter = await waitFor(async () => {
+      const l = await Enquiry.findById(gwLead._id).lean();
+      return l && l.kiaraSafetyNetAt ? l : null;
+    }, "gw miss engaged");
+    ok(
+      !!(await LeadInternalEvent.findOne({ leadId: gwLead._id, type: "kiara_safety_net_engaged", "payload.reason": "golden_window_missed" }).lean()),
+      "journey reason golden_window_missed"
+    );
+    const gwTplCalls = mock.metaCalls.filter((m) => m.body.type === "template" && m.body.to === pS4).length;
+    await api("GET", "/enquiry/dashboard", { token: founderToken }); // second sweep
+    await sleep(800);
+    const gwTplCalls2 = mock.metaCalls.filter((m) => m.body.type === "template" && m.body.to === pS4).length;
+    ok(gwTplCalls === 1 && gwTplCalls2 === 1, "engaged exactly ONCE per lead");
+
+    section("S5: mission-quiet for safety-net leads");
+    const dash5 = await api("GET", "/enquiry/dashboard", { token: founderToken });
+    ok(
+      !(dash5.data.newUntouched || []).some((r) => String(r.leadId || r._id) === String(gwAfter._id)),
+      "safety-net-engaged lead joins mission-quiet (absent from new-untouched)"
+    );
+    // Disarm for the remaining slices.
+    await api("PUT", "/settings", { token: founderToken, body: { key: "kiara.welcomeTemplateName", value: "" } });
   } catch (e) {
     failed++;
     failures.push(`fatal: ${e.message}`);

--- a/scripts/e2e-mb56.js
+++ b/scripts/e2e-mb56.js
@@ -54,6 +54,10 @@ const mock = {
   anthropicCalls: [],
   metaCalls: [],
   igCalls: [], // Instagram DM sends (Slice 7)
+  googleTokenCalls: [],
+  freeBusyCalls: [],
+  eventCreateCalls: [],
+  googleBusy: [], // injected busy blocks for freeBusy
   replyText: "Lovely! Tell me more 😊",
   extractor: { qualified: false, escalate: false, escalateReason: "", classification: "lead", data: {} },
   anthropic429s: 0, // consume N 429s before answering (Slice 11)
@@ -62,7 +66,12 @@ const mockServer = http.createServer((req, res) => {
   let raw = "";
   req.on("data", (c) => (raw += c));
   req.on("end", () => {
-    const body = raw ? JSON.parse(raw) : {};
+    let body = {};
+    try {
+      body = raw ? JSON.parse(raw) : {};
+    } catch (_) {
+      body = {}; // form-urlencoded (Google token exchange) — raw is enough
+    }
     if (req.url === "/v1/messages") {
       if (mock.anthropic429s > 0) {
         mock.anthropic429s--;
@@ -89,6 +98,47 @@ const mockServer = http.createServer((req, res) => {
       mock.igCalls.push({ body });
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ recipient_id: body.recipient && body.recipient.id, message_id: "igm.mb56" }));
+      return;
+    }
+    // ── Google mocks (Slice 8) ──
+    if (req.url === "/google/token") {
+      mock.googleTokenCalls.push(body || raw);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          access_token: "mock-access-token",
+          refresh_token: "mock-refresh-token",
+          scope: "https://www.googleapis.com/auth/calendar.events email",
+          expires_in: 3600,
+        })
+      );
+      return;
+    }
+    if (req.url === "/google/userinfo") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ email: "saleslead@wedsy.test" }));
+      return;
+    }
+    if (req.url === "/gcal/freeBusy") {
+      mock.freeBusyCalls.push(body);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          calendars: { primary: { busy: mock.googleBusy } },
+        })
+      );
+      return;
+    }
+    if (req.url.startsWith("/gcal/calendars/primary/events")) {
+      mock.eventCreateCalls.push(body);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          id: `gev_${mock.eventCreateCalls.length}`,
+          hangoutLink: "https://meet.google.com/mock-abc-def",
+          status: "confirmed",
+        })
+      );
       return;
     }
     res.writeHead(404);
@@ -282,6 +332,13 @@ const inboundText = (phone, text, profileName = "MB56 Customer") => ({
       INSTAGRAM_AGENT_APP_SECRET: "mb56-ig-secret",
       INSTAGRAM_AGENT_PAGE_ACCESS_TOKEN: "mb56-ig-token",
       INSTAGRAM_GRAPH_BASE_URL: `http://localhost:${MOCK_PORT}/iggraph`,
+      // Google (Slice 8) — configured + fully mocked.
+      GOOGLE_CLIENT_ID: "mb56-google-client",
+      GOOGLE_CLIENT_SECRET: "mb56-google-secret",
+      GOOGLE_REDIRECT_URI: `http://localhost:${APP_PORT}/google/oauth/callback`,
+      GOOGLE_TOKEN_URL: `http://localhost:${MOCK_PORT}/google/token`,
+      GOOGLE_USERINFO_URL: `http://localhost:${MOCK_PORT}/google/userinfo`,
+      GOOGLE_CALENDAR_URL: `http://localhost:${MOCK_PORT}/gcal`,
     },
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -777,10 +834,15 @@ const inboundText = (phone, text, profileName = "MB56 Customer") => ({
       (m) => m.body.type === "template" && m.body.template && m.body.template.name === "wedsy_welcome_v1" && m.body.to === pS2
     );
     ok(!!tplCall && tplCall.phoneNumberId === "MB56_AGENT", "welcome template sent from KIARA's number");
-    const ahConv = await WAConversation.findOne({ phone: pS2 }).lean();
+    // The marker is stamped (CAS) BEFORE the send/conversation writes — wait
+    // for the conversation rather than racing it.
+    const ahConv = await waitFor(async () => WAConversation.findOne({ phone: pS2 }).lean(), "safety-net conversation");
     ok(!!ahConv && ahConv.mode === "ai" && String(ahConv.enquiryId) === String(ahLead._id), "ai-mode conversation opened + linked");
     ok(
-      !!(await LeadInternalEvent.findOne({ leadId: ahLead._id, type: "kiara_safety_net_engaged", "payload.reason": "after_hours_create" }).lean()),
+      !!(await waitFor(
+        async () => LeadInternalEvent.findOne({ leadId: ahLead._id, type: "kiara_safety_net_engaged", "payload.reason": "after_hours_create" }).lean(),
+        "safety-net journey event"
+      )),
       "journey event kiara_safety_net_engaged (after_hours_create)"
     );
     ok(
@@ -1054,6 +1116,176 @@ const inboundText = (phone, text, profileName = "MB56 Customer") => ({
     const igQl = await QualifiedLead.findOne({ phone: IG3 }).lean();
     ok(!!igQl && igQl.crmSynced === true, "QualifiedLead.crmSynced mirrors the WA idiom");
     mock.extractor = { qualified: false, escalate: false, escalateReason: "", classification: "lead", data: {} };
+
+    // ════ SLICE 8 — Google Workspace (mocked end-to-end) ════
+    section("S8: link flow (oauth start → callback → status)");
+    let gStatus = await api("GET", "/google/status", { token: salesLeadToken });
+    ok(gStatus.status === 200 && gStatus.data.configured === true && gStatus.data.linked === false, "configured but unlinked");
+    const gStart = await api("GET", "/google/oauth/start", { token: salesLeadToken });
+    ok(
+      gStart.status === 200 &&
+        String(gStart.data.url).includes("client_id=mb56-google-client") &&
+        String(gStart.data.url).includes(encodeURIComponent(`http://localhost:${APP_PORT}/google/oauth/callback`)),
+      "consent URL pins the redirect URI"
+    );
+    const gState = new URL(gStart.data.url).searchParams.get("state");
+    const cbRes = await fetch(`${BASE}/google/oauth/callback?code=mock-code&state=${encodeURIComponent(gState)}`);
+    ok(cbRes.status === 200, "oauth callback succeeds");
+    const GoogleAccount = require("../models/GoogleAccount");
+    const gAcc = await GoogleAccount.findOne({ adminId: salesLead._id }).lean();
+    ok(!!gAcc && gAcc.refreshToken === "mock-refresh-token" && gAcc.email === "saleslead@wedsy.test", "GoogleAccount stored (refresh token + email)");
+    gStatus = await api("GET", "/google/status", { token: salesLeadToken });
+    ok(gStatus.data.linked === true && gStatus.data.email === "saleslead@wedsy.test", "status reflects the link");
+    const badState = await fetch(`${BASE}/google/oauth/callback?code=x&state=tampered`);
+    ok(badState.status === 403, "tampered oauth state rejected (403)");
+
+    section("S8: availability — merged Google + OS free/busy");
+    const gLead = await Enquiry.create({
+      name: `${MARK} GoogleLead`,
+      phone: phone(501),
+      verified: false,
+      source: "Website",
+      additionalInfo: {},
+      stage: "new",
+      assignedTo: intern._id, // intern-owned → books on the sales lead's calendar
+    });
+    await api("PUT", `/enquiry/${gLead._id}/qualification`, {
+      token: internToken,
+      body: { email: "couple@example.com", additionalEmails: ["partner@example.com"] },
+    });
+    // Google busy: tomorrow 05:00–06:00 UTC; OS busy: tomorrow 08:00–09:00 UTC.
+    const tomorrow = new Date(Date.now() + 24 * 3600 * 1000);
+    const dayUTC = (h) =>
+      new Date(Date.UTC(tomorrow.getUTCFullYear(), tomorrow.getUTCMonth(), tomorrow.getUTCDate(), h, 0));
+    mock.googleBusy = [{ start: dayUTC(5).toISOString(), end: dayUTC(6).toISOString() }];
+    const CalendarEventS8 = require("../models/CalendarEvent");
+    const osBlock = await CalendarEventS8.create({
+      ownerId: salesLead._id,
+      type: "block",
+      title: "MB56 os busy block",
+      start: dayUTC(8),
+      end: dayUTC(9),
+    });
+    const avail = await api("GET", `/google/availability?leadId=${gLead._id}&days=3`, { token: salesLeadToken });
+    ok(avail.status === 200 && avail.data.configured && avail.data.googleUsed, "availability uses linked Google free/busy");
+    ok(
+      avail.data.busy.some((b) => b.source === "google") && avail.data.busy.some((b) => b.source === "os"),
+      "busy merges Google + OS calendars"
+    );
+    const overlaps = (slot, busyStart, busyEnd) =>
+      new Date(slot.start) < busyEnd && new Date(slot.end) > busyStart;
+    ok(
+      avail.data.slots.length > 0 &&
+        !avail.data.slots.some((s) => overlaps(s, dayUTC(5), dayUTC(6)) || overlaps(s, dayUTC(8), dayUTC(9))),
+      "suggested slots avoid both busy windows"
+    );
+
+    section("S8: book — Google event w/ Meet + invites + OS mirror + follow-up");
+    const slot = avail.data.slots[0];
+    const evBefore = mock.eventCreateCalls.length;
+    const book = await api("POST", "/google/book", {
+      token: salesLeadToken,
+      body: { leadId: String(gLead._id), start: slot.start, end: slot.end },
+    });
+    ok(book.status === 200 && book.data.google === true, "booking succeeds via Google");
+    ok(book.data.meetLink === "https://meet.google.com/mock-abc-def", "Meet link returned");
+    ok(mock.eventCreateCalls.length === evBefore + 1, "exactly one Google event created");
+    const gEvBody = mock.eventCreateCalls[mock.eventCreateCalls.length - 1];
+    const invitedEmails = (gEvBody.attendees || []).map((a) => a.email);
+    ok(
+      invitedEmails.includes("couple@example.com") && invitedEmails.includes("partner@example.com"),
+      "client + additionalEmails invited"
+    );
+    ok(invitedEmails.includes(salesLead.email), "internal attendee (sales lead) invited");
+    ok(!!gEvBody.conferenceData, "event requests a Meet conference");
+    const gLeadAfter = await Enquiry.findById(gLead._id).lean();
+    ok(
+      (gLeadAfter.followUps || []).some((f) => f.type === "meet" && new Date(f.scheduledAt).getTime() === new Date(slot.start).getTime()),
+      "meet follow-up booked as today"
+    );
+    ok(String(gLeadAfter.assignedTo) === String(salesLead._id) && String(gLeadAfter.qualifiedBy) === String(intern._id),
+      "intern handoff fired through the same booking path");
+    const mirroredEv = await CalendarEventS8.findOne({ leadId: gLead._id, type: "gmeet" }).lean();
+    ok(!!mirroredEv && mirroredEv.googleEventId === book.data.googleEventId, "OS mirror stamped with googleEventId");
+
+    section("S8: unlinked fallback (OS-only, exactly as today)");
+    await api("DELETE", "/google/link", { token: salesLeadToken });
+    gStatus = await api("GET", "/google/status", { token: salesLeadToken });
+    ok(gStatus.data.linked === false, "disconnect removes the link");
+    const gLead2 = await Enquiry.create({
+      name: `${MARK} GoogleLead2`,
+      phone: phone(502),
+      verified: false,
+      source: "Website",
+      additionalInfo: {},
+      stage: "new",
+      assignedTo: salesLead._id,
+    });
+    const evBefore2 = mock.eventCreateCalls.length;
+    const book2 = await api("POST", "/google/book", {
+      token: salesLeadToken,
+      body: { leadId: String(gLead2._id), start: dayUTC(10).toISOString() },
+    });
+    ok(book2.status === 200 && book2.data.google === false, "unlinked → OS-only booking (google:false)");
+    ok(mock.eventCreateCalls.length === evBefore2, "no Google call when unlinked");
+    const gLead2After = await Enquiry.findById(gLead2._id).lean();
+    ok((gLead2After.followUps || []).some((f) => f.type === "meet"), "meet follow-up still books (fallback)");
+    await CalendarEventS8.deleteMany({ _id: osBlock._id });
+
+    section("S8: not-configured dormancy (separate boot, no GOOGLE_* env)");
+    const DORMANT_PORT = 8129;
+    const dormantChild = spawn("node", ["server.js"], {
+      cwd: `${__dirname}/..`,
+      env: {
+        ...process.env,
+        PORT: String(DORMANT_PORT),
+        ANTHROPIC_API_URL: `http://localhost:${MOCK_PORT}/v1/messages`,
+        META_GRAPH_BASE_URL: `http://localhost:${MOCK_PORT}/graph`,
+        GOOGLE_CLIENT_ID: "",
+        GOOGLE_CLIENT_SECRET: "",
+        GOOGLE_SHEETS_KEY_PATH: "/nonexistent/mb56-keyfile.json",
+      },
+      stdio: "ignore",
+    });
+    try {
+      await waitFor(
+        () => fetch(`http://localhost:${DORMANT_PORT}/`).then((r) => r.ok).catch(() => false),
+        "dormant server boot",
+        30000
+      );
+      const dApi = async (method, path, body) => {
+        const r = await fetch(`http://localhost:${DORMANT_PORT}${path}`, {
+          method,
+          headers: { Authorization: `Bearer ${salesLeadToken}`, ...(body ? { "Content-Type": "application/json" } : {}) },
+          body: body ? JSON.stringify(body) : undefined,
+        });
+        let data = null;
+        try { data = await r.json(); } catch (_) {}
+        return { status: r.status, data };
+      };
+      const dStatus = await dApi("GET", "/google/status");
+      ok(dStatus.status === 200 && dStatus.data.configured === false, "dormant: status reports not configured");
+      const dStart = await dApi("GET", "/google/oauth/start");
+      ok(dStart.status === 409, "dormant: oauth start refuses tidily (409)");
+      const gLead3 = await Enquiry.create({
+        name: `${MARK} GoogleLead3`,
+        phone: phone(503),
+        verified: false,
+        source: "Website",
+        additionalInfo: {},
+        stage: "new",
+        assignedTo: salesLead._id,
+      });
+      const dBook = await dApi("POST", "/google/book", {
+        leadId: String(gLead3._id),
+        start: dayUTC(12).toISOString(),
+      });
+      ok(dBook.status === 200 && dBook.data.google === false, "dormant: booking falls back to OS-only");
+      const gLead3After = await Enquiry.findById(gLead3._id).lean();
+      ok((gLead3After.followUps || []).some((f) => f.type === "meet"), "dormant: the meet follow-up still books");
+    } finally {
+      dormantChild.kill();
+    }
   } catch (e) {
     failed++;
     failures.push(`fatal: ${e.message}`);
@@ -1076,6 +1308,8 @@ const inboundText = (phone, text, profileName = "MB56 Customer") => ({
     await VendorContact.deleteMany({ phone: { $regex: `^(${PHONE_PREFIX}|MB56IG)` } });
     await Attendance.deleteMany({ adminId: { $in: [founder._id, salesLead._id, intern._id] } });
     const allAdminIds = [founder._id, salesLead._id, intern._id, holder._id, revenueHead._id];
+    const GoogleAccountModel = require("../models/GoogleAccount");
+    await GoogleAccountModel.deleteMany({ adminId: { $in: allAdminIds } });
     const CalendarEventModel = require("../models/CalendarEvent");
     const AdminNotificationModel = require("../models/AdminNotification");
     await CalendarEventModel.deleteMany({ ownerId: { $in: allAdminIds } });

--- a/scripts/mb56-seed-permissions.js
+++ b/scripts/mb56-seed-permissions.js
@@ -1,0 +1,54 @@
+/* MB5+6 permission seed-diff.
+ *
+ * Grants (idempotent, append-only — never removes anything):
+ *   leads:triage:all          → sales-lead-class roles: Revenue Head, Sales Manager
+ *   settings_scripts:edit:all → CRM Admin (cockpit scripts category; founder's
+ *                               *:*:all wildcard already covers both grants)
+ *
+ * Dry-run by default; --confirm applies. Prints a per-role diff either way.
+ * Usage: node scripts/mb56-seed-permissions.js [--confirm]
+ */
+require("dotenv").config();
+const mongoose = require("mongoose");
+
+const CONFIRM = process.argv.includes("--confirm");
+
+const GRANTS = [
+  { roles: ["Revenue Head", "Sales Manager"], permission: "leads:triage:all" },
+  { roles: ["CRM Admin"], permission: "settings_scripts:edit:all" },
+];
+
+(async () => {
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Role = require("../models/Role");
+
+  let changes = 0;
+  for (const grant of GRANTS) {
+    for (const roleName of grant.roles) {
+      const role = await Role.findOne({ name: roleName, deletedAt: null });
+      if (!role) {
+        console.log(`- ${roleName}: NOT FOUND (skipped)`);
+        continue;
+      }
+      if ((role.permissions || []).includes(grant.permission)) {
+        console.log(`= ${roleName}: already has ${grant.permission}`);
+        continue;
+      }
+      changes++;
+      console.log(`+ ${roleName}: grant ${grant.permission}`);
+      if (CONFIRM) {
+        role.permissions.push(grant.permission);
+        await role.save();
+      }
+    }
+  }
+  console.log(
+    changes === 0
+      ? "\nNothing to do."
+      : CONFIRM
+        ? `\nApplied ${changes} grant(s).`
+        : `\nDRY RUN — ${changes} grant(s) pending. Re-run with --confirm.`
+  );
+  await mongoose.disconnect();
+  process.exit(0);
+})();

--- a/scripts/verify-bug-a.js
+++ b/scripts/verify-bug-a.js
@@ -1,0 +1,206 @@
+/* MB5 Slice 1 — Bug A verification (permanent).
+ *
+ * Boots the real server on TEST ports (mocked Anthropic/Meta, same seams as
+ * e2e-kiara), creates one lead via signed WhatsApp webhook and one via the
+ * normal POST /enquiry path (what NewLeadModal sends), then ASSERTS:
+ *   - both leads appear in the board query (GET /enquiry?page=1&limit=200)
+ *     and the list query (GET /enquiry?view=active)
+ *   - the two Enquiry documents are field-identical apart from the expected
+ *     identity fields (_id, name, phone, source, timestamps, assignedTo)
+ *   - the WA lead's stage is exactly "new" (the board's column key)
+ * Exits 1 on any failure. Cleans every fixture. Run: node scripts/verify-bug-a.js
+ */
+require("dotenv").config();
+const http = require("http");
+const crypto = require("crypto");
+const { spawn } = require("child_process");
+const mongoose = require("mongoose");
+const jwt = require("jsonwebtoken");
+
+const APP_PORT = 8123;
+const MOCK_PORT = 8124;
+const BASE = `http://localhost:${APP_PORT}`;
+const APP_SECRET = process.env.WHATSAPP_AGENT_APP_SECRET || "kiara-e2e-secret";
+const WA_PHONE = "919170000777";
+const NORMAL_PHONE = "919170000778";
+
+const mockServer = http.createServer((req, res) => {
+  let raw = "";
+  req.on("data", (c) => (raw += c));
+  req.on("end", () => {
+    if (req.url === "/v1/messages") {
+      const body = raw ? JSON.parse(raw) : {};
+      const content = String(body.system || "").startsWith("You are a data extractor")
+        ? [{ type: "text", text: JSON.stringify({ qualified: false, escalate: false, classification: "lead", data: {} }) }]
+        : [{ type: "text", text: "Hi from mock Kiara" }];
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ id: "msg_repro", content, stop_reason: "end_turn" }));
+      return;
+    }
+    if (/\/messages$/.test(req.url)) {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ messaging_product: "whatsapp", messages: [{ id: "wamid.repro" }] }));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+});
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const waitFor = async (fn, label, timeoutMs = 20000) => {
+  const until = Date.now() + timeoutMs;
+  while (Date.now() < until) {
+    try {
+      const v = await fn();
+      if (v) return v;
+    } catch (_) {}
+    await sleep(300);
+  }
+  throw new Error(`waitFor timed out: ${label}`);
+};
+
+(async () => {
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Enquiry = require("../models/Enquiry");
+  const WAConversation = require("../models/WAConversation");
+  const WAAgentMessage = require("../models/WAAgentMessage");
+  const LeadInternalEvent = require("../models/LeadInternalEvent");
+  const Setting = require("../models/Setting");
+  const Admin = require("../models/Admin");
+  const Role = require("../models/Role");
+  const Department = require("../models/Department");
+
+  const dept = await Department.create({ name: "BUGA-Dept" });
+  const founderRole = await Role.create({ name: "BUGA-Founder", departmentId: dept._id, permissions: ["*:*:all"] });
+  const internRole = await Role.create({ name: "BUGA-Intern", departmentId: dept._id, permissions: ["leads:view:own", "leads:edit:own"] });
+  const founder = await Admin.create({
+    name: "BugA Founder", email: `buga-founder-${Date.now()}@test.local`, phone: "919170000700",
+    password: "x", roles: ["crm"], roleId: founderRole._id, departmentId: dept._id, status: "active",
+  });
+  const intern = await Admin.create({
+    name: "BugA Intern", email: `buga-intern-${Date.now()}@test.local`, phone: "919170000701",
+    password: "x", roles: ["sales"], roleId: internRole._id, departmentId: dept._id, status: "active",
+  });
+  const founderToken = jwt.sign({ _id: String(founder._id), isAdmin: true }, process.env.JWT_SECRET);
+  const settingsBefore = await Setting.find({ key: "assignment.poolRoles" }).lean();
+
+  await new Promise((r) => mockServer.listen(MOCK_PORT, r));
+  const child = spawn("node", ["server.js"], {
+    cwd: `${__dirname}/..`,
+    env: {
+      ...process.env,
+      PORT: String(APP_PORT),
+      ANTHROPIC_API_URL: `http://localhost:${MOCK_PORT}/v1/messages`,
+      META_GRAPH_BASE_URL: `http://localhost:${MOCK_PORT}/graph`,
+      WHATSAPP_AGENT_PHONE_NUMBER_ID: "BUGA_AGENT",
+      WHATSAPP_AGENT_APP_SECRET: APP_SECRET,
+      META_WA_AGENT_ACCESS_TOKEN: "repro-token",
+      GOOGLE_SHEETS_KEY_PATH: "/nonexistent/keyfile.json",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let serverLog = "";
+  child.stdout.on("data", (d) => (serverLog += d));
+  child.stderr.on("data", (d) => (serverLog += d));
+
+  const api = async (method, path, body) => {
+    const res = await fetch(`${BASE}${path}`, {
+      method,
+      headers: { Authorization: `Bearer ${founderToken}`, ...(body ? { "Content-Type": "application/json" } : {}) },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    let data = null;
+    try { data = await res.json(); } catch (_) {}
+    return { status: res.status, data };
+  };
+
+  try {
+    await waitFor(() => fetch(`${BASE}/`).then((r) => r.ok).catch(() => false), "server boot", 30000);
+    await api("PUT", "/settings", { key: "assignment.poolRoles", value: ["BUGA-Intern"] });
+
+    // 1. WhatsApp-intake lead via signed webhook
+    const payload = {
+      entry: [{ changes: [{ value: {
+        contacts: [{ profile: { name: "BugA WA Customer" }, wa_id: WA_PHONE }],
+        messages: [{ from: WA_PHONE, id: `wamid.in.${Date.now()}`, type: "text", text: { body: "Hi planning a wedding" } }],
+      } }] }],
+    };
+    const raw = JSON.stringify(payload);
+    const sig = "sha256=" + crypto.createHmac("sha256", APP_SECRET).update(raw).digest("hex");
+    const wh = await fetch(`${BASE}/webhook/whatsapp-agent`, {
+      method: "POST", headers: { "Content-Type": "application/json", "x-hub-signature-256": sig }, body: raw,
+    });
+    console.log("webhook status:", wh.status);
+    const conv = await waitFor(async () => {
+      const c = await WAConversation.findOne({ phone: WA_PHONE }).lean();
+      return c && c.enquiryId ? c : null;
+    }, "wa lead link");
+
+    // 2. Normal create (NewLeadModal shape)
+    const created = await api("POST", "/enquiry", {
+      name: "BugA Normal Lead", phone: NORMAL_PHONE, source: "Website", verified: false,
+    });
+    console.log("normal create status:", created.status);
+
+    const waLead = await Enquiry.findById(conv.enquiryId).lean();
+    const normalLead = await Enquiry.findOne({ phone: NORMAL_PHONE }).lean();
+
+    // 3. Field parity assertions (identity fields excluded)
+    let failed = 0;
+    const ok = (cond, label) => {
+      console.log(`  ${cond ? "✓" : "✗"} ${label}`);
+      if (!cond) failed++;
+    };
+    console.log("\n── FIELD PARITY ──");
+    const EXPECTED_DIFFS = new Set(["_id", "name", "phone", "source", "createdAt", "updatedAt", "__v", "assignedTo"]);
+    const keys = new Set([...Object.keys(waLead), ...Object.keys(normalLead)]);
+    for (const k of [...keys].sort()) {
+      if (EXPECTED_DIFFS.has(k)) continue;
+      const a = JSON.stringify(waLead[k]);
+      const b = JSON.stringify(normalLead[k]);
+      if (a !== b) ok(false, `field "${k}" differs: wa=${a} normal=${b}`);
+    }
+    ok(waLead.stage === "new", `WA lead stage is "new" (got ${JSON.stringify(waLead.stage)})`);
+    ok(typeof waLead.verified === "boolean", "WA lead verified is boolean");
+    console.log("  (unlisted fields are identical)");
+
+    // 4. Visibility in board + list queries
+    const board = await api("GET", "/enquiry?page=1&limit=200");
+    const list = await api("GET", "/enquiry?page=1&limit=200&view=active");
+    const inBoardWA = (board.data.list || []).some((l) => String(l._id) === String(waLead._id));
+    const inBoardNormal = (board.data.list || []).some((l) => String(l._id) === String(normalLead._id));
+    const inListWA = (list.data.list || []).some((l) => String(l._id) === String(waLead._id));
+    const inListNormal = (list.data.list || []).some((l) => String(l._id) === String(normalLead._id));
+    console.log("\n── VISIBILITY ──");
+    ok(inBoardWA, "WA lead in board query");
+    ok(inBoardNormal, "normal lead in board query");
+    ok(inListWA, "WA lead in active list query");
+    ok(inListNormal, "normal lead in active list query");
+    if (!inBoardWA || !inListWA) {
+      console.log("\nWA lead document:", JSON.stringify(waLead, null, 2));
+    }
+    process.exitCode = failed === 0 ? 0 : 1;
+    console.log(failed === 0 ? "\nBUG A VERIFY: ALL PASSED" : `\nBUG A VERIFY: ${failed} FAILED`);
+  } catch (e) {
+    console.error("REPRO ERROR:", e);
+    console.error("server log tail:", serverLog.slice(-3000));
+  } finally {
+    // Cleanup
+    const waLeadDoc = await Enquiry.findOne({ phone: WA_PHONE }).lean();
+    await Enquiry.deleteMany({ phone: { $in: [WA_PHONE, NORMAL_PHONE] } });
+    await WAConversation.deleteMany({ phone: WA_PHONE });
+    await WAAgentMessage.deleteMany({ phone: WA_PHONE });
+    if (waLeadDoc) await LeadInternalEvent.deleteMany({ leadId: waLeadDoc._id });
+    const normalDoc = await Enquiry.findOne({ phone: NORMAL_PHONE }).lean();
+    if (normalDoc) await LeadInternalEvent.deleteMany({ leadId: normalDoc._id });
+    await Admin.deleteMany({ _id: { $in: [founder._id, intern._id] } });
+    await Role.deleteMany({ _id: { $in: [founderRole._id, internRole._id] } });
+    await Department.deleteMany({ _id: dept._id });
+    await Setting.deleteMany({ key: "assignment.poolRoles" });
+    if (settingsBefore.length) await Setting.insertMany(settingsBefore.map(({ _id, ...rest }) => rest));
+    child.kill();
+    mockServer.close();
+    await mongoose.disconnect();
+  }
+})();

--- a/services/AdminNotificationService.js
+++ b/services/AdminNotificationService.js
@@ -1,0 +1,40 @@
+const AdminNotification = require("../models/AdminNotification");
+
+// Fire-and-safe like LeadInternalEventService — a failed notification must
+// never break the action that triggered it.
+const notify = async (adminIds, { type, title, message = "", leadId = null, payload = {} }) => {
+  try {
+    const ids = (Array.isArray(adminIds) ? adminIds : [adminIds]).filter(Boolean);
+    if (!ids.length) return [];
+    return await AdminNotification.insertMany(
+      ids.map((adminId) => ({ adminId, type, title, message, leadId, payload }))
+    );
+  } catch (e) {
+    console.error("AdminNotificationService.notify failed:", e.message);
+    return [];
+  }
+};
+
+const listMine = async (adminId, { unreadOnly = false, limit = 50 } = {}) => {
+  const filter = { adminId };
+  if (unreadOnly) filter.read = false;
+  return await AdminNotification.find(filter)
+    .sort({ createdAt: -1 })
+    .limit(Math.min(100, limit))
+    .lean();
+};
+
+const markRead = async (adminId, notificationId) =>
+  await AdminNotification.findOneAndUpdate(
+    { _id: notificationId, adminId },
+    { $set: { read: true } },
+    { new: true }
+  );
+
+const markAllRead = async (adminId) =>
+  await AdminNotification.updateMany({ adminId, read: false }, { $set: { read: true } });
+
+const unreadCount = async (adminId) =>
+  await AdminNotification.countDocuments({ adminId, read: false });
+
+module.exports = { notify, listMine, markRead, markAllRead, unreadCount };

--- a/services/AttendanceService.js
+++ b/services/AttendanceService.js
@@ -1,0 +1,149 @@
+const Attendance = require("../models/Attendance");
+const Admin = require("../models/Admin");
+
+// Idle = no heartbeat for > 5 minutes while checked in. The frontend pings
+// every 60s from an active tab, so a 5-min gap means the OS genuinely wasn't
+// being used (tab hidden/closed/asleep).
+const IDLE_GAP_MS = 5 * 60 * 1000;
+
+const httpError = (status, message) => Object.assign(new Error(message), { status });
+
+// IST calendar day — attendance is an India-office concept.
+const dayKey = (d = new Date()) => d.toLocaleDateString("en-CA", { timeZone: "Asia/Kolkata" });
+
+// Derived per-employee status. in_meeting comes from the calendar layer
+// (Slice 3) via the liveMeetingIds set so this service stays dependency-free.
+const statusOf = (row, now = new Date(), liveMeetingIds = new Set()) => {
+  if (!row || !row.checkInAt || row.checkOutAt) return "checked_out";
+  if (liveMeetingIds.has(String(row.adminId))) return "in_meeting";
+  const last = row.lastHeartbeatAt ? new Date(row.lastHeartbeatAt).getTime() : 0;
+  return now.getTime() - last > IDLE_GAP_MS ? "idle" : "online";
+};
+
+// Check in (idempotent). Re-check-in after a check-out re-opens the same day:
+// checkInAt keeps the FIRST stamp, the away time becomes an idle segment.
+const checkIn = async (adminId, now = new Date()) => {
+  const date = dayKey(now);
+  let row = await Attendance.findOne({ adminId, date });
+  if (!row) {
+    try {
+      row = await Attendance.create({ adminId, date, checkInAt: now, lastHeartbeatAt: now });
+    } catch (e) {
+      // double-click race on the unique index
+      row = await Attendance.findOne({ adminId, date });
+      if (!row) throw e;
+    }
+    return row;
+  }
+  if (row.checkOutAt) {
+    row.idleSegments.push({ from: row.checkOutAt, to: now });
+    row.idleMs += now.getTime() - new Date(row.checkOutAt).getTime();
+    row.checkOutAt = null;
+    row.lastHeartbeatAt = now;
+    await row.save();
+  }
+  return row;
+};
+
+const checkOut = async (adminId, now = new Date()) => {
+  const date = dayKey(now);
+  const row = await Attendance.findOne({ adminId, date });
+  if (!row || row.checkOutAt) throw httpError(409, "Not checked in");
+  // A silent gap right before checkout is idle time too.
+  const last = row.lastHeartbeatAt ? new Date(row.lastHeartbeatAt) : row.checkInAt;
+  if (now.getTime() - last.getTime() > IDLE_GAP_MS) {
+    row.idleSegments.push({ from: last, to: now });
+    row.idleMs += now.getTime() - last.getTime();
+  }
+  row.checkOutAt = now;
+  await row.save();
+  return row;
+};
+
+// Activity ping (60s cadence while the tab is visible). A gap > 5 min closes
+// as an idle segment. No-op when not checked in (404 keeps the client honest).
+const heartbeat = async (adminId, now = new Date()) => {
+  const date = dayKey(now);
+  const row = await Attendance.findOne({ adminId, date });
+  if (!row || row.checkOutAt) throw httpError(404, "Not checked in");
+  const last = row.lastHeartbeatAt ? new Date(row.lastHeartbeatAt) : row.checkInAt;
+  const gap = now.getTime() - last.getTime();
+  if (gap > IDLE_GAP_MS) {
+    row.idleSegments.push({ from: last, to: now });
+    row.idleMs += gap;
+  }
+  row.lastHeartbeatAt = now;
+  await row.save();
+  return row;
+};
+
+// Own status — the transparency view: the employee sees exactly what the
+// system recorded about them (status + today's idle total).
+const me = async (adminId, liveMeetingIds = new Set()) => {
+  const now = new Date();
+  const row = await Attendance.findOne({ adminId, date: dayKey(now) }).lean();
+  return {
+    date: dayKey(now),
+    status: statusOf(row, now, liveMeetingIds),
+    checkInAt: row ? row.checkInAt : null,
+    checkOutAt: row ? row.checkOutAt : null,
+    idleMs: row ? row.idleMs : 0,
+    lastHeartbeatAt: row ? row.lastHeartbeatAt : null,
+  };
+};
+
+// Admin ids visible under a lead-scope filter built with ownerField "adminId":
+// {} (all) → every active admin; {adminId: X} → [X]; {adminId:{$in:[..]}} → those.
+const visibleAdminIds = async (scopeFilter = {}) => {
+  if (!scopeFilter || Object.keys(scopeFilter).length === 0) {
+    const all = await Admin.find({ status: "active" }, { _id: 1 }).lean();
+    return all.map((a) => a._id);
+  }
+  const v = scopeFilter.adminId;
+  if (v && v.$in) return v.$in;
+  return v ? [v] : [];
+};
+
+// Daily team list: one row per visible admin with status + day numbers.
+// liveMeetingIds injected by the controller (calendar layer, Slice 3).
+const team = async ({ date } = {}, scopeFilter = {}, liveMeetingIds = new Set()) => {
+  const day = date || dayKey();
+  const ids = await visibleAdminIds(scopeFilter);
+  const [admins, rows] = await Promise.all([
+    Admin.find({ _id: { $in: ids }, status: "active" }, { name: 1, email: 1 }).lean(),
+    Attendance.find({ adminId: { $in: ids }, date: day }).lean(),
+  ]);
+  const byAdmin = new Map(rows.map((r) => [String(r.adminId), r]));
+  const now = new Date();
+  const isToday = day === dayKey(now);
+  return {
+    date: day,
+    list: admins
+      .map((a) => {
+        const row = byAdmin.get(String(a._id)) || null;
+        return {
+          adminId: a._id,
+          name: a.name,
+          // Past days have no "live" status — everyone reads checked_out unless absent entirely.
+          status: isToday ? statusOf(row, now, liveMeetingIds) : row ? "checked_out" : "absent",
+          present: !!row,
+          checkInAt: row ? row.checkInAt : null,
+          checkOutAt: row ? row.checkOutAt : null,
+          idleMs: row ? row.idleMs : 0,
+        };
+      })
+      .sort((x, y) => x.name.localeCompare(y.name)),
+  };
+};
+
+module.exports = {
+  IDLE_GAP_MS,
+  dayKey,
+  statusOf,
+  checkIn,
+  checkOut,
+  heartbeat,
+  me,
+  team,
+  visibleAdminIds,
+};

--- a/services/CalendarEventService.js
+++ b/services/CalendarEventService.js
@@ -1,0 +1,445 @@
+const mongoose = require("mongoose");
+const CalendarEvent = require("../models/CalendarEvent");
+const Enquiry = require("../models/Enquiry");
+const Admin = require("../models/Admin");
+const SettingsService = require("./SettingsService");
+const LeadInternalEventService = require("./LeadInternalEventService");
+const AdminNotificationService = require("./AdminNotificationService");
+
+const httpError = (status, message) => Object.assign(new Error(message), { status });
+const assertValidId = (id, label = "id") => {
+  if (!mongoose.Types.ObjectId.isValid(id)) throw httpError(400, `Invalid ${label}`);
+};
+
+const MEETING_TYPES = ["meeting", "gmeet", "visit"]; // types the meeting-notes gate applies to
+const DEFAULT_MEET_MINUTES = 60;
+
+// ── Live / unclosed meeting derivation ────────────────────────────────────────
+
+// A meeting is LIVE while now ∈ [start, end] and it hasn't been closed.
+const liveMeetingFilter = (now = new Date()) => ({
+  type: { $in: MEETING_TYPES },
+  status: "scheduled",
+  start: { $lte: now },
+  end: { $gte: now },
+});
+
+// Over but never closed with notes — pinned, and blocks the next meeting.
+const unclosedMeetingFilter = (now = new Date()) => ({
+  type: { $in: MEETING_TYPES },
+  status: "scheduled",
+  end: { $lt: now },
+});
+
+// Admin ids currently in a live meeting — feeds the in_meeting status (Slice 2 seam).
+const liveMeetingAdminIds = async (now = new Date()) => {
+  const rows = await CalendarEvent.find(liveMeetingFilter(now), { ownerId: 1 }).lean();
+  return new Set(rows.map((r) => String(r.ownerId)));
+};
+
+// ── Follow-up mirror + huddle + handoff (hooked from addFollowUp) ─────────────
+
+// Detect the intern class: role names configured as the auto-assignment pool.
+const isInternOwner = async (admin) => {
+  if (!admin || !admin.roleId) return false;
+  const Role = require("../models/Role");
+  const role = await Role.findById(admin.roleId, { name: 1 }).lean();
+  if (!role) return false;
+  const poolRoles = (await SettingsService.get("assignment.poolRoles")) || [];
+  return poolRoles.includes(role.name);
+};
+
+// HANDOFF RULE: a meet follow-up booked on an intern-owned lead auto-transfers
+// the lead to the intern's reportingManager; the intern keeps permanent credit
+// via the set-once qualifiedBy field. Both sides get notified.
+const handoffIfInternOwned = async (lead, actorId) => {
+  const owner = lead.assignedTo
+    ? await Admin.findById(lead.assignedTo, { name: 1, roleId: 1, reportingManagerId: 1, status: 1 }).lean()
+    : null;
+  if (!owner || !owner.reportingManagerId) return { transferred: false, owner };
+  if (!(await isInternOwner(owner))) return { transferred: false, owner };
+  const manager = await Admin.findById(owner.reportingManagerId, { name: 1, status: 1 }).lean();
+  if (!manager || manager.status !== "active") return { transferred: false, owner };
+
+  await Enquiry.findByIdAndUpdate(lead._id, {
+    $set: {
+      assignedTo: manager._id,
+      // Set-once credit: the intern who qualified the lead keeps it in their stats.
+      ...(lead.qualifiedBy ? {} : { qualifiedBy: owner._id }),
+    },
+  });
+  await LeadInternalEventService.record({
+    leadId: lead._id,
+    type: "transferred",
+    actorId,
+    payload: { from: String(owner._id), to: String(manager._id), toName: manager.name, reason: "meet_handoff" },
+  });
+  await LeadInternalEventService.record({
+    leadId: lead._id,
+    type: "meet_handoff",
+    actorId,
+    payload: {
+      internId: String(owner._id),
+      internName: owner.name,
+      managerId: String(manager._id),
+      managerName: manager.name,
+    },
+  });
+  await AdminNotificationService.notify(owner._id, {
+    type: "meet_handoff",
+    title: `${lead.name} moved to ${manager.name} for the meet`,
+    message: "You keep the qualification credit — great work getting them to a meeting.",
+    leadId: lead._id,
+  });
+  await AdminNotificationService.notify(manager._id, {
+    type: "meet_handoff",
+    title: `${lead.name} handed to you — meet booked by ${owner.name}`,
+    message: "Huddle pending: align the team before the meeting.",
+    leadId: lead._id,
+  });
+  return { transferred: true, owner, manager };
+};
+
+// Called by CallCockpitService.addFollowUp AFTER the follow-up is appended.
+// Fire-safe: a calendar/huddle/handoff failure must never break the booking.
+const onFollowUpBooked = async (enquiryId, followUp, actorId) => {
+  try {
+    if (!["meet", "visit"].includes(followUp.type)) return null;
+    const lead = await Enquiry.findById(enquiryId).lean();
+    if (!lead) return null;
+
+    // 1. Handoff first (meet only) so the mirror lands on the final owner.
+    let ownerId = lead.assignedTo || actorId;
+    let internId = null;
+    if (followUp.type === "meet") {
+      const result = await handoffIfInternOwned(lead, actorId);
+      if (result.transferred) {
+        ownerId = result.manager._id;
+        internId = result.owner._id;
+      }
+    }
+
+    // 2. Mirror the follow-up into the calendar.
+    const start = new Date(followUp.scheduledAt);
+    const end = new Date(start.getTime() + DEFAULT_MEET_MINUTES * 60 * 1000);
+    const mirrored = await CalendarEvent.create({
+      ownerId,
+      type: followUp.type === "meet" ? "gmeet" : "visit",
+      leadId: lead._id,
+      title: `${followUp.type === "meet" ? "G-Meet" : "Visit"} — ${lead.name}`,
+      start,
+      end,
+      participantIds: [ownerId, ...(internId ? [internId] : [])],
+      followUpId: followUp._id || null,
+    });
+
+    // 3. Huddle (gmeet only): assigned to the lead's sales lead, due AT the meet.
+    if (followUp.type === "meet") {
+      await CalendarEvent.create({
+        ownerId,
+        type: "huddle",
+        leadId: lead._id,
+        title: `Huddle — ${lead.name}`,
+        start,
+        end: start,
+        participantIds: [ownerId, ...(internId ? [internId] : [])],
+      });
+      await AdminNotificationService.notify(ownerId, {
+        type: "huddle_due",
+        title: `Team huddle needed before ${lead.name}'s meeting`,
+        message: "Run the huddle: attendees, event-team assignments, notes.",
+        leadId: lead._id,
+      });
+    }
+    return mirrored;
+  } catch (e) {
+    console.error("CalendarEventService.onFollowUpBooked failed:", e.message);
+    return null;
+  }
+};
+
+// ── Manual events + the meeting-notes gate ────────────────────────────────────
+
+const assertNoUnclosed = async (ownerId, now = new Date()) => {
+  const unclosed = await CalendarEvent.findOne({ ownerId, ...unclosedMeetingFilter(now) }).lean();
+  if (unclosed) {
+    throw httpError(
+      422,
+      `You have an unclosed meeting ("${unclosed.title}") — close it with notes before starting the next one`
+    );
+  }
+};
+
+const createEvent = async (ownerId, { type, title, start, end, leadId, participantIds } = {}) => {
+  if (!["meeting", "gmeet", "huddle", "visit", "block"].includes(type)) {
+    throw httpError(400, "Invalid type");
+  }
+  if (!title || typeof title !== "string") throw httpError(400, "title is required");
+  const s = new Date(start);
+  const e = new Date(end || new Date(s.getTime() + DEFAULT_MEET_MINUTES * 60 * 1000));
+  if (Number.isNaN(s.getTime()) || Number.isNaN(e.getTime()) || e < s) {
+    throw httpError(400, "Invalid start/end");
+  }
+  if (leadId) assertValidId(leadId, "leadId");
+  // The gate: an unclosed past meeting blocks scheduling the next meeting.
+  if (MEETING_TYPES.includes(type)) await assertNoUnclosed(ownerId);
+  return await CalendarEvent.create({
+    ownerId,
+    type,
+    title: title.trim(),
+    start: s,
+    end: e,
+    leadId: leadId || null,
+    participantIds: (participantIds || []).filter((p) => mongoose.Types.ObjectId.isValid(p)),
+  });
+};
+
+// Save draft notes while the meeting is live (the dashboard capture pane).
+const saveNotes = async (eventId, actorId, notes) => {
+  assertValidId(eventId, "eventId");
+  if (typeof notes !== "string") throw httpError(400, "notes must be a string");
+  const event = await CalendarEvent.findOneAndUpdate(
+    { _id: eventId, ownerId: actorId, status: "scheduled" },
+    { $set: { notes } },
+    { new: true }
+  );
+  if (!event) throw httpError(404, "Open meeting not found on your calendar");
+  return event;
+};
+
+// Close a meeting — NOTES ARE MANDATORY (founder rule: no meeting closes silent).
+const closeMeeting = async (eventId, actorId, { notes } = {}) => {
+  assertValidId(eventId, "eventId");
+  const event = await CalendarEvent.findOne({ _id: eventId, status: "scheduled" });
+  if (!event) throw httpError(404, "Open meeting not found");
+  if (String(event.ownerId) !== String(actorId)) {
+    throw httpError(403, "Only the meeting owner can close it");
+  }
+  const finalNotes = (typeof notes === "string" && notes.trim()) || (event.notes || "").trim();
+  if (!finalNotes) {
+    throw httpError(422, "A meeting cannot be closed without notes");
+  }
+  event.notes = finalNotes;
+  event.status = "closed";
+  event.closedAt = new Date();
+  event.closedBy = actorId;
+  await event.save();
+  if (event.leadId) {
+    await LeadInternalEventService.record({
+      leadId: event.leadId,
+      type: "meeting_closed",
+      actorId,
+      payload: { eventId: String(event._id), title: event.title, notes: finalNotes.slice(0, 500) },
+    });
+  }
+  return event;
+};
+
+// ── Huddles ───────────────────────────────────────────────────────────────────
+
+// Huddle state for a lead's upcoming gmeet — drives the countdown chip.
+const huddleForLead = async (leadId, now = new Date()) => {
+  assertValidId(leadId, "leadId");
+  const huddle = await CalendarEvent.findOne({
+    leadId,
+    type: "huddle",
+    status: { $in: ["scheduled", "closed"] },
+  })
+    .sort({ start: -1 })
+    .lean();
+  if (!huddle) return null;
+  const msToMeet = new Date(huddle.start).getTime() - now.getTime();
+  return {
+    ...huddle,
+    pending: huddle.status === "scheduled",
+    msToMeet,
+    overdue: huddle.status === "scheduled" && msToMeet <= 0,
+  };
+};
+
+// Huddle completion: attendees + event-team assignments + notes. Writes the
+// lightweight eventTeam[] onto the Enquiry and flips the chip.
+const completeHuddle = async (huddleId, actorId, { attendeeIds = [], eventTeam = [], notes } = {}) => {
+  assertValidId(huddleId, "huddleId");
+  if (!notes || !String(notes).trim()) throw httpError(422, "Huddle notes are required");
+  const huddle = await CalendarEvent.findOne({ _id: huddleId, type: "huddle", status: "scheduled" });
+  if (!huddle) throw httpError(404, "Pending huddle not found");
+
+  const cleanAttendees = (attendeeIds || []).filter((a) => mongoose.Types.ObjectId.isValid(a));
+  const cleanTeam = (eventTeam || [])
+    .filter((t) => t && mongoose.Types.ObjectId.isValid(t.adminId))
+    .map((t) => ({ adminId: t.adminId, label: String(t.label || "").slice(0, 60) }));
+
+  huddle.status = "closed";
+  huddle.closedAt = new Date();
+  huddle.closedBy = actorId;
+  huddle.notes = String(notes).trim();
+  huddle.huddleOutcome = { attendeeIds: cleanAttendees, eventTeam: cleanTeam };
+  await huddle.save();
+
+  if (huddle.leadId) {
+    if (cleanTeam.length) {
+      await Enquiry.findByIdAndUpdate(huddle.leadId, { $set: { eventTeam: cleanTeam } });
+    }
+    await LeadInternalEventService.record({
+      leadId: huddle.leadId,
+      type: "huddle_completed",
+      actorId,
+      payload: {
+        attendeeIds: cleanAttendees.map(String),
+        eventTeam: cleanTeam.map((t) => ({ adminId: String(t.adminId), label: t.label })),
+        notes: huddle.notes.slice(0, 500),
+      },
+    });
+  }
+  return huddle;
+};
+
+// ── Views ─────────────────────────────────────────────────────────────────────
+
+// Visible admin ids under a lead-scope filter keyed on ownerId (same trick as attendance).
+const visibleAdminIds = async (scopeFilter = {}) => {
+  if (!scopeFilter || Object.keys(scopeFilter).length === 0) {
+    const all = await Admin.find({ status: "active" }, { _id: 1 }).lean();
+    return all.map((a) => a._id);
+  }
+  const v = scopeFilter.ownerId;
+  if (v && v.$in) return v.$in;
+  return v ? [v] : [];
+};
+
+// Team calendar grid: events in [from,to] for visible admins + live status dots.
+const teamCalendar = async ({ from, to } = {}, scopeFilter = {}) => {
+  const f = from ? new Date(from) : new Date();
+  const t = to ? new Date(to) : new Date(f.getTime() + 7 * 24 * 60 * 60 * 1000);
+  if (Number.isNaN(f.getTime()) || Number.isNaN(t.getTime())) throw httpError(400, "Invalid from/to");
+  const ids = await visibleAdminIds(scopeFilter);
+  const AttendanceService = require("./AttendanceService");
+  const [admins, events, liveIds] = await Promise.all([
+    Admin.find({ _id: { $in: ids }, status: "active" }, { name: 1 }).lean(),
+    CalendarEvent.find({
+      ownerId: { $in: ids },
+      status: { $ne: "cancelled" },
+      start: { $lt: t },
+      end: { $gte: f },
+    })
+      .sort({ start: 1 })
+      .lean(),
+    liveMeetingAdminIds(),
+  ]);
+  const Attendance = require("../models/Attendance");
+  const day = AttendanceService.dayKey();
+  const attRows = await Attendance.find({ adminId: { $in: ids }, date: day }).lean();
+  const attByAdmin = new Map(attRows.map((r) => [String(r.adminId), r]));
+  const now = new Date();
+
+  // Lead names for event chips (one query).
+  const leadIds = [...new Set(events.map((e) => e.leadId).filter(Boolean).map(String))];
+  const leads = leadIds.length
+    ? await Enquiry.find({ _id: { $in: leadIds } }, { name: 1, stage: 1 }).lean()
+    : [];
+  const leadById = new Map(leads.map((l) => [String(l._id), l]));
+
+  return {
+    from: f,
+    to: t,
+    rows: admins
+      .map((a) => ({
+        adminId: a._id,
+        name: a.name,
+        status: AttendanceService.statusOf(attByAdmin.get(String(a._id)) || null, now, liveIds),
+        events: events
+          .filter((e) => String(e.ownerId) === String(a._id))
+          .map((e) => ({
+            ...e,
+            lead: e.leadId ? leadById.get(String(e.leadId)) || null : null,
+            live: e.status === "scheduled" && e.start <= now && e.end >= now && MEETING_TYPES.includes(e.type),
+            unclosed: e.status === "scheduled" && e.end < now && MEETING_TYPES.includes(e.type),
+            huddlePending:
+              e.type === "gmeet" &&
+              e.status === "scheduled" &&
+              events.some(
+                (h) =>
+                  h.type === "huddle" &&
+                  h.status === "scheduled" &&
+                  String(h.leadId || "") === String(e.leadId || "x")
+              ),
+          })),
+      }))
+      .sort((x, y) => x.name.localeCompare(y.name)),
+  };
+};
+
+// Meeting-mode state for ONE admin: the live meeting (banner), unclosed pile
+// (pinned + blocking), pending huddles with countdowns.
+const meetingMode = async (adminId, now = new Date()) => {
+  const [live, unclosed, huddles] = await Promise.all([
+    CalendarEvent.findOne({ ownerId: adminId, ...liveMeetingFilter(now) }).sort({ start: 1 }).lean(),
+    CalendarEvent.find({ ownerId: adminId, ...unclosedMeetingFilter(now) }).sort({ end: 1 }).lean(),
+    CalendarEvent.find({ ownerId: adminId, type: "huddle", status: "scheduled" }).sort({ start: 1 }).lean(),
+  ]);
+  const leadIds = [
+    ...new Set(
+      [live, ...unclosed, ...huddles].filter(Boolean).map((e) => e.leadId).filter(Boolean).map(String)
+    ),
+  ];
+  const leads = leadIds.length
+    ? await Enquiry.find({ _id: { $in: leadIds } }, { name: 1, stage: 1, phone: 1 }).lean()
+    : [];
+  const leadById = new Map(leads.map((l) => [String(l._id), l]));
+  const withLead = (e) => (e ? { ...e, lead: e.leadId ? leadById.get(String(e.leadId)) || null : null } : null);
+  return {
+    live: withLead(live),
+    unclosed: unclosed.map(withLead),
+    blocked: unclosed.length > 0,
+    pendingHuddles: huddles.map((h) => ({
+      ...withLead(h),
+      msToMeet: new Date(h.start).getTime() - now.getTime(),
+      overdue: new Date(h.start).getTime() <= now.getTime(),
+    })),
+  };
+};
+
+// Unclosed meetings across the caller's scope — the Revenue Head list.
+const unclosedList = async (scopeFilter = {}, now = new Date()) => {
+  const ids = await visibleAdminIds(scopeFilter);
+  const rows = await CalendarEvent.find({ ownerId: { $in: ids }, ...unclosedMeetingFilter(now) })
+    .sort({ end: 1 })
+    .lean();
+  const adminIds = [...new Set(rows.map((r) => String(r.ownerId)))];
+  const admins = adminIds.length ? await Admin.find({ _id: { $in: adminIds } }, { name: 1 }).lean() : [];
+  const byId = new Map(admins.map((a) => [String(a._id), a.name]));
+  const leadIds = [...new Set(rows.map((r) => r.leadId).filter(Boolean).map(String))];
+  const leads = leadIds.length ? await Enquiry.find({ _id: { $in: leadIds } }, { name: 1 }).lean() : [];
+  const leadById = new Map(leads.map((l) => [String(l._id), l]));
+  return rows.map((r) => ({
+    ...r,
+    ownerName: byId.get(String(r.ownerId)) || null,
+    lead: r.leadId ? leadById.get(String(r.leadId)) || null : null,
+  }));
+};
+
+// Calendar items for one lead (Client File: huddle chip + meet state).
+const leadEvents = async (leadId) => {
+  assertValidId(leadId, "leadId");
+  const events = await CalendarEvent.find({ leadId, status: { $ne: "cancelled" } })
+    .sort({ start: 1 })
+    .lean();
+  const huddle = await huddleForLead(leadId);
+  return { events, huddle };
+};
+
+module.exports = {
+  MEETING_TYPES,
+  liveMeetingAdminIds,
+  onFollowUpBooked,
+  createEvent,
+  saveNotes,
+  closeMeeting,
+  completeHuddle,
+  huddleForLead,
+  teamCalendar,
+  meetingMode,
+  unclosedList,
+  leadEvents,
+};

--- a/services/CallCockpitService.js
+++ b/services/CallCockpitService.js
@@ -212,6 +212,18 @@ const addFollowUp = async (
     payload: { followUpType: type, scheduledAt: scheduledAtDate, promiseNote: promiseNote || "" },
   });
 
+  // MB5 Slice 3 (fire-safe inside): meet/visit mirror into the team calendar,
+  // gmeet huddle auto-create, intern→manager handoff with qualifiedBy credit.
+  const justAdded = (updated.followUps || [])
+    .filter((f) => f.type === type)
+    .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))[0];
+  const CalendarEventService = require("./CalendarEventService");
+  await CalendarEventService.onFollowUpBooked(
+    enquiryId,
+    { _id: justAdded ? justAdded._id : null, type, scheduledAt: scheduledAtDate },
+    actorId
+  );
+
   return updated;
 };
 

--- a/services/CallCockpitService.js
+++ b/services/CallCockpitService.js
@@ -249,6 +249,37 @@ const updateQualification = async (enquiryId, body = {}, actorId) => {
       set[`qualificationData.${field}`] = body[field];
     }
   }
+  // MB6 Slice 6 — Cockpit v2 fields.
+  if (body.servicesRequired !== undefined) {
+    if (!Array.isArray(body.servicesRequired) || body.servicesRequired.some((s) => typeof s !== "string")) {
+      throw httpError(400, "Invalid servicesRequired (expected an array of strings)");
+    }
+    set["qualificationData.servicesRequired"] = [...new Set(body.servicesRequired.map((s) => s.trim()).filter(Boolean))];
+  }
+  if (body.budgetAmount !== undefined) {
+    if (body.budgetAmount !== null && (typeof body.budgetAmount !== "number" || !Number.isFinite(body.budgetAmount) || body.budgetAmount < 0)) {
+      throw httpError(400, "Invalid budgetAmount (expected a non-negative number or null)");
+    }
+    set["qualificationData.budgetAmount"] = body.budgetAmount;
+  }
+  if (body.budgetNote !== undefined) {
+    if (typeof body.budgetNote !== "string" || body.budgetNote.length > 1000) {
+      throw httpError(400, "Invalid budgetNote");
+    }
+    set["qualificationData.budgetNote"] = body.budgetNote;
+  }
+  if (body.additionalEmails !== undefined) {
+    const emailish = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (
+      !Array.isArray(body.additionalEmails) ||
+      body.additionalEmails.some((e) => typeof e !== "string" || (e.trim() && !emailish.test(e.trim())))
+    ) {
+      throw httpError(400, "Invalid additionalEmails (expected an array of email addresses)");
+    }
+    set["qualificationData.additionalEmails"] = [
+      ...new Set(body.additionalEmails.map((e) => e.trim().toLowerCase()).filter(Boolean)),
+    ];
+  }
   if (Object.keys(set).length === 0) {
     throw httpError(400, "No valid qualification fields provided");
   }
@@ -316,9 +347,59 @@ const listInternalEvents = async (enquiryId) => {
   return await LeadInternalEventService.listForLead(enquiryId);
 };
 
+// MB6 Slice 6 — meet-refuser: the lead won't take a meeting. Tags 'no-meet',
+// escalates to the owner's sales lead, notifies the Revenue Head, journey event.
+const meetRefused = async (enquiryId, actorId) => {
+  assertValidId(enquiryId);
+  const enquiry = await EnquiryRepository.findById(enquiryId);
+  if (!enquiry) throw httpError(404, "Enquiry not found");
+
+  const Enquiry = require("../models/Enquiry");
+  const Admin = require("../models/Admin");
+  const Role = require("../models/Role");
+  const AdminNotificationService = require("./AdminNotificationService");
+
+  await Enquiry.findByIdAndUpdate(enquiryId, { $addToSet: { tags: "no-meet" } });
+  await LeadInternalEventService.record({
+    leadId: enquiryId,
+    type: "meet_refused",
+    actorId,
+    payload: {},
+  });
+
+  // Escalate to the owner's sales lead (reportingManager).
+  const owner = enquiry.assignedTo
+    ? await Admin.findById(enquiry.assignedTo, { name: 1, reportingManagerId: 1 }).lean()
+    : null;
+  if (owner && owner.reportingManagerId) {
+    await AdminNotificationService.notify(owner.reportingManagerId, {
+      type: "meet_refused",
+      title: `${enquiry.name} is refusing a meeting`,
+      message: `Tagged no-meet by ${owner.name} — step in or coach the close.`,
+      leadId: enquiryId,
+    });
+  }
+  // Notify the Revenue Head(s).
+  const rhRole = await Role.findOne({ name: "Revenue Head", deletedAt: null }, { _id: 1 }).lean();
+  if (rhRole) {
+    const heads = await Admin.find({ roleId: rhRole._id, status: "active" }, { _id: 1 }).lean();
+    await AdminNotificationService.notify(
+      heads.map((h) => h._id),
+      {
+        type: "meet_refused",
+        title: `Meet-refuser: ${enquiry.name}`,
+        message: "Lead is dodging the meeting — tagged no-meet.",
+        leadId: enquiryId,
+      }
+    );
+  }
+  return await EnquiryRepository.findById(enquiryId);
+};
+
 module.exports = {
   logCall,
   addFollowUp,
+  meetRefused,
   updateQualification,
   completeCall,
   listInternalEvents,

--- a/services/DashboardService.js
+++ b/services/DashboardService.js
@@ -84,16 +84,28 @@ const buildDashboard = async (adminId, scope, scopeFilter = {}) => {
     console.error("[Dashboard] triage sweep failed:", e.message);
   }
 
-  // MISSION-QUIET (Kiara): WhatsApp leads actively handled by the AI agent
-  // (mode ai, open, not escalated) carry no call-now pressure — Kiara is
-  // already talking to them. They re-enter missions the moment the
-  // conversation escalates or qualifies (needsHuman flips / qualified path).
+  // MB5 Slice 5: Kiara safety net sweep — in-hours golden-window misses get
+  // the welcome template. Template-gated; dormant when unset.
+  try {
+    await require("./KiaraSafetyNetService").sweepGoldenWindowMisses();
+  } catch (e) {
+    console.error("[Dashboard] safety net sweep failed:", e.message);
+  }
+
+  // MISSION-QUIET (Kiara): leads actively handled by the AI agent (mode ai,
+  // open, not escalated) carry no call-now pressure — Kiara is already
+  // talking to them. WhatsApp-source leads + safety-net-engaged leads (any
+  // source, Slice 5). They re-enter missions the moment the conversation
+  // escalates or qualifies (needsHuman flips / qualified path).
   let kiaraQuietIds = [];
   try {
     const quietConvIds = await WAConversationRepository.findQuietEnquiryIds();
     if (quietConvIds.length) {
       const quietLeads = await Enquiry.find(
-        { _id: { $in: quietConvIds }, source: "whatsapp" },
+        {
+          _id: { $in: quietConvIds },
+          $or: [{ source: "whatsapp" }, { kiaraSafetyNetAt: { $ne: null } }],
+        },
         { _id: 1 }
       ).lean();
       kiaraQuietIds = quietLeads.map((l) => l._id);

--- a/services/DashboardService.js
+++ b/services/DashboardService.js
@@ -76,6 +76,14 @@ const buildDashboard = async (adminId, scope, scopeFilter = {}) => {
   // Lazy resurface (Slice E): recycled leads past revisitAt come back before we read.
   await LeadLifecycleService.resurfaceDueLeads(scopeFilter);
 
+  // MB5 Slice 4: lazy triage-escalation sweep rides the dashboard read too
+  // (same no-new-infra pattern). No-op outside triage mode / working hours.
+  try {
+    await require("./TriageService").sweepEscalations();
+  } catch (e) {
+    console.error("[Dashboard] triage sweep failed:", e.message);
+  }
+
   // MISSION-QUIET (Kiara): WhatsApp leads actively handled by the AI agent
   // (mode ai, open, not escalated) carry no call-now pressure — Kiara is
   // already talking to them. They re-enter missions the moment the

--- a/services/GoogleWorkspaceService.js
+++ b/services/GoogleWorkspaceService.js
@@ -1,0 +1,354 @@
+const jwt = require("jsonwebtoken");
+const GoogleAccount = require("../models/GoogleAccount");
+const Admin = require("../models/Admin");
+const Role = require("../models/Role");
+const Enquiry = require("../models/Enquiry");
+const CalendarEvent = require("../models/CalendarEvent");
+const SettingsService = require("./SettingsService");
+
+// MB6 Slice 8 — Google Workspace, built fully behind env seams (the
+// ANTHROPIC_API_URL pattern): every Google URL is overridable so the e2e
+// suite drives a local mock. When GOOGLE_CLIENT_ID/SECRET are unset the whole
+// feature is DORMANT: status reports configured:false, booking falls back to
+// the OS-only flow, the UI shows a tidy "not configured yet" state.
+
+const httpError = (status, message, extra = {}) =>
+  Object.assign(new Error(message), { status, ...extra });
+
+// The PINNED production redirect URI (env override for local/test).
+const REDIRECT_URI =
+  process.env.GOOGLE_REDIRECT_URI || "https://prod.server.wedsy.in/google/oauth/callback";
+
+const AUTH_URL = process.env.GOOGLE_AUTH_URL || "https://accounts.google.com/o/oauth2/v2/auth";
+const TOKEN_URL = process.env.GOOGLE_TOKEN_URL || "https://oauth2.googleapis.com/token";
+const USERINFO_URL = process.env.GOOGLE_USERINFO_URL || "https://openidconnect.googleapis.com/v1/userinfo";
+const CALENDAR_URL = process.env.GOOGLE_CALENDAR_URL || "https://www.googleapis.com/calendar/v3";
+
+const SCOPES = [
+  "https://www.googleapis.com/auth/calendar.events",
+  "https://www.googleapis.com/auth/calendar.freebusy",
+  "openid",
+  "email",
+];
+
+const isConfigured = () => !!(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET);
+
+// ── OAuth ─────────────────────────────────────────────────────────────────────
+
+// Consent URL with a signed state (the adminId rides through Google and back).
+const startUrl = (adminId) => {
+  if (!isConfigured()) throw httpError(409, "Google is not configured yet");
+  const state = jwt.sign({ g: String(adminId) }, process.env.JWT_SECRET, { expiresIn: "15m" });
+  const params = new URLSearchParams({
+    client_id: process.env.GOOGLE_CLIENT_ID,
+    redirect_uri: REDIRECT_URI,
+    response_type: "code",
+    scope: SCOPES.join(" "),
+    access_type: "offline",
+    prompt: "consent",
+    state,
+  });
+  return `${AUTH_URL}?${params.toString()}`;
+};
+
+const exchangeCode = async (code) => {
+  const res = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      code,
+      client_id: process.env.GOOGLE_CLIENT_ID,
+      client_secret: process.env.GOOGLE_CLIENT_SECRET,
+      redirect_uri: REDIRECT_URI,
+      grant_type: "authorization_code",
+    }).toString(),
+  });
+  if (!res.ok) throw httpError(502, `Google token exchange failed (${res.status})`);
+  return await res.json();
+};
+
+const handleCallback = async (code, state) => {
+  if (!isConfigured()) throw httpError(409, "Google is not configured yet");
+  let adminId;
+  try {
+    adminId = jwt.verify(state, process.env.JWT_SECRET).g;
+  } catch (_) {
+    throw httpError(403, "Invalid or expired state");
+  }
+  const tokens = await exchangeCode(code);
+  if (!tokens.refresh_token) {
+    throw httpError(502, "Google did not return a refresh token — retry with consent");
+  }
+  // Who linked? userinfo via the fresh access token.
+  let email = "";
+  try {
+    const ui = await fetch(USERINFO_URL, {
+      headers: { Authorization: `Bearer ${tokens.access_token}` },
+    });
+    if (ui.ok) email = (await ui.json()).email || "";
+  } catch (_) { /* email is display-only */ }
+
+  const account = await GoogleAccount.findOneAndUpdate(
+    { adminId },
+    {
+      $set: {
+        email,
+        refreshToken: tokens.refresh_token,
+        scopes: String(tokens.scope || "").split(" ").filter(Boolean),
+        linkedAt: new Date(),
+      },
+    },
+    { upsert: true, new: true, setDefaultsOnInsert: true }
+  );
+  return account;
+};
+
+const accessTokenFor = async (account) => {
+  const res = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      refresh_token: account.refreshToken,
+      client_id: process.env.GOOGLE_CLIENT_ID,
+      client_secret: process.env.GOOGLE_CLIENT_SECRET,
+      grant_type: "refresh_token",
+    }).toString(),
+  });
+  if (!res.ok) throw httpError(502, `Google token refresh failed (${res.status})`);
+  return (await res.json()).access_token;
+};
+
+const status = async (adminId) => {
+  const account = await GoogleAccount.findOne({ adminId }).lean();
+  return {
+    configured: isConfigured(),
+    linked: !!account,
+    email: account ? account.email : null,
+    linkedAt: account ? account.linkedAt : null,
+  };
+};
+
+const disconnect = async (adminId) => {
+  await GoogleAccount.deleteMany({ adminId });
+  return { ok: true };
+};
+
+// ── Booking flow support ──────────────────────────────────────────────────────
+
+// The two internal attendees of every G-Meet: the lead's sales lead (interns
+// book on their reporting manager's calendar) and the Revenue-Head admin.
+const meetingAttendees = async (lead) => {
+  let salesLeadAdmin = lead.assignedTo
+    ? await Admin.findById(lead.assignedTo, { name: 1, email: 1, roleId: 1, reportingManagerId: 1 }).lean()
+    : null;
+  if (salesLeadAdmin && salesLeadAdmin.roleId && salesLeadAdmin.reportingManagerId) {
+    const poolRoles = (await SettingsService.get("assignment.poolRoles")) || [];
+    const role = await Role.findById(salesLeadAdmin.roleId, { name: 1 }).lean();
+    if (role && poolRoles.includes(role.name)) {
+      // Intern-owned lead: the meet lives on the sales lead's calendar.
+      const manager = await Admin.findById(salesLeadAdmin.reportingManagerId, { name: 1, email: 1 }).lean();
+      if (manager) salesLeadAdmin = manager;
+    }
+  }
+  let revenueHead = null;
+  const rhRole = await Role.findOne({ name: "Revenue Head", deletedAt: null }, { _id: 1 }).lean();
+  if (rhRole) {
+    revenueHead = await Admin.findOne({ roleId: rhRole._id, status: "active" }, { name: 1, email: 1 }).lean();
+  }
+  return { salesLeadAdmin, revenueHead };
+};
+
+const googleBusy = async (account, from, to) => {
+  const token = await accessTokenFor(account);
+  const res = await fetch(`${CALENDAR_URL}/freeBusy`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      timeMin: from.toISOString(),
+      timeMax: to.toISOString(),
+      items: [{ id: "primary" }],
+    }),
+  });
+  if (!res.ok) throw httpError(502, `Google freeBusy failed (${res.status})`);
+  const data = await res.json();
+  const cal = data.calendars && data.calendars.primary;
+  return (cal && cal.busy ? cal.busy : []).map((b) => ({ start: b.start, end: b.end, source: "google" }));
+};
+
+// Merged availability for the lead's meet: Google free/busy (linked admins)
+// + OS CalendarEvents for BOTH attendees. Returns the busy blocks + 1h slot
+// suggestions inside working hours.
+const availability = async (leadId, { from, days = 5 } = {}) => {
+  const lead = await Enquiry.findById(leadId).lean();
+  if (!lead) throw httpError(404, "Lead not found");
+  const start = from ? new Date(from) : new Date();
+  if (Number.isNaN(start.getTime())) throw httpError(400, "Invalid from");
+  const end = new Date(start.getTime() + days * 24 * 3600 * 1000);
+
+  const { salesLeadAdmin, revenueHead } = await meetingAttendees(lead);
+  const attendeeAdmins = [salesLeadAdmin, revenueHead].filter(Boolean);
+  const attendeeIds = attendeeAdmins.map((a) => a._id);
+
+  const busy = [];
+  // OS calendar events of both attendees.
+  const osEvents = await CalendarEvent.find({
+    ownerId: { $in: attendeeIds },
+    status: "scheduled",
+    start: { $lt: end },
+    end: { $gte: start },
+  }).lean();
+  for (const e of osEvents) busy.push({ start: e.start.toISOString(), end: e.end.toISOString(), source: "os" });
+
+  // Google free/busy where linked (and configured).
+  let googleUsed = false;
+  if (isConfigured()) {
+    for (const adminId of attendeeIds) {
+      const account = await GoogleAccount.findOne({ adminId }).lean();
+      if (!account) continue;
+      try {
+        busy.push(...(await googleBusy(account, start, end)));
+        googleUsed = true;
+      } catch (e) {
+        console.error("[Google] freeBusy failed:", e.message);
+      }
+    }
+  }
+
+  // 1-hour slot suggestions inside working hours, skipping busy overlaps.
+  const cfg = await SettingsService.getMany(["golden.workStartHour", "golden.workEndHour"]);
+  const IST_OFFSET_MS = 330 * 60 * 1000;
+  const slots = [];
+  for (let d = 0; d < days; d++) {
+    for (let h = cfg["golden.workStartHour"]; h < cfg["golden.workEndHour"]; h++) {
+      const istDay = new Date(start.getTime() + IST_OFFSET_MS);
+      const slotStart = new Date(
+        Date.UTC(istDay.getUTCFullYear(), istDay.getUTCMonth(), istDay.getUTCDate() + d, h, 0) - IST_OFFSET_MS
+      );
+      const slotEnd = new Date(slotStart.getTime() + 3600 * 1000);
+      if (slotStart < new Date()) continue;
+      const clash = busy.some(
+        (b) => new Date(b.start) < slotEnd && new Date(b.end) > slotStart
+      );
+      if (!clash) slots.push({ start: slotStart.toISOString(), end: slotEnd.toISOString() });
+    }
+  }
+
+  return {
+    configured: isConfigured(),
+    googleUsed,
+    attendees: attendeeAdmins.map((a) => ({ _id: a._id, name: a.name })),
+    busy,
+    slots: slots.slice(0, 40),
+  };
+};
+
+// Create the Google Calendar event WITH a Meet link, client + internal
+// attendees invited. Returns { googleEventId, meetLink } or null when no
+// linked organizer exists (the caller falls back to OS-only).
+const createMeetEvent = async (lead, start, end) => {
+  if (!isConfigured()) return null;
+  const { salesLeadAdmin, revenueHead } = await meetingAttendees(lead);
+  // Organizer preference: the sales lead's linked account, else the Revenue Head's.
+  let organizer = null;
+  let account = null;
+  for (const candidate of [salesLeadAdmin, revenueHead].filter(Boolean)) {
+    const acc = await GoogleAccount.findOne({ adminId: candidate._id }).lean();
+    if (acc) {
+      organizer = candidate;
+      account = acc;
+      break;
+    }
+  }
+  if (!account) return null;
+
+  const clientEmails = [
+    (lead.qualificationData && lead.qualificationData.email) || lead.email || "",
+    ...((lead.qualificationData && lead.qualificationData.additionalEmails) || []),
+  ].filter(Boolean);
+  const internalEmails = [salesLeadAdmin, revenueHead]
+    .filter(Boolean)
+    .map((a) => a.email)
+    .filter(Boolean);
+  const attendees = [...new Set([...clientEmails, ...internalEmails])].map((email) => ({ email }));
+
+  const token = await accessTokenFor(account);
+  const res = await fetch(`${CALENDAR_URL}/calendars/primary/events?conferenceDataVersion=1&sendUpdates=all`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      summary: `Wedsy — ${lead.name}'s wedding meet`,
+      description: "Scheduled from Wedsy OS.",
+      start: { dateTime: new Date(start).toISOString() },
+      end: { dateTime: new Date(end).toISOString() },
+      attendees,
+      conferenceData: {
+        createRequest: { requestId: `wedsy-${lead._id}-${new Date(start).getTime()}`, conferenceSolutionKey: { type: "hangoutsMeet" } },
+      },
+    }),
+  });
+  if (!res.ok) throw httpError(502, `Google event create failed (${res.status})`);
+  const event = await res.json();
+  return {
+    googleEventId: event.id,
+    meetLink: event.hangoutLink || "",
+    organizerAdminId: organizer._id,
+    invited: attendees.map((a) => a.email),
+  };
+};
+
+// The cockpit finale's one-call booking: Google event (when wired) + the meet
+// follow-up exactly as today (which mirrors the OS CalendarEvent, runs the
+// huddle auto-create and the intern handoff). The mirrored event is then
+// stamped with the googleEventId.
+const bookMeet = async (leadId, { start, end }, actorId) => {
+  const lead = await Enquiry.findById(leadId).lean();
+  if (!lead) throw httpError(404, "Lead not found");
+  const s = new Date(start);
+  if (Number.isNaN(s.getTime())) throw httpError(400, "Invalid start");
+  const e = end ? new Date(end) : new Date(s.getTime() + 3600 * 1000);
+
+  let google = null;
+  try {
+    google = await createMeetEvent(lead, s, e);
+  } catch (err) {
+    console.error("[Google] meet create failed — falling back to OS-only:", err.message);
+  }
+
+  // The follow-up books exactly as today (journey, mirror, huddle, handoff).
+  const CallCockpitService = require("./CallCockpitService");
+  await CallCockpitService.addFollowUp(
+    leadId,
+    { type: "meet", scheduledAt: s.toISOString(), promiseNote: google && google.meetLink ? `G-Meet: ${google.meetLink}` : "" },
+    actorId
+  );
+
+  // Stamp the mirrored OS event with the Google linkage.
+  const mirrored = await CalendarEvent.findOne({ leadId, type: "gmeet", start: s })
+    .sort({ createdAt: -1 })
+    .lean();
+  if (mirrored && google) {
+    await CalendarEvent.findByIdAndUpdate(mirrored._id, {
+      $set: { googleEventId: google.googleEventId, end: e },
+    });
+  }
+
+  return {
+    google: !!google,
+    meetLink: google ? google.meetLink : "",
+    googleEventId: google ? google.googleEventId : "",
+    invited: google ? google.invited : [],
+    osEventId: mirrored ? mirrored._id : null,
+  };
+};
+
+module.exports = {
+  isConfigured,
+  startUrl,
+  handleCallback,
+  status,
+  disconnect,
+  availability,
+  bookMeet,
+  meetingAttendees,
+  REDIRECT_URI,
+};

--- a/services/InstagramAgentService.js
+++ b/services/InstagramAgentService.js
@@ -5,6 +5,31 @@ const QualifiedLead = require('../models/QualifiedLead');
 const axios = require('axios');
 const { google } = require('googleapis');
 
+// MB6 Slice 7 — the MB4 hook pattern ADAPTED to Instagram's reality: the
+// thread is keyed by the IG-scoped user id (NOT a phone). The conversation
+// record carries channel:'instagram'; CRM lead linkage happens only once a
+// real phone number is captured by the extractor. Until then the conversation
+// lives unlinked in the inbox.
+const WAConversationService = require('./WAConversationService');
+const KiaraCrmSyncService = require('./KiaraCrmSyncService');
+const LeadIntakeService = require('./LeadIntakeService');
+const LeadInternalEventService = require('./LeadInternalEventService');
+const WAConversationRepository = require('../repositories/WAConversationRepository');
+
+// Mock seam (same idiom as the WhatsApp agent).
+const ANTHROPIC_API_URL = process.env.ANTHROPIC_API_URL || 'https://api.anthropic.com/v1/messages';
+
+// CRASH FIX (mirrors MB4's WhatsApp fix): response.data.content[0].text threw
+// on empty content arrays and tool/thinking-first responses. Find the first
+// text block; null means the caller treats it as a failure.
+const firstTextBlock = (response) => {
+  const content = response && response.data && Array.isArray(response.data.content)
+    ? response.data.content
+    : [];
+  const block = content.find((b) => b && b.type === 'text' && typeof b.text === 'string');
+  return block ? block.text : null;
+};
+
 const SYSTEM_PROMPT = `You are Kiara, a wedding planner at Wedsy in Bengaluru. You're chatting with a potential client on Instagram DM.
 
 Your personality:
@@ -55,7 +80,7 @@ const sendToClaude = async (history) => {
   while (attempt <= MAX_RETRIES) {
     try {
       const response = await axios.post(
-        'https://api.anthropic.com/v1/messages',
+        ANTHROPIC_API_URL,
         {
           model: 'claude-sonnet-4-5',
           max_tokens: 500,
@@ -70,7 +95,9 @@ const sendToClaude = async (history) => {
           }
         }
       );
-      return response.data.content[0].text;
+      const text = firstTextBlock(response);
+      if (text !== null) return text;
+      throw new Error('No text block in Anthropic response');
     } catch (error) {
       attempt++;
       if (attempt > MAX_RETRIES) {
@@ -95,11 +122,17 @@ const checkQualified = async (history) => {
   while (attempt <= MAX_RETRIES) {
     try {
       const response = await axios.post(
-        'https://api.anthropic.com/v1/messages',
+        ANTHROPIC_API_URL,
         {
           model: 'claude-sonnet-4-5',
           max_tokens: 400,
-          system: 'You are a data extractor. Based on the conversation, check if the qualification is complete — meaning the user has provided their phone number AND the assistant has thanked them and said the team will connect within 24 hours. Extract whatever details were collected. Respond ONLY with valid JSON, no markdown, no explanation. Format: {"qualified": true/false, "data": {"name": "", "phoneNumber": "", "eventType": "", "city": "", "eventDate": "", "numberOfEvents": "", "venueStatus": "", "venueName": "", "servicesRequired": "", "budget": "", "weddingStyle": ""}}',
+          // MB6 Slice 7: the WA extractor's routing contract (escalate +
+          // classification), keeping IG's phone-collection mission —
+          // qualification still requires the phone number.
+          system: 'You are a data extractor. Based on the conversation, check if the qualification is complete — meaning the user has provided their phone number AND the assistant has thanked them and said the team will connect within 24 hours. Extract whatever details were collected. ' +
+            'Also decide two routing signals. (1) "escalate": set true when the customer explicitly asks for a human, shows frustration or anger, pushes pricing/negotiation beyond rapport, or the conversation is stuck (3+ exchanges without progress) — and ALWAYS when qualified is true (use escalateReason "Qualified — ready for your call"). Give a short escalateReason whenever escalate is true. ' +
+            '(2) "classification": classify the contact as one of "lead" (a genuine wedding/engagement customer), "vendor" (a vendor/photographer/supplier pitching their services), "birthday" (a birthday inquiry), "corporate" (a corporate-event inquiry), or "destination" (a confirmed destination wedding outside Bengaluru). ' +
+            'Respond ONLY with valid JSON, no markdown, no explanation. Format: {"qualified": true/false, "escalate": true/false, "escalateReason": "", "classification": "lead", "data": {"name": "", "phoneNumber": "", "eventType": "", "city": "", "eventDate": "", "numberOfEvents": "", "venueStatus": "", "venueName": "", "servicesRequired": "", "budget": "", "weddingStyle": ""}}',
           messages: history
         },
         {
@@ -110,7 +143,8 @@ const checkQualified = async (history) => {
           }
         }
       );
-      const text = response.data.content[0].text;
+      const text = firstTextBlock(response);
+      if (text === null) return { qualified: false };
       try {
         return JSON.parse(text);
       } catch {
@@ -133,9 +167,57 @@ const checkQualified = async (history) => {
   }
 };
 
-const saveQualifiedLead = async (instagramId, data) => {
+// HOOK 3 support (MB6 Slice 7): once the extractor captured a REAL phone
+// number, link the IG conversation to a CRM lead — full intake semantics
+// (normalized-phone dedup, re-enquiry on terminal leads, shared create path).
+// Idempotent: an already-linked conversation returns untouched.
+const ensureLeadLinkedByPhone = async (conversation, data = {}) => {
+  try {
+    if (!conversation || conversation.enquiryId) return conversation;
+    const phoneNumber = String(data.phoneNumber || '').replace(/\D/g, '');
+    if (phoneNumber.length < 10) return conversation; // no usable phone yet
+
+    let enquiryId = null;
+    const existing = await LeadIntakeService.findExistingByNormalizedPhone(phoneNumber);
+    if (existing) {
+      enquiryId = existing._id;
+      await LeadIntakeService.recordReEnquiry(existing._id, {
+        source: 'instagram',
+        message: `Instagram DM (${conversation.phone})`,
+      });
+    } else {
+      try {
+        const created = await LeadIntakeService.createLead({
+          name: (data.name || '').trim() || `Instagram ${String(conversation.phone).slice(-4)}`,
+          phone: phoneNumber.length === 10 ? `91${phoneNumber}` : phoneNumber,
+          verified: false,
+          source: 'instagram',
+          additionalInfo: { instagramId: conversation.phone },
+        });
+        enquiryId = created._id;
+      } catch (e) {
+        const winner = await LeadIntakeService.findExistingByNormalizedPhone(phoneNumber);
+        if (!winner) throw e;
+        enquiryId = winner._id;
+      }
+    }
+    const updated = await WAConversationRepository.updateFieldsById(conversation._id, { enquiryId });
+    await LeadInternalEventService.record({
+      leadId: enquiryId,
+      type: 'ig_conversation_linked',
+      actorId: null,
+      payload: { instagramId: conversation.phone, phoneNumber },
+    });
+    return updated;
+  } catch (e) {
+    console.error('[InstagramAgent] ensureLeadLinkedByPhone failed:', e.message);
+    return conversation;
+  }
+};
+
+const saveQualifiedLead = async (instagramId, data, conversation = null) => {
   const existing = await QualifiedLead.findOne({ phone: instagramId });
-  if (existing && existing.googleSheetSynced) {
+  if (existing && existing.googleSheetSynced && existing.crmSynced) {
     console.log('[InstagramAgent] Lead already qualified and synced, skipping:', instagramId);
     return existing;
   }
@@ -210,7 +292,7 @@ const saveQualifiedLead = async (instagramId, data) => {
       leadDoc.googleSheetSynced = true;
       await leadDoc.save();
       console.log('[InstagramAgent] Lead appended to Google Sheet:', instagramId);
-      return true;
+      break;
     } catch (error) {
       attempt++;
       if (attempt > MAX_RETRIES) {
@@ -222,25 +304,78 @@ const saveQualifiedLead = async (instagramId, data) => {
           createdAt: new Date()
         });
         console.error(`[InstagramAgent] Google Sheet append failed after ${attempt} attempts:`, error.message);
-        return null;
+        break;
       }
       await new Promise(resolve => setTimeout(resolve, 2000));
     }
   }
+
+  // HOOK 3 (MB6 Slice 7): CRM sync — crmSynced mirrors the googleSheetSynced
+  // retry idiom, exactly like the WhatsApp agent. Requires a linked lead
+  // (i.e. a captured phone), which the caller establishes first.
+  if (!leadDoc.crmSynced && conversation && conversation.enquiryId) {
+    attempt = 0;
+    while (attempt <= MAX_RETRIES) {
+      try {
+        await KiaraCrmSyncService.syncQualifiedToCrm(data.phoneNumber || instagramId, data, conversation);
+        leadDoc.crmSynced = true;
+        await leadDoc.save();
+        console.log('[InstagramAgent] Lead synced to CRM:', instagramId);
+        break;
+      } catch (error) {
+        attempt++;
+        if (attempt > MAX_RETRIES) {
+          await NotificationFailureLog.create({
+            service: 'KiaraCrmSync',
+            phone: instagramId,
+            error: error.message,
+            attempts: attempt,
+            createdAt: new Date()
+          });
+          console.error(`[InstagramAgent] CRM sync failed after ${attempt} attempts:`, error.message);
+          break;
+        }
+        await new Promise(resolve => setTimeout(resolve, 2000));
+      }
+    }
+  }
+
+  return leadDoc.googleSheetSynced && leadDoc.crmSynced ? true : null;
 };
 
 const receiveMessage = async (instagramId, message) => {
   try {
     await WAAgentMessageRepository.saveMessage(instagramId, 'user', message);
+
+    // HOOK 1 (adapted): conversation upsert keyed by the IG user id,
+    // channel:'instagram'. NO lead linkage yet — that waits for a real phone.
+    let conversation = await WAConversationService.recordInbound(instagramId, message, 'instagram');
+
+    // Mode gate: a human owns the thread (takeover) or it's closed — the IG
+    // bot stays silent, identically to WhatsApp. Zero Anthropic spend.
+    if (conversation.mode !== 'ai' || conversation.status === 'closed') return;
+
     const history = await WAAgentMessageRepository.getHistory(instagramId);
     const reply = await sendToClaude(history);
     if (!reply) return;
     await WAAgentMessageRepository.saveMessage(instagramId, 'assistant', reply);
+    await WAConversationRepository.touchOutbound(conversation._id, reply.slice(0, 120));
     await sendInstagramDM(instagramId, reply);
     const updatedHistory = await WAAgentMessageRepository.getHistory(instagramId);
     const qualification = await checkQualified(updatedHistory);
+
+    // Phone captured → CRM lead linkage (dedup or shared create path).
+    if (qualification && qualification.data && qualification.data.phoneNumber) {
+      conversation = await ensureLeadLinkedByPhone(conversation, qualification.data);
+    }
+
+    // HOOK 2 (adapted): escalation + classification routing — the same
+    // contract as WhatsApp (vendor/birthday/corporate close out, destination
+    // escalates, qualified always escalates). Channel-aware journey events.
+    conversation = await KiaraCrmSyncService.applyExtraction(conversation, qualification);
+
     if (qualification && qualification.qualified) {
-      await saveQualifiedLead(instagramId, qualification.data);
+      await saveQualifiedLead(instagramId, qualification.data, conversation);
     }
   } catch (error) {
     console.error('[InstagramAgent] receiveMessage error:', error.message);

--- a/services/InstagramAgentService.js
+++ b/services/InstagramAgentService.js
@@ -16,8 +16,10 @@ const LeadIntakeService = require('./LeadIntakeService');
 const LeadInternalEventService = require('./LeadInternalEventService');
 const WAConversationRepository = require('../repositories/WAConversationRepository');
 
-// Mock seam (same idiom as the WhatsApp agent).
-const ANTHROPIC_API_URL = process.env.ANTHROPIC_API_URL || 'https://api.anthropic.com/v1/messages';
+// MB6 Slice 11: every Anthropic call rides the shared in-process queue
+// (serialized, exponential backoff on 429) — shared with the WhatsApp agent.
+// The queue owns the ANTHROPIC_API_URL test seam.
+const { callAnthropic } = require('../utils/anthropicQueue');
 
 // CRASH FIX (mirrors MB4's WhatsApp fix): response.data.content[0].text threw
 // on empty content arrays and tool/thinking-first responses. Find the first
@@ -79,22 +81,12 @@ const sendToClaude = async (history) => {
 
   while (attempt <= MAX_RETRIES) {
     try {
-      const response = await axios.post(
-        ANTHROPIC_API_URL,
-        {
-          model: 'claude-sonnet-4-5',
-          max_tokens: 500,
-          system: SYSTEM_PROMPT,
-          messages: history
-        },
-        {
-          headers: {
-            'x-api-key': process.env.ANTHROPIC_API_KEY,
-            'anthropic-version': '2023-06-01',
-            'Content-Type': 'application/json'
-          }
-        }
-      );
+      const response = await callAnthropic({
+        model: 'claude-sonnet-4-5',
+        max_tokens: 500,
+        system: SYSTEM_PROMPT,
+        messages: history
+      });
       const text = firstTextBlock(response);
       if (text !== null) return text;
       throw new Error('No text block in Anthropic response');
@@ -121,28 +113,18 @@ const checkQualified = async (history) => {
 
   while (attempt <= MAX_RETRIES) {
     try {
-      const response = await axios.post(
-        ANTHROPIC_API_URL,
-        {
-          model: 'claude-sonnet-4-5',
-          max_tokens: 400,
-          // MB6 Slice 7: the WA extractor's routing contract (escalate +
-          // classification), keeping IG's phone-collection mission —
-          // qualification still requires the phone number.
-          system: 'You are a data extractor. Based on the conversation, check if the qualification is complete — meaning the user has provided their phone number AND the assistant has thanked them and said the team will connect within 24 hours. Extract whatever details were collected. ' +
-            'Also decide two routing signals. (1) "escalate": set true when the customer explicitly asks for a human, shows frustration or anger, pushes pricing/negotiation beyond rapport, or the conversation is stuck (3+ exchanges without progress) — and ALWAYS when qualified is true (use escalateReason "Qualified — ready for your call"). Give a short escalateReason whenever escalate is true. ' +
-            '(2) "classification": classify the contact as one of "lead" (a genuine wedding/engagement customer), "vendor" (a vendor/photographer/supplier pitching their services), "birthday" (a birthday inquiry), "corporate" (a corporate-event inquiry), or "destination" (a confirmed destination wedding outside Bengaluru). ' +
-            'Respond ONLY with valid JSON, no markdown, no explanation. Format: {"qualified": true/false, "escalate": true/false, "escalateReason": "", "classification": "lead", "data": {"name": "", "phoneNumber": "", "eventType": "", "city": "", "eventDate": "", "numberOfEvents": "", "venueStatus": "", "venueName": "", "servicesRequired": "", "budget": "", "weddingStyle": ""}}',
-          messages: history
-        },
-        {
-          headers: {
-            'x-api-key': process.env.ANTHROPIC_API_KEY,
-            'anthropic-version': '2023-06-01',
-            'Content-Type': 'application/json'
-          }
-        }
-      );
+      const response = await callAnthropic({
+        model: 'claude-sonnet-4-5',
+        max_tokens: 400,
+        // MB6 Slice 7: the WA extractor's routing contract (escalate +
+        // classification), keeping IG's phone-collection mission —
+        // qualification still requires the phone number.
+        system: 'You are a data extractor. Based on the conversation, check if the qualification is complete — meaning the user has provided their phone number AND the assistant has thanked them and said the team will connect within 24 hours. Extract whatever details were collected. ' +
+          'Also decide two routing signals. (1) "escalate": set true when the customer explicitly asks for a human, shows frustration or anger, pushes pricing/negotiation beyond rapport, or the conversation is stuck (3+ exchanges without progress) — and ALWAYS when qualified is true (use escalateReason "Qualified — ready for your call"). Give a short escalateReason whenever escalate is true. ' +
+          '(2) "classification": classify the contact as one of "lead" (a genuine wedding/engagement customer), "vendor" (a vendor/photographer/supplier pitching their services), "birthday" (a birthday inquiry), "corporate" (a corporate-event inquiry), or "destination" (a confirmed destination wedding outside Bengaluru). ' +
+          'Respond ONLY with valid JSON, no markdown, no explanation. Format: {"qualified": true/false, "escalate": true/false, "escalateReason": "", "classification": "lead", "data": {"name": "", "phoneNumber": "", "eventType": "", "city": "", "eventDate": "", "numberOfEvents": "", "venueStatus": "", "venueName": "", "servicesRequired": "", "budget": "", "weddingStyle": ""}}',
+        messages: history
+      });
       const text = firstTextBlock(response);
       if (text === null) return { qualified: false };
       try {
@@ -362,6 +344,12 @@ const receiveMessage = async (instagramId, message) => {
     await WAConversationRepository.touchOutbound(conversation._id, reply.slice(0, 120));
     await sendInstagramDM(instagramId, reply);
     const updatedHistory = await WAAgentMessageRepository.getHistory(instagramId);
+
+    // MB6 Slice 11: same early-skip as WhatsApp — no qualification check
+    // until the customer has sent at least 3 messages.
+    const userMessages = updatedHistory.filter((m) => m.role === 'user').length;
+    if (userMessages < 3) return;
+
     const qualification = await checkQualified(updatedHistory);
 
     // Phone captured → CRM lead linkage (dedup or shared create path).

--- a/services/InternMetricsService.js
+++ b/services/InternMetricsService.js
@@ -1,0 +1,161 @@
+const Enquiry = require("../models/Enquiry");
+const Admin = require("../models/Admin");
+const Role = require("../models/Role");
+const LeadInternalEvent = require("../models/LeadInternalEvent");
+const SettingsService = require("./SettingsService");
+const { goldenWindowFor, istDayStart } = require("../utils/goldenWindow");
+
+// MB6 Slice 10 — intern/presales metrics, DERIVED ONLY (no new write paths).
+// Sources: Enquiry fields (createdAt, firstCalledAt, qualified, qualifiedBy,
+// followUps) + journey events (assignment + follow-up bookings).
+
+const periodStart = (period, now = new Date()) => {
+  if (period === "week") return new Date(istDayStart(now).getTime() - 6 * 24 * 3600 * 1000);
+  if (period === "month") return new Date(istDayStart(now).getTime() - 29 * 24 * 3600 * 1000);
+  return istDayStart(now); // today
+};
+
+// Pool-role admins visible under the caller's lead scope.
+const visibleInterns = async (scopeFilter = {}) => {
+  const poolRoles = (await SettingsService.get("assignment.poolRoles")) || [];
+  const roles = await Role.find({ name: { $in: poolRoles }, deletedAt: null }, { _id: 1 }).lean();
+  const base = { roleId: { $in: roles.map((r) => r._id) }, status: "active" };
+  if (scopeFilter && Object.keys(scopeFilter).length > 0) {
+    const v = scopeFilter.assignedTo;
+    const ids = v && v.$in ? v.$in : v ? [v] : [];
+    base._id = { $in: ids };
+  }
+  return await Admin.find(base, { name: 1 }).lean();
+};
+
+const ASSIGN_EVENT_TYPES = ["auto_assigned", "triage_assigned", "triage_auto_assigned"];
+
+const metricsFor = async (intern, from, now, goldenCfg) => {
+  const internId = String(intern._id);
+
+  // Leads received: assignment events targeting this intern in the period.
+  const assignEvents = await LeadInternalEvent.find({
+    type: { $in: ASSIGN_EVENT_TYPES },
+    createdAt: { $gte: from },
+    $or: [{ "payload.assignedTo": internId }, { "payload.to": internId }],
+  })
+    .sort({ createdAt: 1 })
+    .lean();
+  const receivedLeadIds = [...new Set(assignEvents.map((e) => String(e.leadId)))];
+  const receivedLeads = receivedLeadIds.length
+    ? await Enquiry.find(
+        { _id: { $in: receivedLeadIds } },
+        { createdAt: 1, firstCalledAt: 1, importedAt: 1 }
+      ).lean()
+    : [];
+
+  // Contacted-in-window % + avg time-to-first-call (received leads only).
+  let contactedInWindow = 0;
+  let contacted = 0;
+  let firstCallMsTotal = 0;
+  for (const lead of receivedLeads) {
+    if (!lead.firstCalledAt) continue;
+    contacted++;
+    firstCallMsTotal += new Date(lead.firstCalledAt) - new Date(lead.createdAt);
+    const gw = goldenWindowFor(lead.createdAt, new Date(lead.firstCalledAt), goldenCfg);
+    if (gw.inWindow) contactedInWindow++;
+  }
+
+  // Qualified leads they own OR were handed off from (permanent qualifiedBy
+  // credit) — the lead must actually be qualified either way.
+  const qualified = await Enquiry.countDocuments({
+    $or: [{ qualifiedBy: intern._id }, { assignedTo: intern._id }],
+    qualified: true,
+    updatedAt: { $gte: from },
+  });
+
+  // Meets booked by this intern in the period (journey, actor-stamped).
+  const meetsBooked = await LeadInternalEvent.countDocuments({
+    type: "follow_up_scheduled",
+    actorId: intern._id,
+    "payload.followUpType": "meet",
+    createdAt: { $gte: from },
+  });
+
+  // Incomplete discovery: their qualified/credited leads missing any of the
+  // canonical 7 discovery fields.
+  const discoveryLeads = await Enquiry.find(
+    {
+      $or: [{ qualifiedBy: intern._id }, { assignedTo: intern._id }],
+      qualified: true,
+    },
+    { qualificationData: 1 }
+  ).lean();
+  const incompleteDiscovery = discoveryLeads.filter((l) => {
+    const q = l.qualificationData || {};
+    const filled = [
+      q.groomName,
+      q.brideName,
+      q.weddingStyle,
+      q.venueStatus,
+      q.email,
+      (q.servicesRequired || []).length > 0,
+      q.budgetAmount != null || q.budgetNote,
+    ].filter(Boolean).length;
+    return filled < 7;
+  }).length;
+
+  // Meeting show-up rate: completed vs booked across their meet follow-ups in
+  // the period (completions stamped on the lead's followUps array; the booking
+  // counts via the journey above).
+  const meetLeads = await Enquiry.find(
+    {
+      followUps: { $elemMatch: { type: "meet", createdBy: intern._id, createdAt: { $gte: from } } },
+    },
+    { followUps: 1 }
+  ).lean();
+  let meetsCompleted = 0;
+  let meetsBookedOnLeads = 0;
+  for (const lead of meetLeads) {
+    for (const f of lead.followUps || []) {
+      if (f.type !== "meet" || String(f.createdBy) !== internId) continue;
+      if (new Date(f.createdAt) < from) continue;
+      meetsBookedOnLeads++;
+      if (f.completedAt) meetsCompleted++;
+    }
+  }
+
+  return {
+    adminId: intern._id,
+    name: intern.name,
+    leadsReceived: receivedLeadIds.length,
+    contacted,
+    contactedInWindowPct: contacted ? Math.round((contactedInWindow / contacted) * 100) : null,
+    qualified,
+    meetsBooked,
+    incompleteDiscovery,
+    avgFirstCallMinutes: contacted ? Math.round(firstCallMsTotal / contacted / 60000) : null,
+    meetShowUpRatePct: meetsBookedOnLeads ? Math.round((meetsCompleted / meetsBookedOnLeads) * 100) : null,
+  };
+};
+
+const internMetrics = async ({ period = "today" } = {}, scopeFilter = {}) => {
+  if (!["today", "week", "month"].includes(period)) {
+    throw Object.assign(new Error("period must be today|week|month"), { status: 400 });
+  }
+  const now = new Date();
+  const from = periodStart(period, now);
+  const cfg = await SettingsService.getMany([
+    "golden.windowMinutes",
+    "golden.workStartHour",
+    "golden.workEndHour",
+  ]);
+  const goldenCfg = {
+    windowMinutes: cfg["golden.windowMinutes"],
+    workStartHour: cfg["golden.workStartHour"],
+    workEndHour: cfg["golden.workEndHour"],
+  };
+  const interns = await visibleInterns(scopeFilter);
+  const rows = [];
+  for (const intern of interns) {
+    rows.push(await metricsFor(intern, from, now, goldenCfg));
+  }
+  return { period, from, rows: rows.sort((a, b) => a.name.localeCompare(b.name)) };
+};
+
+module.exports = { internMetrics, visibleInterns, periodStart };

--- a/services/JourneyService.js
+++ b/services/JourneyService.js
@@ -32,6 +32,24 @@ const EVENT_TITLES = {
   wa_classified: "Classified by Kiara",
   wa_admin_message_sent: "WhatsApp message sent",
   wa_template_sent: "Re-engage template sent",
+  // Kiara on Instagram (MB6 Slice 7).
+  ig_conversation_linked: "Instagram chat linked",
+  ig_escalated: "Kiara asked for a human (Instagram)",
+  ig_human_takeover: "Human took over the Instagram chat",
+  ig_handed_back: "Handed back to Kiara (Instagram)",
+  ig_qualified_by_kiara: "Qualified by Kiara on Instagram ✦",
+  ig_classified: "Classified by Kiara (Instagram)",
+  ig_admin_message_sent: "Instagram DM sent",
+  // MB5/6 moments.
+  triage_entered: "Landed in triage",
+  triage_assigned: "Assigned from triage",
+  triage_escalated: "Triage escalation",
+  triage_auto_assigned: "Auto-assigned from triage",
+  meet_handoff: "Handed to the sales lead for the meet",
+  meeting_closed: "Meeting closed with notes",
+  huddle_completed: "Huddle complete — team onboarded 🤝",
+  kiara_safety_net_engaged: "Kiara safety net engaged ✦",
+  meet_refused: "Refusing a meeting — tagged no-meet",
 };
 
 // GET /enquiry/:_id/journey — every moment of a lead's life, one chronological

--- a/services/KiaraCrmSyncService.js
+++ b/services/KiaraCrmSyncService.js
@@ -58,6 +58,10 @@ const closeLeadAsSystem = async (enquiryId, reason) => {
 };
 
 // ── Escalation ────────────────────────────────────────────────────────────────
+// Journey event types are channel-prefixed (wa_* / ig_* — MB6 Slice 7).
+const evType = (conversation, suffix) =>
+  `${conversation && conversation.channel === "instagram" ? "ig" : "wa"}_${suffix}`;
+
 const escalate = async (conversation, reason) => {
   const updated = await WAConversationRepository.updateFieldsById(conversation._id, {
     needsHuman: true,
@@ -67,7 +71,7 @@ const escalate = async (conversation, reason) => {
   if (conversation.enquiryId) {
     await LeadInternalEventService.record({
       leadId: conversation.enquiryId,
-      type: "wa_escalated",
+      type: evType(conversation, "escalated"),
       actorId: null,
       payload: { reason: reason || "" },
     });
@@ -107,7 +111,7 @@ const applyExtraction = async (conversation, extraction) => {
           name: (extraction.data && extraction.data.name) || "",
           offering: (extraction.data && extraction.data.servicesRequired) || "",
           firstMessage: firstMsg ? firstMsg.message : "",
-          source: "whatsapp",
+          source: conversation.channel === "instagram" ? "instagram" : "whatsapp",
           conversationId: conversation._id,
         });
       }
@@ -122,7 +126,7 @@ const applyExtraction = async (conversation, extraction) => {
         await closeLeadAsSystem(conversation.enquiryId, reason);
         await LeadInternalEventService.record({
           leadId: conversation.enquiryId,
-          type: "wa_classified",
+          type: evType(conversation, "classified"),
           actorId: null,
           payload: { classification, action: "conversation_closed_lead_lost", reason },
         });
@@ -317,7 +321,7 @@ const syncQualifiedToCrm = async (phone, data = {}, conversation = null) => {
 
   await LeadInternalEventService.record({
     leadId: enquiryId,
-    type: "wa_qualified_by_kiara",
+    type: evType(conversation, "qualified_by_kiara"),
     actorId: null,
     payload: {
       answers: ANSWER_KEYS.reduce((acc, k) => {

--- a/services/KiaraCrmSyncService.js
+++ b/services/KiaraCrmSyncService.js
@@ -256,6 +256,47 @@ const syncQualifiedToCrm = async (phone, data = {}, conversation = null) => {
   fillQd("venueName", data.venueName);
   fillQd("weddingStyle", data.weddingStyle);
 
+  // MB6 Slice 6 (closes MB4 judgment-call #2): best-effort map Kiara's
+  // servicesRequired/budget answers onto the cockpit-v2 fields — fill-only-
+  // empty like everything above; the raw answers stay in kiaraAnswers.
+  if (data.servicesRequired && !(qd.servicesRequired || []).length) {
+    let available = [];
+    try {
+      available = await require("./SettingsService").get("services.available");
+    } catch (_) { /* master list is advisory for matching */ }
+    const rawParts = Array.isArray(data.servicesRequired)
+      ? data.servicesRequired
+      : String(data.servicesRequired).split(/[,/&+]|\band\b/i);
+    const matched = [
+      ...new Set(
+        rawParts
+          .map((s) => {
+            const t = String(s).trim().toLowerCase();
+            if (!t) return null;
+            const hit = (available || []).find(
+              (a) => t.includes(a.toLowerCase()) || a.toLowerCase().includes(t)
+            );
+            return hit || null;
+          })
+          .filter(Boolean)
+      ),
+    ];
+    if (matched.length) set["qualificationData.servicesRequired"] = matched;
+  }
+  if (data.budget && qd.budgetAmount == null && !qd.budgetNote) {
+    const raw = String(data.budget);
+    const digits = raw.replace(/[^\d.]/g, "");
+    let amount = digits ? parseFloat(digits) : null;
+    const lower = raw.toLowerCase();
+    if (amount != null && Number.isFinite(amount)) {
+      if (/(lakh|lac|\bl\b)/.test(lower)) amount *= 100000;
+      else if (/(crore|\bcr\b)/.test(lower)) amount *= 10000000;
+      else if (/\d\s*k\b/.test(lower)) amount *= 1000;
+      set["qualificationData.budgetAmount"] = amount;
+    }
+    set["qualificationData.budgetNote"] = raw.slice(0, 500);
+  }
+
   // Placeholder lead names ("WhatsApp 1234") upgrade to the real one.
   if (data.name && /^WhatsApp \d{4}$/.test(lead.name || "")) {
     set.name = String(data.name);

--- a/services/KiaraSafetyNetService.js
+++ b/services/KiaraSafetyNetService.js
@@ -1,0 +1,151 @@
+const Enquiry = require("../models/Enquiry");
+const WAConversation = require("../models/WAConversation");
+const WAAgentMessage = require("../models/WAAgentMessage");
+const SettingsService = require("./SettingsService");
+const LeadIntakeService = require("./LeadIntakeService");
+const LeadInternalEventService = require("./LeadInternalEventService");
+const { sendWhatsApp } = require("../utils/whatsapp");
+const { toIstWallClock, goldenWindowFor } = require("../utils/goldenWindow");
+
+// KIARA SAFETY NET (MB5 Slice 5) — template-gated, ships DORMANT.
+// When kiara.welcomeTemplateName is set:
+//  (a) a lead created OUTSIDE working hours with a phone gets the welcome
+//      template from Kiara's number immediately + an open ai-mode conversation
+//  (b) a lead created IN hours but still uncontacted (no firstCalledAt) past
+//      the golden window gets the same engagement — once per lead.
+// Engaged leads join mission-quiet until escalation/qualification; after-hours
+// leads surface in triage at open with the Kiara transcript attached.
+
+// Meta wa_id format: digits with country code (Indian default).
+const metaPhone = (phone) => {
+  const digits = String(phone || "").replace(/\D/g, "");
+  if (digits.length === 10) return `91${digits}`;
+  return digits;
+};
+
+const templateName = async () => {
+  try {
+    return (await SettingsService.get("kiara.welcomeTemplateName")) || "";
+  } catch (_) {
+    return "";
+  }
+};
+
+const inWorkingHours = async (now = new Date()) => {
+  const cfg = await SettingsService.getMany(["golden.workStartHour", "golden.workEndHour"]);
+  const istHour = toIstWallClock(now).getUTCHours();
+  return istHour >= cfg["golden.workStartHour"] && istHour < cfg["golden.workEndHour"];
+};
+
+// The engagement itself: template out, conversation open (mode ai), thread
+// placeholder stored, set-once marker + journey event. CAS-guarded.
+const engageLead = async (lead, reason, now = new Date()) => {
+  const tpl = await templateName();
+  if (!tpl) return false; // dormant
+  const phone = metaPhone(lead.phone);
+  if (!phone || phone.length < 12) return false;
+
+  // Once per lead — atomic claim.
+  const claimed = await Enquiry.findOneAndUpdate(
+    { _id: lead._id, kiaraSafetyNetAt: null },
+    { $set: { kiaraSafetyNetAt: now } },
+    { new: true }
+  );
+  if (!claimed) return false;
+
+  const firstName = (lead.name || "").split(/\s+/)[0] || "there";
+  const sent = await sendWhatsApp(phone, tpl, [firstName], null, process.env.WHATSAPP_AGENT_PHONE_NUMBER_ID);
+  if (!sent) {
+    // Roll the claim back so a transient Meta failure can retry on a later sweep.
+    await Enquiry.findByIdAndUpdate(lead._id, { $set: { kiaraSafetyNetAt: null } });
+    return false;
+  }
+
+  const body = `[template: ${tpl}]`;
+  await WAConversation.findOneAndUpdate(
+    { phone },
+    {
+      $setOnInsert: {
+        phone,
+        normalizedPhone: LeadIntakeService.normalizePhone(phone),
+        mode: "ai",
+        status: "active",
+        unreadCount: 0,
+      },
+      $set: {
+        enquiryId: lead._id,
+        lastMessageAt: now,
+        lastMessagePreview: body,
+      },
+    },
+    { upsert: true, new: true, setDefaultsOnInsert: true }
+  );
+  await new WAAgentMessage({ phone, role: "assistant", message: body, sentBy: null }).save();
+  await LeadInternalEventService.record({
+    leadId: lead._id,
+    type: "kiara_safety_net_engaged",
+    actorId: null,
+    payload: { reason, template: tpl },
+  });
+  return true;
+};
+
+// (a) Create-time hook — fires only OUTSIDE working hours. Fire-safe; called
+// from LeadIntakeService.afterCreate for every intake path.
+const maybeEngageOnCreate = async (enquiryId, now = new Date()) => {
+  try {
+    if (!(await templateName())) return false; // dormant — zero queries beyond settings cache
+    if (await inWorkingHours(now)) return false;
+    const lead = await Enquiry.findById(enquiryId).lean();
+    if (!lead || !lead.phone) return false;
+    if (lead.source === "whatsapp") return false; // already talking to Kiara
+    if (lead.kiaraSafetyNetAt) return false;
+    return await engageLead(lead, "after_hours_create", now);
+  } catch (e) {
+    console.error("KiaraSafetyNet.maybeEngageOnCreate failed:", e.message);
+    return false;
+  }
+};
+
+// (b) Lazy sweep (rides dashboard reads): in-hours leads past the golden
+// window with no first call. Bounded to the last 48h of creates.
+const sweepGoldenWindowMisses = async (now = new Date()) => {
+  try {
+    if (!(await templateName())) return { engaged: 0 }; // dormant
+    if (!(await inWorkingHours(now))) return { engaged: 0 };
+    const cfg = await SettingsService.getMany([
+      "golden.windowMinutes",
+      "golden.workStartHour",
+      "golden.workEndHour",
+    ]);
+    const goldenCfg = {
+      windowMinutes: cfg["golden.windowMinutes"],
+      workStartHour: cfg["golden.workStartHour"],
+      workEndHour: cfg["golden.workEndHour"],
+    };
+    const candidates = await Enquiry.find({
+      kiaraSafetyNetAt: null,
+      firstCalledAt: null,
+      source: { $ne: "whatsapp" },
+      phone: { $nin: [null, ""] },
+      importedAt: null, // historical imports never get pinged
+      stage: { $nin: ["won", "lost"] },
+      "recycled.isRecycled": { $ne: true },
+      createdAt: { $gte: new Date(now.getTime() - 48 * 3600 * 1000) },
+    })
+      .limit(25)
+      .lean();
+    let engaged = 0;
+    for (const lead of candidates) {
+      const gw = goldenWindowFor(lead.createdAt, now, goldenCfg);
+      if (gw.inWindow) continue; // still fresh — the team gets first shot
+      if (await engageLead(lead, "golden_window_missed", now)) engaged++;
+    }
+    return { engaged };
+  } catch (e) {
+    console.error("KiaraSafetyNet.sweep failed:", e.message);
+    return { engaged: 0 };
+  }
+};
+
+module.exports = { maybeEngageOnCreate, sweepGoldenWindowMisses, engageLead, metaPhone };

--- a/services/LeadAssignmentService.js
+++ b/services/LeadAssignmentService.js
@@ -48,6 +48,21 @@ const doAssignLead = async (enquiryId) => {
     if (!(await SettingsService.get("assignment.autoAssignEnabled"))) {
       return null; // auto-assignment switched off in Settings — lead stays unassigned
     }
+    // MB5 Slice 4: triage mode — the lead lands UNASSIGNED in the triage queue
+    // instead of round-robin. 'auto' (the shipped default) is byte-identical
+    // to the old behavior.
+    if ((await SettingsService.get("assignment.mode")) === "triage") {
+      await Enquiry.findByIdAndUpdate(enquiryId, {
+        $set: { triagePending: true, triageEnteredAt: new Date() },
+      });
+      await LeadInternalEventService.record({
+        leadId: enquiryId,
+        type: "triage_entered",
+        actorId: null,
+        payload: {},
+      });
+      return null;
+    }
     const assignee = await pickAssignee();
     if (!assignee) {
       await LeadInternalEventService.record({

--- a/services/LeadIntakeService.js
+++ b/services/LeadIntakeService.js
@@ -100,9 +100,31 @@ const afterCreate = async (enquiryId) => {
   }
 };
 
+// The ONE create path for hook/intake-created leads (WhatsApp, Instagram, …).
+// Mirrors the CreateNew controller's create branch and PINS the board/list-
+// critical fields explicitly (stage and the boolean flags), so an intake-created
+// lead can never be shaped differently from a manually created one — the board
+// renders only configured stage columns, so a lead with a missing/unknown stage
+// silently disappears from it.
+const createLead = async ({ name, phone, verified = false, source, additionalInfo = {} }) => {
+  const created = await new Enquiry({
+    name,
+    phone,
+    verified,
+    source,
+    additionalInfo,
+    stage: "new",
+    isInterested: false,
+    isLost: false,
+  }).save();
+  await afterCreate(created._id);
+  return created;
+};
+
 module.exports = {
   normalizePhone,
   findExistingByNormalizedPhone,
   recordReEnquiry,
   afterCreate,
+  createLead,
 };

--- a/services/LeadIntakeService.js
+++ b/services/LeadIntakeService.js
@@ -98,6 +98,13 @@ const afterCreate = async (enquiryId) => {
   } catch (e) {
     console.error("LeadIntakeService.afterCreate failed:", e.message);
   }
+  // MB5 Slice 5: Kiara safety net — after-hours creates get the welcome
+  // template immediately. Template-gated (dormant when unset); fire-safe.
+  try {
+    await require("./KiaraSafetyNetService").maybeEngageOnCreate(enquiryId);
+  } catch (e) {
+    console.error("LeadIntakeService.afterCreate safety net failed:", e.message);
+  }
 };
 
 // The ONE create path for hook/intake-created leads (WhatsApp, Instagram, …).

--- a/services/SettingsService.js
+++ b/services/SettingsService.js
@@ -9,6 +9,10 @@ const DEFAULTS = {
   "assignment.overflowRoles": ["Sales Executive"],
   "assignment.dailyCap": 15,
   "assignment.autoAssignEnabled": true,
+  // MB5 Slice 4: 'auto' = round-robin exactly as before (zero behavior change
+  // on deploy); 'triage' = new leads land unassigned in the Triage queue.
+  "assignment.mode": "auto",
+  "triage.escalateAfterMinutes": 10,
   "golden.windowMinutes": 30,
   "golden.workStartHour": 10,
   "golden.workEndHour": 19,
@@ -44,6 +48,8 @@ const KEY_CATEGORY = {
   "assignment.overflowRoles": "settings_assignment",
   "assignment.dailyCap": "settings_assignment",
   "assignment.autoAssignEnabled": "settings_assignment",
+  "assignment.mode": "settings_assignment",
+  "triage.escalateAfterMinutes": "settings_assignment",
   "golden.windowMinutes": "settings_sla",
   "golden.workStartHour": "settings_sla",
   "golden.workEndHour": "settings_sla",
@@ -82,6 +88,12 @@ const validateValue = (key, value) => {
       return value.map((s) => s.trim());
     case "assignment.dailyCap":
       if (!isIntInRange(value, 1, 100)) throw err(400, "assignment.dailyCap must be an integer 1–100");
+      return value;
+    case "assignment.mode":
+      if (!["auto", "triage"].includes(value)) throw err(400, "assignment.mode must be 'auto' or 'triage'");
+      return value;
+    case "triage.escalateAfterMinutes":
+      if (!isIntInRange(value, 1, 240)) throw err(400, "triage.escalateAfterMinutes must be an integer 1–240");
       return value;
     case "assignment.autoAssignEnabled":
     case "lost.approvalRequired":

--- a/services/SettingsService.js
+++ b/services/SettingsService.js
@@ -13,8 +13,10 @@ const DEFAULTS = {
   // on deploy); 'triage' = new leads land unassigned in the Triage queue.
   "assignment.mode": "auto",
   "triage.escalateAfterMinutes": 10,
-  "golden.windowMinutes": 30,
-  "golden.workStartHour": 10,
+  // MB5 Slice 5: founder-approved default changes — golden window 15 min,
+  // working hours 11:00–19:00 IST.
+  "golden.windowMinutes": 15,
+  "golden.workStartHour": 11,
   "golden.workEndHour": 19,
   "cadence.attemptOffsetsDays": [0, 1, 3, 5],
   "cadence.maxAttempts": 4,
@@ -40,6 +42,9 @@ const DEFAULTS = {
   // FIELDS stay code-defined (extractor + QualifiedLead + Sheets coupling).
   "kiara.systemPrompt": KIARA_DEFAULT_SYSTEM_PROMPT,
   "kiara.reengageTemplateName": "",
+  // MB5 Slice 5: the safety net's approved welcome template. '' = the whole
+  // safety net is DORMANT (ships off; founder arms it in Settings → Kiara).
+  "kiara.welcomeTemplateName": "",
 };
 
 // key → settings permission category. Every write is gated by ITS category.
@@ -68,6 +73,7 @@ const KEY_CATEGORY = {
   // Kiara's brain — founder-gated category.
   "kiara.systemPrompt": "settings_kiara",
   "kiara.reengageTemplateName": "settings_kiara",
+  "kiara.welcomeTemplateName": "settings_kiara",
 };
 
 const err = (status, message) => Object.assign(new Error(message), { status });
@@ -152,13 +158,14 @@ const validateValue = (key, value) => {
       }
       return value;
     }
-    case "kiara.reengageTemplateName": {
+    case "kiara.reengageTemplateName":
+    case "kiara.welcomeTemplateName": {
       if (typeof value !== "string" || value.length > 200) {
-        throw err(400, "kiara.reengageTemplateName must be a string of at most 200 chars");
+        throw err(400, `${key} must be a string of at most 200 chars`);
       }
       // Meta template names: lowercase/digits/underscores. Empty = unset.
       if (value && !/^[a-z0-9_]+$/.test(value)) {
-        throw err(400, "kiara.reengageTemplateName must match Meta's template-name format (lowercase letters, digits, underscores)");
+        throw err(400, `${key} must match Meta's template-name format (lowercase letters, digits, underscores)`);
       }
       return value;
     }

--- a/services/SettingsService.js
+++ b/services/SettingsService.js
@@ -45,6 +45,39 @@ const DEFAULTS = {
   // MB5 Slice 5: the safety net's approved welcome template. '' = the whole
   // safety net is DORMANT (ships off; founder arms it in Settings → Kiara).
   "kiara.welcomeTemplateName": "",
+  // MB6 Slice 6: the services master list (qualification multi-select chips).
+  "services.available": [
+    "Venue",
+    "Decor",
+    "Catering",
+    "Photography",
+    "Makeup",
+    "Mehendi",
+    "Logistics",
+    "Entertainment",
+  ],
+  // MB6 Slice 6: cockpit call scripts — founder-editable in Settings (the
+  // settings_scripts category). Draft v1 texts; the cockpit renders these live.
+  "cockpit.briefScript":
+    "Hi {{name}}! This is {{caller}} from Wedsy — first of all, congratulations on the wedding! 🎉 " +
+    "I saw your enquiry come in and wanted to call right away. A quick line about us: we're a Bengaluru " +
+    "wedding company that takes care of everything under one roof — planning, decor, catering, photography, " +
+    "makeup, mehendi, and all the running-around on the day itself. But before I talk shop — tell me about " +
+    "you two! When's the big day, and how far along are the preparations?",
+  "cockpit.servicesScript":
+    "Lovely — so here's how we usually help. Some couples hand us the entire wedding, others just the pieces " +
+    "they don't want to worry about: the venue hunt, decor, catering, photography, makeup, mehendi, " +
+    "entertainment, or simply the day-of logistics so the family actually gets to enjoy the wedding. " +
+    "Which parts are still open for you? I'll note them down so the right team preps before we meet.",
+  "cockpit.budgetScript":
+    "And just so I point you to the right options — do you have a rough budget in mind? Even a ballpark " +
+    "for the pieces you want us to handle helps us tailor things properly. And honestly, if you'd rather " +
+    "not put a number on it yet, that's completely fine — most couples figure it out with us as we go.",
+  "cockpit.qualificationIntro":
+    "Before I let you go — let me make sure I have everything so the team can hit the ground running: " +
+    "both your names, the date or month you're aiming for, whether the venue is sorted, and the best email " +
+    "to send our ideas to (yours and your partner's, if you like — that way nobody misses anything). " +
+    "Two quick minutes, promise!",
 };
 
 // key → settings permission category. Every write is gated by ITS category.
@@ -74,6 +107,13 @@ const KEY_CATEGORY = {
   "kiara.systemPrompt": "settings_kiara",
   "kiara.reengageTemplateName": "settings_kiara",
   "kiara.welcomeTemplateName": "settings_kiara",
+  // Services master list rides the templates/tag-library category.
+  "services.available": "settings_templates",
+  // Cockpit scripts — their own resource (seed-granted; founder wildcard covers).
+  "cockpit.briefScript": "settings_scripts",
+  "cockpit.servicesScript": "settings_scripts",
+  "cockpit.budgetScript": "settings_scripts",
+  "cockpit.qualificationIntro": "settings_scripts",
 };
 
 const err = (status, message) => Object.assign(new Error(message), { status });
@@ -90,8 +130,17 @@ const validateValue = (key, value) => {
     case "lost.reasons":
     case "recycle.reasons":
     case "tags.available":
+    case "services.available":
       if (!isStringArray(value)) throw err(400, `${key} must be a non-empty array of non-empty strings`);
       return value.map((s) => s.trim());
+    case "cockpit.briefScript":
+    case "cockpit.servicesScript":
+    case "cockpit.budgetScript":
+    case "cockpit.qualificationIntro":
+      if (typeof value !== "string" || value.length > 5000) {
+        throw err(400, `${key} must be a string of at most 5000 chars`);
+      }
+      return value;
     case "assignment.dailyCap":
       if (!isIntInRange(value, 1, 100)) throw err(400, "assignment.dailyCap must be an integer 1–100");
       return value;

--- a/services/TriageService.js
+++ b/services/TriageService.js
@@ -83,10 +83,10 @@ const listTriage = async () => {
     .limit(100)
     .lean();
 
-  // Kiara transcript preview for whatsapp leads (last few messages).
-  const waLeads = leads.filter((l) => l.source === "whatsapp");
-  const convs = waLeads.length
-    ? await WAConversation.find({ enquiryId: { $in: waLeads.map((l) => l._id) } }).lean()
+  // Kiara transcript preview for any lead with a conversation — whatsapp
+  // intake AND safety-net-engaged leads (the morning pile, Slice 5).
+  const convs = leads.length
+    ? await WAConversation.find({ enquiryId: { $in: leads.map((l) => l._id) } }).lean()
     : [];
   const convByLead = new Map(convs.map((c) => [String(c.enquiryId), c]));
   const transcripts = new Map();

--- a/services/TriageService.js
+++ b/services/TriageService.js
@@ -1,0 +1,279 @@
+const mongoose = require("mongoose");
+const Enquiry = require("../models/Enquiry");
+const Admin = require("../models/Admin");
+const Role = require("../models/Role");
+const Attendance = require("../models/Attendance");
+const WAConversation = require("../models/WAConversation");
+const WAAgentMessage = require("../models/WAAgentMessage");
+const SettingsService = require("./SettingsService");
+const AttendanceService = require("./AttendanceService");
+const LeadInternalEventService = require("./LeadInternalEventService");
+const AdminNotificationService = require("./AdminNotificationService");
+const { permissionSatisfies } = require("../middlewares/requirePermission");
+const { goldenWindowFor, toIstWallClock } = require("../utils/goldenWindow");
+
+const httpError = (status, message) => Object.assign(new Error(message), { status });
+
+// ── Who holds triage? Admins whose ROLE grants leads:triage (any scope). ──────
+const HOLDER_CACHE_TTL_MS = 60 * 1000;
+let holderCache = { ids: null, expires: 0 };
+
+const triageHolderIds = async () => {
+  if (holderCache.ids && holderCache.expires > Date.now()) return holderCache.ids;
+  const roles = await Role.find({ deletedAt: null }, { permissions: 1 }).lean();
+  const holderRoleIds = roles
+    .filter((r) => permissionSatisfies(r.permissions || [], "leads:triage:own").allowed)
+    .map((r) => r._id);
+  const holders = holderRoleIds.length
+    ? await Admin.find({ roleId: { $in: holderRoleIds }, status: "active" }, { _id: 1 }).lean()
+    : [];
+  const ids = holders.map((h) => h._id);
+  holderCache = { ids, expires: Date.now() + HOLDER_CACHE_TTL_MS };
+  return ids;
+};
+
+// ── Pool interns with live status (the assign picker + auto-assign target). ───
+const internsWithStatus = async () => {
+  const poolRoles = (await SettingsService.get("assignment.poolRoles")) || [];
+  const roles = await Role.find({ name: { $in: poolRoles }, deletedAt: null }, { _id: 1 }).lean();
+  const interns = await Admin.find(
+    { roleId: { $in: roles.map((r) => r._id) }, status: "active" },
+    { name: 1, reportingManagerId: 1, lastAssignedAt: 1 }
+  ).lean();
+  const CalendarEventService = require("./CalendarEventService");
+  const [liveIds, attRows] = await Promise.all([
+    CalendarEventService.liveMeetingAdminIds(),
+    Attendance.find({ adminId: { $in: interns.map((i) => i._id) }, date: AttendanceService.dayKey() }).lean(),
+  ]);
+  const attByAdmin = new Map(attRows.map((r) => [String(r.adminId), r]));
+  const now = new Date();
+  return interns.map((i) => ({
+    _id: i._id,
+    name: i.name,
+    reportingManagerId: i.reportingManagerId || null,
+    lastAssignedAt: i.lastAssignedAt || null,
+    status: AttendanceService.statusOf(attByAdmin.get(String(i._id)) || null, now, liveIds),
+  }));
+};
+
+// ── The triage queue (dashboard section + leads filter both read this). ──────
+const TRANSCRIPT_PREVIEW_MESSAGES = 3;
+
+const listTriage = async () => {
+  // Lazy escalation sweep rides every queue read (the established no-new-infra pattern).
+  await sweepEscalations().catch(() => {});
+
+  const goldenCfg = await SettingsService.getMany([
+    "golden.windowMinutes",
+    "golden.workStartHour",
+    "golden.workEndHour",
+  ]);
+  const cfg = {
+    windowMinutes: goldenCfg["golden.windowMinutes"],
+    workStartHour: goldenCfg["golden.workStartHour"],
+    workEndHour: goldenCfg["golden.workEndHour"],
+  };
+  const leads = await Enquiry.find({
+    triagePending: true,
+    assignedTo: null,
+    "recycled.isRecycled": { $ne: true },
+    stage: { $nin: ["won", "lost"] },
+  })
+    .sort({ createdAt: -1 })
+    .limit(100)
+    .lean();
+
+  // Kiara transcript preview for whatsapp leads (last few messages).
+  const waLeads = leads.filter((l) => l.source === "whatsapp");
+  const convs = waLeads.length
+    ? await WAConversation.find({ enquiryId: { $in: waLeads.map((l) => l._id) } }).lean()
+    : [];
+  const convByLead = new Map(convs.map((c) => [String(c.enquiryId), c]));
+  const transcripts = new Map();
+  for (const c of convs) {
+    const msgs = await WAAgentMessage.find({ phone: c.phone }, { role: 1, message: 1, createdAt: 1 })
+      .sort({ createdAt: -1 })
+      .limit(TRANSCRIPT_PREVIEW_MESSAGES)
+      .lean();
+    transcripts.set(String(c.enquiryId), msgs.reverse());
+  }
+
+  const now = new Date();
+  return leads.map((l) => ({
+    _id: l._id,
+    name: l.name,
+    source: l.source,
+    createdAt: l.createdAt,
+    triageEnteredAt: l.triageEnteredAt,
+    triageEscalatedAt: l.triageEscalatedAt,
+    goldenWindow: goldenWindowFor(l.createdAt, now, cfg),
+    conversationId: convByLead.has(String(l._id)) ? convByLead.get(String(l._id))._id : null,
+    transcript: transcripts.get(String(l._id)) || [],
+  }));
+};
+
+// ── Assign out of triage (picker or "take it myself"). ───────────────────────
+const assign = async (leadId, toAdminId, actorId) => {
+  if (!mongoose.Types.ObjectId.isValid(leadId)) throw httpError(400, "Invalid lead id");
+  if (!mongoose.Types.ObjectId.isValid(toAdminId)) throw httpError(400, "Invalid admin id");
+  const target = await Admin.findOne({ _id: toAdminId, status: "active" }, { name: 1 }).lean();
+  if (!target) throw httpError(404, "Assignee not found or inactive");
+  const lead = await Enquiry.findOneAndUpdate(
+    { _id: leadId, triagePending: true },
+    { $set: { assignedTo: target._id, triagePending: false } },
+    { new: true }
+  );
+  if (!lead) throw httpError(404, "Lead is not in triage");
+  await Admin.findByIdAndUpdate(target._id, { $set: { lastAssignedAt: new Date() } });
+  await LeadInternalEventService.record({
+    leadId,
+    type: "triage_assigned",
+    actorId,
+    payload: {
+      to: String(target._id),
+      toName: target.name,
+      self: String(target._id) === String(actorId),
+    },
+  });
+  if (String(target._id) !== String(actorId)) {
+    await AdminNotificationService.notify(target._id, {
+      type: "triage_assigned",
+      title: `${lead.name} assigned to you from triage`,
+      message: "Fresh lead — call within the golden window.",
+      leadId,
+    });
+  }
+  return lead;
+};
+
+// ── Escalation chain (lazy/poll — invoked from queue + dashboard reads). ─────
+// After triage.escalateAfterMinutes unassigned (working hours only):
+//   → notify ALL triage holders (once per lead).
+//   → if ALL holders are in_meeting at that moment: auto-assign to a
+//     checked-in ONLINE intern + notify Revenue Head + that intern's sales
+//     lead with reason "auto-assigned: triage was in meetings".
+const inWorkingHours = async (now = new Date()) => {
+  const cfg = await SettingsService.getMany(["golden.workStartHour", "golden.workEndHour"]);
+  const istHour = toIstWallClock(now).getUTCHours();
+  return istHour >= cfg["golden.workStartHour"] && istHour < cfg["golden.workEndHour"];
+};
+
+const revenueHeadIds = async () => {
+  const role = await Role.findOne({ name: "Revenue Head", deletedAt: null }, { _id: 1 }).lean();
+  if (!role) return [];
+  const heads = await Admin.find({ roleId: role._id, status: "active" }, { _id: 1 }).lean();
+  return heads.map((h) => h._id);
+};
+
+const sweepEscalations = async (now = new Date()) => {
+  if ((await SettingsService.get("assignment.mode")) !== "triage") return { escalated: 0 };
+  if (!(await inWorkingHours(now))) return { escalated: 0 };
+
+  const afterMinutes = await SettingsService.get("triage.escalateAfterMinutes");
+  const cutoff = new Date(now.getTime() - afterMinutes * 60 * 1000);
+  const due = await Enquiry.find({
+    triagePending: true,
+    assignedTo: null,
+    triageEscalatedAt: null,
+    triageEnteredAt: { $lte: cutoff },
+  })
+    .limit(20)
+    .lean();
+  if (!due.length) return { escalated: 0 };
+
+  const holders = await triageHolderIds();
+  const CalendarEventService = require("./CalendarEventService");
+  const liveIds = await CalendarEventService.liveMeetingAdminIds(now);
+  // "ALL triage holders in_meeting" counts only holders who are CHECKED IN —
+  // a checked-out holder can't act on triage either way. Nobody checked in at
+  // all → same outcome: the queue has no available human, auto-assign.
+  const attRows = await Attendance.find({
+    adminId: { $in: holders },
+    date: AttendanceService.dayKey(now),
+  }).lean();
+  const checkedInHolders = attRows
+    .filter((r) => r.checkInAt && !r.checkOutAt)
+    .map((r) => String(r.adminId));
+  const allHoldersInMeeting =
+    holders.length > 0 &&
+    (checkedInHolders.length === 0 || checkedInHolders.every((h) => liveIds.has(h)));
+
+  let escalated = 0;
+  for (const lead of due) {
+    // CAS guard — one concurrent sweep wins.
+    const claimed = await Enquiry.findOneAndUpdate(
+      { _id: lead._id, triageEscalatedAt: null, triagePending: true },
+      { $set: { triageEscalatedAt: now } },
+      { new: true }
+    );
+    if (!claimed) continue;
+    escalated++;
+
+    await LeadInternalEventService.record({
+      leadId: lead._id,
+      type: "triage_escalated",
+      actorId: null,
+      payload: { afterMinutes, allHoldersInMeeting },
+    });
+    await AdminNotificationService.notify(holders, {
+      type: "triage_escalation",
+      title: `Triage waiting ${afterMinutes}+ min: ${lead.name}`,
+      message: "Unassigned new lead is aging — assign or take it.",
+      leadId: lead._id,
+    });
+
+    if (allHoldersInMeeting) {
+      // Pick a checked-in ONLINE intern (least recently assigned first).
+      const interns = (await internsWithStatus())
+        .filter((i) => i.status === "online")
+        .sort((a, b) => new Date(a.lastAssignedAt || 0) - new Date(b.lastAssignedAt || 0));
+      const target = interns[0];
+      if (!target) continue; // nobody online — holders were notified, queue stays
+      await Enquiry.findByIdAndUpdate(lead._id, {
+        $set: { assignedTo: target._id, triagePending: false },
+      });
+      await Admin.findByIdAndUpdate(target._id, { $set: { lastAssignedAt: new Date() } });
+      await LeadInternalEventService.record({
+        leadId: lead._id,
+        type: "triage_auto_assigned",
+        actorId: null,
+        payload: {
+          to: String(target._id),
+          toName: target.name,
+          reason: "auto-assigned: triage was in meetings",
+        },
+      });
+      await AdminNotificationService.notify(target._id, {
+        type: "triage_auto_assigned",
+        title: `${lead.name} auto-assigned to you`,
+        message: "Triage was in meetings — call them now (golden window).",
+        leadId: lead._id,
+      });
+      await AdminNotificationService.notify(await revenueHeadIds(), {
+        type: "triage_auto_assigned",
+        title: `Triage overflow: ${lead.name} auto-assigned to ${target.name}`,
+        message: "auto-assigned: triage was in meetings",
+        leadId: lead._id,
+      });
+      if (target.reportingManagerId) {
+        await AdminNotificationService.notify(target.reportingManagerId, {
+          type: "triage_auto_assigned",
+          title: `${lead.name} auto-assigned to ${target.name} (your team)`,
+          message: "auto-assigned: triage was in meetings",
+          leadId: lead._id,
+        });
+      }
+    }
+  }
+  return { escalated };
+};
+
+module.exports = {
+  listTriage,
+  assign,
+  internsWithStatus,
+  triageHolderIds,
+  sweepEscalations,
+  inWorkingHours,
+  _holderCache: holderCache,
+};

--- a/services/WAConversationService.js
+++ b/services/WAConversationService.js
@@ -67,16 +67,17 @@ const ensureLeadLinked = async (conversation, { profileName, firstMessage } = {}
   } else {
     const name = (profileName || "").trim() || `WhatsApp ${String(conversation.phone).slice(-4)}`;
     try {
-      const created = await new Enquiry({
+      // Bug A fix (MB5 Slice 1): the shared intake create path — pins stage
+      // and the create-path defaults so the lead is indistinguishable from a
+      // manual create (round-robin auto-assign included).
+      const created = await LeadIntakeService.createLead({
         name,
         phone: conversation.phone,
         verified: false,
         source: "whatsapp",
         additionalInfo: {},
-      }).save();
+      });
       enquiryId = created._id;
-      // Round-robin auto-assign (never throws).
-      await LeadIntakeService.afterCreate(created._id);
     } catch (e) {
       // Unique-phone race (duplicate webhook delivery): fall back to the winner.
       const winner = await LeadIntakeService.findExistingByNormalizedPhone(conversation.phone);

--- a/services/WAConversationService.js
+++ b/services/WAConversationService.js
@@ -41,11 +41,16 @@ const windowInfo = (conversation, now = new Date()) => {
 // ── Hook 1 support: inbound touch + CRM lead linkage ─────────────────────────
 
 // Upsert the conversation row for an inbound message (creates it on first
-// contact) and bump freshness/unread.
-const recordInbound = async (phone, text) => {
-  const normalized = LeadIntakeService.normalizePhone(phone);
-  return await WAConversationRepository.upsertOnInbound(phone, normalized, preview(text));
+// contact) and bump freshness/unread. channel: 'whatsapp' (phone-keyed) or
+// 'instagram' (IG-user-id-keyed — no meaningful normalized phone).
+const recordInbound = async (phone, text, channel = "whatsapp") => {
+  const normalized = channel === "whatsapp" ? LeadIntakeService.normalizePhone(phone) : "";
+  return await WAConversationRepository.upsertOnInbound(phone, normalized, preview(text), new Date(), channel);
 };
+
+// Journey event types are channel-prefixed (wa_* / ig_*).
+const evType = (conversation, suffix) =>
+  `${conversation && conversation.channel === "instagram" ? "ig" : "wa"}_${suffix}`;
 
 // Ensure the conversation is linked to a CRM lead — full intake semantics:
 // normalized-phone dedup, re-enquiry on terminal leads, round-robin auto-assign.
@@ -225,7 +230,7 @@ const takeover = async (conversationId, actorId, scopeFilter = {}) => {
   if (conversation.enquiryId) {
     await LeadInternalEventService.record({
       leadId: conversation.enquiryId,
-      type: "wa_human_takeover",
+      type: evType(conversation, "human_takeover"),
       actorId,
       payload: {},
     });
@@ -244,7 +249,7 @@ const handback = async (conversationId, actorId, scopeFilter = {}) => {
   if (conversation.enquiryId) {
     await LeadInternalEventService.record({
       leadId: conversation.enquiryId,
-      type: "wa_handed_back",
+      type: evType(conversation, "handed_back"),
       actorId,
       payload: {},
     });
@@ -270,12 +275,15 @@ const sendText = async (conversationId, text, actorId, scopeFilter = {}) => {
     );
   }
   const clean = text.trim();
-  const sent = await sendWhatsAppText(
-    conversation.phone,
-    clean,
-    process.env.WHATSAPP_AGENT_PHONE_NUMBER_ID
-  );
-  if (!sent) throw httpError(502, "WhatsApp send failed — try again");
+  // MB6 Slice 7: channel-aware delivery — IG threads send a DM, not WhatsApp.
+  let sent;
+  if (conversation.channel === "instagram") {
+    const { sendInstagramDM } = require("../utils/instagram");
+    sent = await sendInstagramDM(conversation.phone, clean);
+  } else {
+    sent = await sendWhatsAppText(conversation.phone, clean, process.env.WHATSAPP_AGENT_PHONE_NUMBER_ID);
+  }
+  if (!sent) throw httpError(502, `${conversation.channel === "instagram" ? "Instagram" : "WhatsApp"} send failed — try again`);
 
   const saved = await new WAAgentMessage({
     phone: conversation.phone,
@@ -291,7 +299,7 @@ const sendText = async (conversationId, text, actorId, scopeFilter = {}) => {
   if (conversation.enquiryId) {
     await LeadInternalEventService.record({
       leadId: conversation.enquiryId,
-      type: "wa_admin_message_sent",
+      type: evType(conversation, "admin_message_sent"),
       actorId,
       payload: { preview: preview(clean) },
     });
@@ -302,6 +310,9 @@ const sendText = async (conversationId, text, actorId, scopeFilter = {}) => {
 // Template send (re-engage): allowed with the window closed, still human-mode-only.
 const sendTemplate = async (conversationId, actorId, scopeFilter = {}) => {
   const conversation = await getScoped(conversationId, scopeFilter);
+  if (conversation.channel === "instagram") {
+    throw httpError(422, "Templates are a WhatsApp feature — Instagram chats can't be re-engaged this way");
+  }
   if (conversation.mode !== "human") {
     throw httpError(409, "Kiara is handling this conversation — take over before sending");
   }

--- a/services/WAConversationService.js
+++ b/services/WAConversationService.js
@@ -283,6 +283,10 @@ const sendText = async (conversationId, text, actorId, scopeFilter = {}) => {
     message: clean,
     sentBy: actorId || null,
   }).save();
+  // Bug B fix (MB5 Slice 1): the response message must have the SAME shape as
+  // getMessages (sentBy populated to {_id,name}) — the chat panel appends it
+  // optimistically and renders sentBy.name.
+  await saved.populate("sentBy", "name");
   const updated = await WAConversationRepository.touchOutbound(conversation._id, preview(clean));
   if (conversation.enquiryId) {
     await LeadInternalEventService.record({
@@ -326,6 +330,8 @@ const sendTemplate = async (conversationId, actorId, scopeFilter = {}) => {
     message: body,
     sentBy: actorId || null,
   }).save();
+  // Bug B fix: same shape as getMessages (sentBy populated) — see sendText.
+  await saved.populate("sentBy", "name");
   const updated = await WAConversationRepository.touchOutbound(conversation._id, body);
   if (conversation.enquiryId) {
     await LeadInternalEventService.record({

--- a/services/WhatsAppAgentService.js
+++ b/services/WhatsAppAgentService.js
@@ -7,12 +7,11 @@ const SettingsService = require('./SettingsService');
 const { KIARA_DEFAULT_SYSTEM_PROMPT } = require('./kiaraDefaultPrompt');
 const NotificationFailureLog = require('../models/NotificationFailureLog');
 const QualifiedLead = require('../models/QualifiedLead');
-const axios = require('axios');
 const { google } = require('googleapis');
-
-// Test seam: e2e suites point this at a local mock so no test ever touches
-// the live API. Unset (production) ⇒ the real endpoint, unchanged.
-const ANTHROPIC_API_URL = process.env.ANTHROPIC_API_URL || 'https://api.anthropic.com/v1/messages';
+// MB6 Slice 11: every Anthropic call rides the shared in-process queue
+// (serialized, exponential backoff on 429) — shared with the Instagram agent.
+// The queue owns the ANTHROPIC_API_URL test seam now.
+const { callAnthropic } = require('../utils/anthropicQueue');
 
 // Kiara's persona now lives in Settings (kiara.systemPrompt, founder-gated,
 // 60s cache) and defaults to the verbatim former hardcoded text — an empty
@@ -50,22 +49,13 @@ const sendToClaude = async (history) => {
 
   while (attempt <= MAX_RETRIES) {
     try {
-      const response = await axios.post(
-        ANTHROPIC_API_URL,
-        {
-          model: 'claude-sonnet-4-5',
-          max_tokens: 500,
-          system: systemPrompt,
-          messages: history
-        },
-        {
-          headers: {
-            'x-api-key': process.env.ANTHROPIC_API_KEY,
-            'anthropic-version': '2023-06-01',
-            'Content-Type': 'application/json'
-          }
-        }
-      );
+      // MB6 Slice 11: through the shared in-process queue (429 backoff inside).
+      const response = await callAnthropic({
+        model: 'claude-sonnet-4-5',
+        max_tokens: 500,
+        system: systemPrompt,
+        messages: history
+      });
       const text = firstTextBlock(response);
       if (text === null) throw new Error('Anthropic response had no text block');
       return text;
@@ -92,22 +82,13 @@ const checkQualified = async (history) => {
 
   while (attempt <= MAX_RETRIES) {
     try {
-      const response = await axios.post(
-        ANTHROPIC_API_URL,
-        {
-          model: 'claude-sonnet-4-5',
-          max_tokens: 400,
-          system: EXTRACTOR_SYSTEM_PROMPT,
-          messages: history
-        },
-        {
-          headers: {
-            'x-api-key': process.env.ANTHROPIC_API_KEY,
-            'anthropic-version': '2023-06-01',
-            'Content-Type': 'application/json'
-          }
-        }
-      );
+      // MB6 Slice 11: through the shared in-process queue (429 backoff inside).
+      const response = await callAnthropic({
+        model: 'claude-sonnet-4-5',
+        max_tokens: 400,
+        system: EXTRACTOR_SYSTEM_PROMPT,
+        messages: history
+      });
       const text = firstTextBlock(response);
       if (text === null) throw new Error('Anthropic response had no text block');
       try {
@@ -291,6 +272,13 @@ const receiveMessage = async (phone, message, meta = {}) => {
     await WAConversationRepository.touchOutbound(conversation._id, reply.slice(0, 120));
     await sendWhatsAppText(phone, reply, process.env.WHATSAPP_AGENT_PHONE_NUMBER_ID);
     const updatedHistory = await WAAgentMessageRepository.getHistory(phone);
+
+    // MB6 Slice 11: skip the qualification-check call entirely while the
+    // conversation has fewer than 3 user messages — nobody qualifies (or needs
+    // routing) two messages in, and this halves early call volume.
+    const userMessages = updatedHistory.filter((m) => m.role === 'user').length;
+    if (userMessages < 3) return;
+
     const qualification = await checkQualified(updatedHistory);
 
     // HOOK 2: escalation + classification routing (vendor/birthday/corporate

--- a/utils/anthropicQueue.js
+++ b/utils/anthropicQueue.js
@@ -1,0 +1,54 @@
+const axios = require('axios');
+
+// MB6 Slice 11 — ONE in-process Anthropic queue shared by the WhatsApp and
+// Instagram agents. Calls are serialized (single node process), and a 429
+// backs the whole queue off exponentially before the request retries — a
+// burst of webhooks can no longer stampede the API. Behavior is otherwise
+// identical: callers keep their own retry/FailureLog semantics for non-429
+// errors, because this module re-throws those untouched.
+const ANTHROPIC_API_URL = process.env.ANTHROPIC_API_URL || 'https://api.anthropic.com/v1/messages';
+
+const BASE_BACKOFF_MS = 1000;
+const MAX_BACKOFF_MS = 30000;
+const MAX_429_RETRIES = 4;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Serialize requests: the same promise-chain idiom LeadAssignmentService uses.
+let queue = Promise.resolve();
+
+const post = async (payload) =>
+  axios.post(ANTHROPIC_API_URL, payload, {
+    headers: {
+      'x-api-key': process.env.ANTHROPIC_API_KEY,
+      'anthropic-version': '2023-06-01',
+      'Content-Type': 'application/json',
+    },
+  });
+
+const is429 = (error) => !!(error && error.response && error.response.status === 429);
+
+const runWithBackoff = async (payload) => {
+  let backoff = BASE_BACKOFF_MS;
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await post(payload);
+    } catch (error) {
+      if (!is429(error) || attempt >= MAX_429_RETRIES) throw error;
+      console.warn(`[AnthropicQueue] 429 — backing off ${backoff}ms (attempt ${attempt + 1}/${MAX_429_RETRIES})`);
+      await sleep(backoff);
+      backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
+    }
+  }
+};
+
+// The one entry point: enqueue an Anthropic messages call. Resolves with the
+// axios response; rejects with the original error for non-429 failures (and
+// for a 429 that survived every backoff).
+const callAnthropic = (payload) => {
+  const task = queue.then(() => runWithBackoff(payload));
+  queue = task.catch(() => {}); // a failed call never wedges the queue
+  return task;
+};
+
+module.exports = { callAnthropic };

--- a/utils/instagram.js
+++ b/utils/instagram.js
@@ -1,5 +1,8 @@
 const NotificationFailureLog = require('../models/NotificationFailureLog');
 
+// Mock seam (MB6 Slice 7) — same idiom as META_GRAPH_BASE_URL in utils/whatsapp.
+const IG_GRAPH_BASE_URL = process.env.INSTAGRAM_GRAPH_BASE_URL || 'https://graph.instagram.com/v25.0';
+
 const sendInstagramDM = async (recipientId, message) => {
   const MAX_RETRIES = 2;
   let attempt = 0;
@@ -7,7 +10,7 @@ const sendInstagramDM = async (recipientId, message) => {
   while (attempt <= MAX_RETRIES) {
     try {
       const response = await fetch(
-        'https://graph.instagram.com/v25.0/me/messages',
+        `${IG_GRAPH_BASE_URL}/me/messages`,
         {
           method: 'POST',
           headers: {

--- a/utils/leadFilterBuilder.js
+++ b/utils/leadFilterBuilder.js
@@ -23,6 +23,121 @@ const STATIC_FIELDS = {
   qualified: { ops: ["eq"], kind: "boolean" },
   "recycled.isRecycled": { ops: ["eq"], kind: "boolean" },
   importedAt: { ops: ["exists"], kind: "date" },
+  // ── MB6 Slice 9 additions ──
+  // Event month ("January"…) — the same field the legacy eventMonth param reads.
+  "additionalInfo.eventMonth": { ops: ["eq", "in"], kind: "string" },
+  // Services any-of: array field, "in" matches any element.
+  "qualificationData.servicesRequired": { ops: ["eq", "in", "contains"], kind: "string" },
+  // Budget range.
+  "qualificationData.budgetAmount": { ops: ["eq", "gte", "lte", "exists"], kind: "number" },
+  // Last activity recency (any write touches updatedAt).
+  updatedAt: { ops: ["gte", "lte"], kind: "date" },
+};
+
+// ── MB6 Slice 9: derived/virtual filters ──────────────────────────────────────
+// The list-level health score (computed WITHOUT the events join, matching the
+// list display): qualified base 20 + venue 15 + email/not-willing 20 + future
+// follow-up 20. Hot ≥75, Warm ≥45, Cold below (or unqualified).
+const healthScoreExpr = (now) => ({
+  $add: [
+    20,
+    { $cond: [{ $gt: [{ $ifNull: ["$qualificationData.venueStatus", ""] }, ""] }, 15, 0] },
+    {
+      $cond: [
+        {
+          $or: [
+            { $gt: [{ $ifNull: ["$qualificationData.email", ""] }, ""] },
+            { $eq: ["$qualificationData.emailNotWilling", true] },
+          ],
+        },
+        20,
+        0,
+      ],
+    },
+    {
+      $cond: [
+        {
+          $gt: [
+            {
+              $size: {
+                $filter: {
+                  input: { $ifNull: ["$followUps", []] },
+                  as: "f",
+                  cond: { $gt: ["$$f.scheduledAt", now] },
+                },
+              },
+            },
+            0,
+          ],
+        },
+        20,
+        0,
+      ],
+    },
+  ],
+});
+
+const healthBandCondition = (value, now = new Date()) => {
+  const score = healthScoreExpr(now);
+  if (value === "Hot") return { qualified: true, $expr: { $gte: [score, 75] } };
+  if (value === "Warm")
+    return { qualified: true, $expr: { $and: [{ $gte: [score, 45] }, { $lt: [score, 75] }] } };
+  if (value === "Cold")
+    return { $or: [{ qualified: { $ne: true } }, { $expr: { $lt: [score, 45] } }] };
+  throw err(400, 'healthBand must be "Hot", "Warm" or "Cold"');
+};
+
+const boolValue = (value, field) => {
+  if (typeof value === "boolean") return value;
+  if (value === "true") return true;
+  if (value === "false") return false;
+  throw err(400, `Invalid boolean for ${field}`);
+};
+
+// Virtual fields: derived conditions (some need a conversation lookup, hence async).
+const VIRTUAL_FIELDS = {
+  healthBand: async (op, value) => {
+    if (op !== "eq") throw err(400, 'healthBand supports only "eq"');
+    return healthBandCondition(value);
+  },
+  hasMeetingBooked: async (op, value) => {
+    if (op !== "eq") throw err(400, 'hasMeetingBooked supports only "eq"');
+    return boolValue(value, "hasMeetingBooked")
+      ? { followUps: { $elemMatch: { type: "meet", completedAt: null } } }
+      : { followUps: { $not: { $elemMatch: { type: "meet", completedAt: null } } } };
+  },
+  overdueFollowUps: async (op, value) => {
+    if (op !== "eq") throw err(400, 'overdueFollowUps supports only "eq"');
+    return boolValue(value, "overdueFollowUps")
+      ? { followUps: { $elemMatch: { completedAt: null, scheduledAt: { $lt: new Date() } } } }
+      : { followUps: { $not: { $elemMatch: { completedAt: null, scheduledAt: { $lt: new Date() } } } } };
+  },
+  reEnquired: async (op, value) => {
+    if (op !== "eq") throw err(400, 'reEnquired supports only "eq"');
+    return boolValue(value, "reEnquired")
+      ? { reEnquiredAt: { $ne: null } }
+      : { $or: [{ reEnquiredAt: { $exists: false } }, { reEnquiredAt: null }] };
+  },
+  kiaraChatting: async (op, value) => {
+    if (op !== "eq") throw err(400, 'kiaraChatting supports only "eq"');
+    const WAConversation = require("../models/WAConversation");
+    const ids = await WAConversation.distinct("enquiryId", {
+      mode: "ai",
+      status: "active",
+      enquiryId: { $ne: null },
+    });
+    return boolValue(value, "kiaraChatting") ? { _id: { $in: ids } } : { _id: { $nin: ids } };
+  },
+  needsHuman: async (op, value) => {
+    if (op !== "eq") throw err(400, 'needsHuman supports only "eq"');
+    const WAConversation = require("../models/WAConversation");
+    const ids = await WAConversation.distinct("enquiryId", {
+      needsHuman: true,
+      status: "active",
+      enquiryId: { $ne: null },
+    });
+    return boolValue(value, "needsHuman") ? { _id: { $in: ids } } : { _id: { $nin: ids } };
+  },
 };
 
 const escapeRegExp = (s) => String(s).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -38,6 +153,11 @@ const castValue = (kind, value, field) => {
     if (value === "true") return true;
     if (value === "false") return false;
     throw err(400, `Invalid boolean for ${field}`);
+  }
+  if (kind === "number") {
+    const n = Number(value);
+    if (!Number.isFinite(n)) throw err(400, `Invalid number for ${field}`);
+    return n;
   }
   if (typeof value !== "string" && typeof value !== "number") {
     throw err(400, `Invalid value for ${field}`);
@@ -104,6 +224,10 @@ const buildFilterConditions = async (filtersRaw) => {
     }
     const { field, op, value } = f;
 
+    if (field in VIRTUAL_FIELDS) {
+      conditions.push(await VIRTUAL_FIELDS[field](op, value));
+      continue;
+    }
     if (field in STATIC_FIELDS) {
       const spec = STATIC_FIELDS[field];
       if (!spec.ops.includes(op)) throw err(400, `Op "${op}" not allowed for ${field}`);


### PR DESCRIPTION
## MEGA-BUILD 5+6 — backend

Built slice-by-slice, each verified before commit. Companion frontend in WedsyOrg/wedsy-os (`claude/mb56-ui`). Full suite: **e2e-mb56 200/200**, **MB4 e2e regression 85/85**, **Bug A verify green**, tsc clean.

### MB4 bug fixes (folded in by founder decision)
- **Bug A — WhatsApp leads missing from list/board.** Intake leads now flow through one shared `LeadIntakeService.createLead` that pins `stage:"new"` + create-path defaults (board renders only configured stage columns, so a missing/unknown stage was the disappearance vector; companion board-fallback in the UI). Ships `scripts/backfill-whatsapp-leads.js` — idempotent, dry-run by default, refuses without `--confirm`, prints before/after counts. **Not run against prod** (founder runs on the box).
- **Bug B — chat send crash.** Root cause: send responses returned `sentBy` as a raw ObjectId while the polled thread populates `{_id,name}`; the optimistic render white-screened. Fixed server-side (`sendText`/`sendTemplate` populate `sentBy`); UI adds a defensive bubble + error boundary and a permanent browser test.

### The 11 slices
1. **MB4 bug fixes** (above).
2. **Attendance & employee status** — Attendance model (IST day, check-in/out, heartbeat-derived idle, permanent timestamps), derived status `checked_out|online|idle|in_meeting`, transparent own-status, scoped team list.
3. **Team calendar + meeting mode + huddle + handoff** — CalendarEvent model; meet/visit follow-ups mirror in; meeting-notes gate (can't close without notes, unclosed pins + blocks the next); gmeet auto-huddle with countdown + completion (eventTeam onto the lead); intern→manager handoff on meet-booked with set-once `qualifiedBy` credit; AdminNotification (in-OS, the only staff channel this build).
4. **Triage & escalation** — `assignment.mode` `auto|triage` (ships **auto** = zero behavior change); new `leads:triage` permission; triage queue (source, Kiara transcript, golden-window freshness); lazy escalation chain (working-hours gated → notify holders → all-checked-in-holders-in-meeting auto-assigns to an online intern + dual notifications).
5. **Golden window 15 + Kiara safety net** — defaults golden window 30→15, hours 10–19→11–19 IST; `kiara.welcomeTemplateName`-gated safety net (after-hours create + golden-window miss, once per lead) — **ships dormant** (empty template = off); morning triage pile with transcript. (Non-collab-venue outreach DEFERRED to Venue Mission Control — the collab flag doesn't exist yet.)
6. **Cockpit v2 + scripts-in-settings** — servicesRequired / budget / additionalEmails; Kiara servicesRequired/budget mapped into cockpit fields (closes MB4 judgment-call #2); resume discovery + completeness meter; meet-refuser (no-meet tag + escalation); `settings_scripts` category with 4 founder-editable call scripts (drafted v1 texts).
7. **Chats messenger v2 + Instagram** — IG agent gets the MB4 hook pattern adapted: `channel` on WAConversation (default whatsapp, migration-free), keyed by IG identity, unlinked until a phone is captured then dedup/create via the shared path, mode gate + escalation/classification + qualified→CRM sync mirroring WhatsApp, plus the `content[0].text` crash fix.
8. **Google Workspace (mocked, env-dormant)** — GoogleAccount model, OAuth start/callback (redirect URI pinned to prod), merged Google+OS availability, create-with-Meet + invites (incl. additionalEmails), OS-only fallback; **dormant when GOOGLE_CLIENT_ID/SECRET unset**. No new dep (googleapis already present).
9. **Filters + saved views** — filter-builder whitelist extended (services any-of, budget range, eventMonth, lastActivity + derived healthBand/hasMeetingBooked/kiaraChatting/needsHuman/reEnquired/overdueFollowUps), scope always ANDed; per-user SavedView CRUD.
10. **Intern/presales metrics** — derived rollup (leads received, contacted-in-window %, qualified, meets booked, incomplete discovery, avg time-to-first-call, show-up rate), period toggle, scope-aware. No new write paths.
11. **Anthropic 429 mitigation** — one shared in-process queue with exponential backoff on 429 across both agents; qualification check skipped under 3 user messages (halves early call volume).

### Authorized agent-file edits (gated review)
Founder-approved: `WhatsAppAgentService.js` (shared queue + <3-msg skip), `InstagramAgentService.js` (full MB4-pattern hooks + crash fix + queue + skip), `utils/instagram.js` (additive `INSTAGRAM_GRAPH_BASE_URL` mock seam). `utils/whatsapp.js` untouched. `KiaraCrmSyncService.js` also edited (CRM glue — channel-aware events, services/budget mapping). Full diffs were provided to the founder in the build report.

### Deploy posture — dormant by default
- `assignment.mode` ships **`auto`** (round-robin exactly as today; founder flips to `triage` in Settings).
- Kiara safety net **off** until `kiara.welcomeTemplateName` is set.
- Google **off** until `GOOGLE_CLIENT_ID/SECRET` are wired (UI shows a tidy not-configured state).
- Settings default changes: golden window 15, working hours 11–19 IST.
- No new backend dependency. New collections created lazily; all Enquiry/WAConversation fields additive with defaults.
- Founder runs on the box: `scripts/backfill-whatsapp-leads.js --confirm`, `scripts/mb56-seed-permissions.js --confirm` (leads:triage → Revenue Head + Sales Manager; settings_scripts → CRM Admin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)