### PR TITLE
Design pass API: Kiara lead-summary endpoint + journey-event actor-naming fix

### DIFF
--- a/controllers/kiaraSummary.js
+++ b/controllers/kiaraSummary.js
@@ -1,0 +1,38 @@
+const mongoose = require("mongoose");
+const Enquiry = require("../models/Enquiry");
+const KiaraSummaryService = require("../services/KiaraSummaryService");
+
+const respond = (res, error) => {
+  const status = error.status || 500;
+  res.status(status).json({ message: status === 500 ? "Server error" : error.message });
+};
+
+// Enforce lead-scope: the lead must satisfy the caller's scope filter (built by
+// requirePermission with ownerField assignedTo). all-scope → {} → no narrowing.
+const assertInScope = async (id, scopeFilter = {}) => {
+  if (!mongoose.Types.ObjectId.isValid(id)) throw Object.assign(new Error("Invalid enquiry id"), { status: 400 });
+  const inScope = await Enquiry.findOne({ $and: [{ _id: id }, scopeFilter || {}] }, { _id: 1 }).lean();
+  if (!inScope) throw Object.assign(new Error("Out of your scope"), { status: 403 });
+};
+
+// GET /enquiry/:_id/kiara-summary — cached summary (generates on first read).
+const Get = async (req, res) => {
+  try {
+    await assertInScope(req.params._id, req.scopeFilter);
+    res.status(200).json(await KiaraSummaryService.getSummary(req.params._id));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// POST /enquiry/:_id/kiara-summary — "Regenerate": force a fresh summary.
+const Regenerate = async (req, res) => {
+  try {
+    await assertInScope(req.params._id, req.scopeFilter);
+    res.status(200).json(await KiaraSummaryService.getSummary(req.params._id, { force: true }));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+module.exports = { Get, Regenerate };

--- a/models/Enquiry.js
+++ b/models/Enquiry.js
@@ -156,6 +156,12 @@ const EnquirySchema = new mongoose.Schema(
     unresponsiveFlaggedAt: { type: Date, default: null },
     // CSV import marker: historical imports are excluded from auto-assignment.
     importedAt: { type: Date, default: null },
+    // ── Design-pass Slice 5 (additive) — cached Kiara AI summary ────────────
+    // Founder-voice synopsis composed from captured data; "Regenerate" refreshes.
+    kiaraSummary: {
+      text: { type: String, default: "" },
+      generatedAt: { type: Date, default: null },
+    },
     // ── MB5 Slice 5 (additive only) — Kiara safety net engagement marker ────
     // Set once when the safety net sends the welcome template (after-hours
     // create or golden-window miss). Gates the once-per-lead rule and joins

--- a/routes/enquiry.js
+++ b/routes/enquiry.js
@@ -128,6 +128,20 @@ router.post(
   requirePermission("leads:edit:own"),
   cockpit.MeetRefused
 );
+// Design-pass Slice 5: Kiara AI summary (lead-scoped; POST regenerates).
+const kiaraSummary = require("../controllers/kiaraSummary");
+router.get(
+  "/:_id/kiara-summary",
+  CheckAdminLogin,
+  requirePermission("leads:view:own", { ownerField: "assignedTo" }),
+  kiaraSummary.Get
+);
+router.post(
+  "/:_id/kiara-summary",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own", { ownerField: "assignedTo" }),
+  kiaraSummary.Regenerate
+);
 router.post(
   "/:_id/call-complete",
   CheckAdminLogin,

--- a/scripts/test-journey-actors.js
+++ b/scripts/test-journey-actors.js
@@ -1,0 +1,87 @@
+/* Slice 4 verify — journey renderer names its actors for every event type.
+ * Seeds a lead + two admins + one event per actor-bearing type, runs
+ * JourneyService.buildJourney, asserts the rendered titles, cleans up.
+ * Local DB only, no server. Run: node scripts/test-journey-actors.js
+ */
+require("dotenv").config();
+const mongoose = require("mongoose");
+
+let pass = 0, fail = 0;
+const failures = [];
+const ok = (cond, label) => {
+  if (cond) { pass++; console.log(`  ✓ ${label}`); }
+  else { fail++; failures.push(label); console.error(`  ✗ ${label}`); }
+};
+
+(async () => {
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Enquiry = require("../models/Enquiry");
+  const Admin = require("../models/Admin");
+  const Role = require("../models/Role");
+  const Department = require("../models/Department");
+  const LeadInternalEvent = require("../models/LeadInternalEvent");
+  const JourneyService = require("../services/JourneyService");
+
+  const MARK = "JOURNEY-ACTORS";
+  const dept = await Department.create({ name: `${MARK} Dept` });
+  const role = await Role.create({ name: `${MARK} Role`, departmentId: dept._id, permissions: ["leads:view:own"] });
+  const alice = await Admin.create({ name: "Alice Intern", email: `ja-alice-${Date.now()}@test.local`, phone: "919900000401", password: "x", roleId: role._id, departmentId: dept._id, status: "active" });
+  const bob = await Admin.create({ name: "Bob Manager", email: `ja-bob-${Date.now()}@test.local`, phone: "919900000402", password: "x", roleId: role._id, departmentId: dept._id, status: "active" });
+  const carol = await Admin.create({ name: "Carol Head", email: `ja-carol-${Date.now()}@test.local`, phone: "919900000403", password: "x", roleId: role._id, departmentId: dept._id, status: "active" });
+
+  const lead = await Enquiry.create({
+    name: "Journey Test Lead", phone: "919900000400", verified: false, source: "Website",
+    additionalInfo: {}, stage: "new", assignedTo: bob._id,
+  });
+
+  const ev = (type, payload, actorId = null) =>
+    LeadInternalEvent.create({ leadId: lead._id, type, actorId, payload });
+
+  try {
+    // One event per actor-bearing type, with the SAME payload shape the real
+    // producers write (see LeadAssignmentService / TriageService / CalendarEventService).
+    await ev("transferred", { from: String(alice._id), to: String(bob._id), toName: "Bob Manager" }, carol._id);
+    await ev("transferred", { from: String(alice._id), to: String(bob._id), toName: "Bob Manager", reason: "meet_handoff" }, alice._id);
+    await ev("meet_handoff", { internId: String(alice._id), internName: "Alice Intern", managerId: String(bob._id), managerName: "Bob Manager" }, alice._id);
+    await ev("auto_assigned", { assignedTo: String(alice._id), assignedToName: "Alice Intern" });
+    await ev("triage_assigned", { to: String(alice._id), toName: "Alice Intern", self: false }, carol._id);
+    await ev("triage_assigned", { to: String(carol._id), toName: "Carol Head", self: true }, carol._id);
+    await ev("triage_auto_assigned", { to: String(alice._id), toName: "Alice Intern", reason: "auto-assigned: triage was in meetings" });
+    await ev("resurfaced_by_reenquiry", { source: "whatsapp", reassignedTo: String(bob._id) });
+    await ev("wa_human_takeover", {}, bob._id);
+
+    const { entries } = await JourneyService.buildJourney(lead._id);
+    const byType = (t) => entries.filter((e) => e.type === t);
+    const titleOf = (t, i = 0) => (byType(t)[i] || {}).title || "";
+
+    console.log("\n── Journey actor naming ──");
+    ok(titleOf("transferred", 0) === "Transferred from Alice Intern to Bob Manager", `transfer names from+to (got: "${titleOf("transferred", 0)}")`);
+    ok(titleOf("transferred", 1) === "Auto-transferred from Alice Intern to Bob Manager — meeting booked", `transfer(meet_handoff) reads auto-transfer (got: "${titleOf("transferred", 1)}")`);
+    ok(titleOf("meet_handoff") === "Auto-transferred from Alice Intern to Bob Manager — meeting booked", `meet_handoff names intern+manager (got: "${titleOf("meet_handoff")}")`);
+    ok(titleOf("auto_assigned") === "Auto-assigned to Alice Intern", `auto_assigned names assignee (got: "${titleOf("auto_assigned")}")`);
+    ok(titleOf("triage_assigned", 0) === "Assigned from triage to Alice Intern", `triage_assigned names assignee (got: "${titleOf("triage_assigned", 0)}")`);
+    ok(titleOf("triage_assigned", 1) === "Took it from triage", `triage self-assign reads "took it" (got: "${titleOf("triage_assigned", 1)}")`);
+    ok(titleOf("triage_auto_assigned") === "Auto-assigned from triage to Alice Intern", `triage_auto_assigned names assignee (got: "${titleOf("triage_auto_assigned")}")`);
+    ok(titleOf("resurfaced_by_reenquiry").includes("back to Bob Manager"), `resurfaced names reassignee (got: "${titleOf("resurfaced_by_reenquiry")}")`);
+    // The actor field is populated (not "—") for human-actor events.
+    ok(byType("transferred")[0].actor === "Carol Head", `transfer actor resolved (got: "${byType("transferred")[0].actor}")`);
+    ok(byType("wa_human_takeover")[0].actor === "Bob Manager", `wa takeover actor resolved (got: "${byType("wa_human_takeover")[0].actor}")`);
+    // No actor-bearing entry shows an unresolved "—".
+    const dashes = entries.filter((e) => e.actor === "—");
+    ok(dashes.length === 0, `no unresolved actors (found ${dashes.length}: ${dashes.map((d) => d.type).join(",")})`);
+  } catch (e) {
+    fail++;
+    failures.push(`fatal: ${e.message}`);
+    console.error("FATAL", e);
+  } finally {
+    await LeadInternalEvent.deleteMany({ leadId: lead._id });
+    await Enquiry.deleteMany({ _id: lead._id });
+    await Admin.deleteMany({ _id: { $in: [alice._id, bob._id, carol._id] } });
+    await Role.deleteMany({ _id: role._id });
+    await Department.deleteMany({ _id: dept._id });
+    await mongoose.disconnect();
+    console.log(`\n══ RESULT: ${pass} passed, ${fail} failed ══`);
+    if (failures.length) console.log("failures:", failures.join(" | "));
+    process.exit(fail === 0 ? 0 : 1);
+  }
+})();

--- a/scripts/test-kiara-summary.js
+++ b/scripts/test-kiara-summary.js
@@ -1,0 +1,134 @@
+/* Slice 5 verify — Kiara AI summary endpoint.
+ * Boots the real server on a TEST port with Anthropic pointed at an in-process
+ * mock (canned response). Covers: generate→cache, regenerate (force), the
+ * empty-data graceful case, and RBAC lead-scope (403 out of scope). Cleans up.
+ * Run: node scripts/test-kiara-summary.js
+ */
+require("dotenv").config();
+const http = require("http");
+const { spawn } = require("child_process");
+const mongoose = require("mongoose");
+const jwt = require("jsonwebtoken");
+
+const APP_PORT = 8131;
+const MOCK_PORT = 8132;
+const BASE = `http://localhost:${APP_PORT}`;
+const MARK = "KIARA-SUMMARY";
+
+let pass = 0, fail = 0;
+const failures = [];
+const ok = (c, label) => { if (c) { pass++; console.log(`  ✓ ${label}`); } else { fail++; failures.push(label); console.error(`  ✗ ${label}`); } };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const waitFor = async (fn, label, t = 30000) => {
+  const until = Date.now() + t;
+  while (Date.now() < until) { try { if (await fn()) return; } catch (_) {} await sleep(300); }
+  throw new Error(`waitFor timed out: ${label}`);
+};
+
+const CANNED = "Aarav & Meera are planning a December South-Indian wedding in Bengaluru, venue still open. They want decor and catering — budget around ₹18L. Next move: lock the venue shortlist on your call.";
+
+const mock = { calls: [] };
+const mockServer = http.createServer((req, res) => {
+  let raw = ""; req.on("data", (c) => (raw += c));
+  req.on("end", () => {
+    if (req.url === "/v1/messages") {
+      mock.calls.push(raw ? JSON.parse(raw) : {});
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ id: "msg_summary", content: [{ type: "text", text: CANNED }], stop_reason: "end_turn" }));
+      return;
+    }
+    res.writeHead(404); res.end();
+  });
+});
+
+(async () => {
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Enquiry = require("../models/Enquiry");
+  const Admin = require("../models/Admin");
+  const Role = require("../models/Role");
+  const Department = require("../models/Department");
+
+  const dept = await Department.create({ name: `${MARK} Dept` });
+  const ownerRole = await Role.create({ name: `${MARK} Owner`, departmentId: dept._id, permissions: ["leads:view:own", "leads:edit:own"] });
+  const owner = await Admin.create({ name: "Summary Owner", email: `ks-owner-${Date.now()}@test.local`, phone: "919900000501", password: "x", roleId: ownerRole._id, departmentId: dept._id, status: "active" });
+  const other = await Admin.create({ name: "Summary Other", email: `ks-other-${Date.now()}@test.local`, phone: "919900000502", password: "x", roleId: ownerRole._id, departmentId: dept._id, status: "active" });
+  const tok = (a) => jwt.sign({ _id: String(a._id), isAdmin: true }, process.env.JWT_SECRET);
+  const ownerToken = tok(owner), otherToken = tok(other);
+
+  const richLead = await Enquiry.create({
+    name: "Aarav Sharma", phone: "919900000510", verified: false, source: "Instagram", additionalInfo: { kiaraAnswers: { city: "Bengaluru", eventDate: "December 2026" } },
+    stage: "contacted", assignedTo: owner._id, qualified: true,
+    qualificationData: { groomName: "Aarav", brideName: "Meera", weddingStyle: "South Indian", venueStatus: "looking", servicesRequired: ["Decor", "Catering"], budgetAmount: 1800000, email: "aarav@example.com" },
+  });
+  const emptyLead = await Enquiry.create({
+    name: "Walk-in Enquiry", phone: "919900000511", verified: false, source: "Website", additionalInfo: {}, stage: "new", assignedTo: owner._id,
+  });
+
+  await new Promise((r) => mockServer.listen(MOCK_PORT, r));
+  const child = spawn("node", ["server.js"], {
+    cwd: `${__dirname}/..`,
+    env: { ...process.env, PORT: String(APP_PORT), ANTHROPIC_API_URL: `http://localhost:${MOCK_PORT}/v1/messages`, GOOGLE_SHEETS_KEY_PATH: "/nonexistent/ks.json" },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let log = ""; child.stdout.on("data", (d) => (log += d)); child.stderr.on("data", (d) => (log += d));
+
+  const api = async (method, path, token) => {
+    const res = await fetch(`${BASE}${path}`, { method, headers: token ? { Authorization: `Bearer ${token}` } : {} });
+    let data = null; try { data = await res.json(); } catch (_) {}
+    return { status: res.status, data };
+  };
+
+  try {
+    await waitFor(() => fetch(`${BASE}/`).then((r) => r.ok).catch(() => false), "server boot");
+
+    console.log("\n── Generate + cache ──");
+    const callsBefore = mock.calls.length;
+    const gen = await api("GET", `/enquiry/${richLead._id}/kiara-summary`, ownerToken);
+    ok(gen.status === 200 && gen.data.text === CANNED, "GET generates the summary from a mocked Anthropic call");
+    ok(gen.data.cached === false && !!gen.data.generatedAt, "first GET is uncached, stamped");
+    ok(mock.calls.length === callsBefore + 1, "exactly one Anthropic call");
+    const sentPrompt = JSON.stringify(mock.calls[mock.calls.length - 1]);
+    ok(sentPrompt.includes("Aarav") && sentPrompt.includes("Decor") && sentPrompt.includes("data extractor") === false, "prompt carries captured facts, founder-voice system prompt");
+    const fresh = await Enquiry.findById(richLead._id).lean();
+    ok(fresh.kiaraSummary && fresh.kiaraSummary.text === CANNED, "summary cached on the lead");
+
+    console.log("\n── Cache hit (no second call) ──");
+    const cached = await api("GET", `/enquiry/${richLead._id}/kiara-summary`, ownerToken);
+    ok(cached.status === 200 && cached.data.cached === true, "second GET returns cached (cached:true)");
+    ok(mock.calls.length === callsBefore + 1, "no extra Anthropic call on cache hit");
+
+    console.log("\n── Regenerate (force) ──");
+    const regen = await api("POST", `/enquiry/${richLead._id}/kiara-summary`, ownerToken);
+    ok(regen.status === 200 && regen.data.cached === false, "POST regenerates (cached:false)");
+    ok(mock.calls.length === callsBefore + 2, "regenerate makes a fresh Anthropic call");
+
+    console.log("\n── Empty-data case ──");
+    const callsBeforeEmpty = mock.calls.length;
+    const empty = await api("GET", `/enquiry/${emptyLead._id}/kiara-summary`, ownerToken);
+    ok(empty.status === 200 && empty.data.empty === true, "empty lead → graceful empty summary");
+    ok(/not enough info/i.test(empty.data.text), "empty summary says 'not enough info yet'");
+    ok(mock.calls.length === callsBeforeEmpty, "empty case makes NO Anthropic call");
+    const emptyDoc = await Enquiry.findById(emptyLead._id).lean();
+    ok(!emptyDoc.kiaraSummary || !emptyDoc.kiaraSummary.text, "empty summary is not cached (refreshes when data lands)");
+
+    console.log("\n── RBAC lead-scope ──");
+    const denied = await api("GET", `/enquiry/${richLead._id}/kiara-summary`, otherToken);
+    ok(denied.status === 403, "own-scope admin who doesn't own the lead → 403");
+    const deniedPost = await api("POST", `/enquiry/${richLead._id}/kiara-summary`, otherToken);
+    ok(deniedPost.status === 403, "regenerate also scope-guarded (403)");
+    const noAuth = await fetch(`${BASE}/enquiry/${richLead._id}/kiara-summary`);
+    ok([400, 401, 403].includes(noAuth.status), `unauthenticated rejected (got ${noAuth.status})`);
+  } catch (e) {
+    fail++; failures.push(`fatal: ${e.message}`);
+    console.error("FATAL", e); console.error("server log tail:", log.slice(-1500));
+  } finally {
+    await Enquiry.deleteMany({ _id: { $in: [richLead._id, emptyLead._id] } });
+    await Admin.deleteMany({ _id: { $in: [owner._id, other._id] } });
+    await Role.deleteMany({ _id: ownerRole._id });
+    await Department.deleteMany({ _id: dept._id });
+    child.kill(); mockServer.close(); await mongoose.disconnect();
+    console.log(`\n══ RESULT: ${pass} passed, ${fail} failed ══`);
+    if (failures.length) console.log("failures:", failures.join(" | "));
+    process.exit(fail === 0 ? 0 : 1);
+  }
+})();

--- a/services/JourneyService.js
+++ b/services/JourneyService.js
@@ -52,6 +52,46 @@ const EVENT_TITLES = {
   meet_refused: "Refusing a meeting — tagged no-meet",
 };
 
+// Payload keys that carry an Admin id of a SECOND party (not the actor) — these
+// must be name-resolved so titles can read "from A to B". Slice 4 (design pass).
+const PARTY_ID_KEYS = [
+  "from", "to", "assignedTo", "internId", "managerId",
+  "originalOwnerId", "reassignedTo", "by", "decidedBy",
+];
+
+// Build the human title for an event, naming every party involved. `nameOf`
+// resolves ids → names; `payloadName(key)` prefers an explicit *Name field in
+// the payload, falling back to the resolved id. Returns null to use the static
+// EVENT_TITLES map.
+const dynamicTitle = (type, payload = {}, nameOf) => {
+  const id = (key) => (payload[key] ? nameOf.get(String(payload[key])) || "someone" : null);
+  // Prefer denormalized names captured at write time, else resolve the id.
+  const toName = payload.toName || id("to") || payload.assignedToName || id("assignedTo");
+  const fromName = payload.fromName || id("from");
+
+  switch (type) {
+    case "transferred":
+      if (payload.reason === "meet_handoff") {
+        return `Auto-transferred${fromName ? ` from ${fromName}` : ""} to ${toName || "the sales lead"} — meeting booked`;
+      }
+      return `Transferred${fromName ? ` from ${fromName}` : ""}${toName ? ` to ${toName}` : ""}`;
+    case "meet_handoff":
+      return `Auto-transferred from ${payload.internName || id("internId") || "the intern"} to ${payload.managerName || id("managerId") || "the manager"} — meeting booked`;
+    case "auto_assigned":
+      return `Auto-assigned${toName ? ` to ${toName}` : ""}`;
+    case "triage_assigned":
+      return payload.self ? "Took it from triage" : `Assigned from triage${toName ? ` to ${toName}` : ""}`;
+    case "triage_auto_assigned":
+      return `Auto-assigned from triage${toName ? ` to ${toName}` : ""}`;
+    case "resurfaced_by_reenquiry": {
+      const re = payload.reassignedTo ? id("reassignedTo") : null;
+      return `Resurfaced — they re-enquired${re ? ` · back to ${re}` : ""}`;
+    }
+    default:
+      return null;
+  }
+};
+
 // GET /enquiry/:_id/journey — every moment of a lead's life, one chronological
 // stream, normalized to { at, type, actor, title, detail }.
 const buildJourney = async (enquiryId) => {
@@ -65,9 +105,16 @@ const buildJourney = async (enquiryId) => {
     ActivityLog.find({ entityType: "lead", entityId: String(lead._id) }).lean(),
   ]);
 
-  // Resolve every actor name in one query.
+  // Resolve every actor name in one query — actors AND named payload parties
+  // (transfer from/to, handoff intern/manager, …) so titles can name everyone.
   const actorIds = new Set();
-  for (const e of internalEvents) if (e.actorId) actorIds.add(String(e.actorId));
+  for (const e of internalEvents) {
+    if (e.actorId) actorIds.add(String(e.actorId));
+    const p = e.payload || {};
+    for (const k of PARTY_ID_KEYS) {
+      if (p[k] && mongoose.Types.ObjectId.isValid(String(p[k]))) actorIds.add(String(p[k]));
+    }
+  }
   for (const a of activityRows) if (a.actorId) actorIds.add(String(a.actorId));
   for (const c of lead.callLog || []) if (c.loggedBy) actorIds.add(String(c.loggedBy));
   for (const f of lead.followUps || []) {
@@ -99,7 +146,8 @@ const buildJourney = async (enquiryId) => {
       at: e.createdAt,
       type: e.type,
       actor: actor(e.actorId),
-      title: EVENT_TITLES[e.type] || e.type,
+      // Name every party: dynamic actor-aware title first, static map as fallback.
+      title: dynamicTitle(e.type, e.payload || {}, nameOf) || EVENT_TITLES[e.type] || e.type,
       detail: e.payload || {},
     });
   }

--- a/services/KiaraSummaryService.js
+++ b/services/KiaraSummaryService.js
@@ -1,0 +1,113 @@
+const Enquiry = require("../models/Enquiry");
+const { callAnthropic } = require("../utils/anthropicQueue");
+const JourneyService = require("./JourneyService");
+
+const httpError = (status, message) => Object.assign(new Error(message), { status });
+
+const SYSTEM_PROMPT =
+  "You are Kiara, the founder's right hand at Wedsy, a Bengaluru wedding company. " +
+  "Write a SHORT internal briefing on a lead for the sales rep about to work it. " +
+  "Founder voice: warm, direct, confident, no fluff. 2–4 sentences, max ~70 words. " +
+  "Use ONLY the facts provided — never invent names, dates, budgets, or preferences. " +
+  "If a key fact is missing, say what's still unknown rather than guessing. " +
+  "Lead with who they are and the event, then what they want, then the single most " +
+  "useful next move. Plain prose, no bullet points, no markdown, no preamble.";
+
+// Compose the captured facts into a compact, model-friendly brief. Returns
+// { facts, hasData } — hasData is false when there's nothing meaningful yet.
+const composeFacts = (lead, journeyEntries = []) => {
+  const q = lead.qualificationData || {};
+  const ka = (lead.additionalInfo && lead.additionalInfo.kiaraAnswers) || {};
+  const lines = [];
+  // Every lead has name/source/stage — those alone don't count as "data".
+  // `substantive` counts facts that actually tell the rep something.
+  const BOILERPLATE = new Set(["Name", "Source", "Stage"]);
+  let substantive = 0;
+  const add = (label, val) => {
+    if (val !== undefined && val !== null && String(val).trim() !== "") {
+      lines.push(`${label}: ${val}`);
+      if (!BOILERPLATE.has(label)) substantive++;
+    }
+  };
+
+  add("Name", lead.name);
+  const couple = [q.groomName, q.brideName].filter(Boolean).join(" & ");
+  add("Couple", couple);
+  add("Source", lead.marketingSource || lead.source);
+  add("Stage", lead.stage);
+  add("Wedding style", q.weddingStyle || ka.weddingStyle);
+  add("City", ka.city);
+  add("Event date", ka.eventDate);
+  add("Number of events", ka.numberOfEvents);
+  add("Venue status", q.venueStatus);
+  add("Venue", q.venueName || q.venueArea);
+  const services = (q.servicesRequired || []).join(", ") || ka.servicesRequired;
+  add("Services wanted", services);
+  if (q.budgetAmount) add("Budget", `₹${q.budgetAmount}`);
+  add("Budget note", q.budgetNote || ka.budget);
+  add("Email on file", q.email || lead.email ? "yes" : "");
+  add("Qualified", lead.qualified ? "yes" : "");
+
+  // Events captured (dates) — a real signal of seriousness.
+  const eventDays = (lead.events || []).flatMap((e) => e.eventDays || []);
+  if (eventDays.length) add("Events in system", `${eventDays.length} day(s)`);
+
+  // Last few journey beats for momentum context (not counted as "data" — the
+  // birth event is always present).
+  const recent = journeyEntries.slice(-4).map((e) => e.title).filter(Boolean);
+  if (recent.length) lines.push(`Recent activity: ${recent.join("; ")}`);
+
+  // "Meaningful" = at least one substantive captured fact beyond name/source/stage.
+  const hasData = substantive >= 1;
+  return { facts: lines.join("\n"), hasData };
+};
+
+const firstTextBlock = (response) => {
+  const content = response && response.data && Array.isArray(response.data.content) ? response.data.content : [];
+  const block = content.find((b) => b && b.type === "text" && typeof b.text === "string");
+  return block ? block.text.trim() : null;
+};
+
+// Generate (or return cached) the summary. force=true regenerates.
+const getSummary = async (enquiryId, { force = false } = {}) => {
+  const lead = await Enquiry.findById(enquiryId);
+  if (!lead) throw httpError(404, "Enquiry not found");
+
+  if (!force && lead.kiaraSummary && lead.kiaraSummary.text) {
+    return { text: lead.kiaraSummary.text, generatedAt: lead.kiaraSummary.generatedAt, cached: true };
+  }
+
+  let journeyEntries = [];
+  try {
+    journeyEntries = (await JourneyService.buildJourney(enquiryId)).entries;
+  } catch (_) { /* journey is advisory context */ }
+
+  const { facts, hasData } = composeFacts(lead.toObject(), journeyEntries);
+
+  // Empty-data case: graceful, no model call, not cached (so it refreshes once
+  // real data lands).
+  if (!hasData) {
+    return {
+      text: "Not enough info yet — Kiara hasn't captured the couple, their event, or what they want. Call them to discover the basics.",
+      generatedAt: null,
+      cached: false,
+      empty: true,
+    };
+  }
+
+  const response = await callAnthropic({
+    model: "claude-sonnet-4-5",
+    max_tokens: 200,
+    system: SYSTEM_PROMPT,
+    messages: [{ role: "user", content: `Lead facts:\n${facts}\n\nWrite the briefing.` }],
+  });
+  const text = firstTextBlock(response);
+  if (!text) throw httpError(502, "Kiara couldn't compose a summary — try again");
+
+  const generatedAt = new Date();
+  lead.kiaraSummary = { text, generatedAt };
+  await lead.save();
+  return { text, generatedAt, cached: false };
+};
+
+module.exports = { getSummary, composeFacts, SYSTEM_PROMPT };


### PR DESCRIPTION
## Design-language pass — backend (2 items)

Companion to the frontend pass in WedsyOrg/wedsy-os (`claude/design-pass`). Two backend changes that the new Client File and journey timeline consume. Regression: `e2e-kiara` (MB4) 85/85, `e2e-mb56` (MB5+6) 200/200, plus the two new suites below.

### Slice 5 — Kiara AI lead-summary endpoint
A founder-voice synopsis of a lead, composed from captured data only.

- `GET /enquiry/:id/kiara-summary` → `{ text, generatedAt, cached, empty? }`. Generates on first read, caches `kiaraSummary {text, generatedAt}` on the lead, returns the cache thereafter.
- `POST /enquiry/:id/kiara-summary` → same shape, **forces** a regenerate ("Regenerate" / "Ask Kiara").
- **Lead-scope RBAC**: both routes `CheckAdminLogin` + `requirePermission` with `ownerField: assignedTo`; the controller 403s if the lead isn't in the caller's scope (all-scope → no narrowing).
- Routes Claude through the **shared `anthropicQueue`** (the MB5+6 in-process queue — reused, not a new client; `ANTHROPIC_API_URL` mock seam honored, 429 backoff inherited).
- Composes `qualificationData` + `kiaraAnswers` + events + recent journey into a founder-voice prompt; factual-from-captured-data-only (no invention).
- **Empty-data case**: returns a graceful "not enough info yet" **without a model call and without caching** (so it refreshes once real data lands).
- `Enquiry.kiaraSummary {text, generatedAt}` is an additive field (defaults) — no migration.
- `scripts/test-kiara-summary.js`: 16 assertions (mocked Anthropic, test ports 8131/8132) — generate, cache hit, regenerate, empty-data, RBAC scope, no-auth.

### Slice 4 — journey-event actor-naming fix (+ full audit)
The timeline showed bare "Transferred" with no parties. Root cause: titles came from a static map and only the acting admin's id was name-resolved.

- Named payload parties are now resolved in the same single Admin query (`from`/`to`/`assignedTo`/`internId`/`managerId`/`originalOwnerId`/`reassignedTo`).
- `dynamicTitle()` names every party: "Transferred from A to B", "Auto-transferred from <intern> to <manager> — meeting booked" (`meet_handoff` + `transferred`-with-reason), "Auto-assigned to X", "Assigned from triage to X" / "Took it from triage", "Auto-assigned from triage to X", "Resurfaced — they re-enquired · back to X". Static map remains the fallback.
- Audited every event type: **no actor-bearing entry renders an unresolved "—"**. Frontend `JourneyFeed` already renders the server title/actor verbatim, so the fix flows through with no UI change.
- `scripts/test-journey-actors.js`: 11 assertions, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)