### PR TITLE
MB7a Onboarding & Money: finalise gate, milestone settings, e-sign, onboard+lock, Razorpay (dormant), auto-invoice, RBAC v2 + CS dashboard

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -785,14 +785,22 @@ const FirstResetPassword = async (req, res) => {
 const GetPermissions = async (req, res) => {
   try {
     const admin = await Admin.findById(req.auth.user_id).lean();
-    if (!admin || !admin.roleId) {
-      return res.status(200).send({ permissions: [] });
+    const { permissionsForAdmin, roleIdsOf } = require("../middlewares/requirePermission");
+    const ids = roleIdsOf(admin);
+    if (!admin || ids.length === 0) {
+      return res.status(200).send({ permissions: [], roleNames: [] });
     }
+    // RBAC v2: union of permissions across every role; roleNames lists all.
     const Role = require("../models/Role");
-    const role = await Role.findById(admin.roleId).lean();
+    const [permissions, roles] = await Promise.all([
+      permissionsForAdmin(admin),
+      Role.find({ _id: { $in: ids } }, { name: 1 }).lean(),
+    ]);
+    const roleNames = roles.map((r) => r.name);
     res.status(200).send({
-      permissions: role && Array.isArray(role.permissions) ? role.permissions : [],
-      roleName: role ? role.name : null,
+      permissions,
+      roleNames,
+      roleName: roleNames[0] || null, // back-compat
     });
   } catch (error) {
     res.status(500).send({ message: "Server error" });

--- a/controllers/disqualify.js
+++ b/controllers/disqualify.js
@@ -28,10 +28,9 @@ const isManagerOfAssigned = async (actorId, assignedToId) => {
 const actorHasApprovePermission = async (actorId) => {
   if (!actorId) return false;
   const admin = await AdminRepository.findById(actorId);
-  if (!admin || !admin.roleId) return false;
-  const role = await RoleRepository.findById(admin.roleId);
-  if (!role || !Array.isArray(role.permissions)) return false;
-  return permissionSatisfies(role.permissions, "leads:approve:own").allowed;
+  const { permissionsForAdmin } = require("../middlewares/requirePermission");
+  const perms = await permissionsForAdmin(admin); // RBAC v2 union
+  return permissionSatisfies(perms, "leads:approve:own").allowed;
 };
 
 // POST /enquiry/:_id/disqualify

--- a/controllers/event.js
+++ b/controllers/event.js
@@ -4,8 +4,9 @@ const User = require("../models/User");
 const { SendUpdate } = require("../utils/update");
 const EventShare = require("../models/EventShare");
 const { sha256 } = require("./eventShare");
+const OnboardingService = require("../services/OnboardingService");
 
-const CreateNew = (req, res) => {
+const CreateNew = async (req, res) => {
   const { user_id, isAdmin } = req.auth;
   // Auto-derive name from groomName + brideName if both provided and name is missing.
   // Keeps downstream code that reads `name` working unchanged.
@@ -16,24 +17,32 @@ const CreateNew = (req, res) => {
   if (!name || !community || !eventDay || !date || !time || !venue) {
     res.status(400).send({ message: "Incomplete Data" });
   } else {
-    // Store the provided date both as date and eventDate to ensure consistency
-    new Event({
-      user: isAdmin ? user : user_id,
-      name,
-      brideName: brideName || null,
-      groomName: groomName || null,
-      community,
-      eventDate: date, // Add the eventDate field explicitly
-      // eventSpace is optional (additive) — existing callers that omit it get the schema default "".
-      eventDays: [{ name: eventDay, date, time, venue, eventSpace: eventSpace || "" }],
-    })
-      .save()
-      .then((result) => {
-        res.status(200).send({ message: "success", _id: result._id });
-      })
-      .catch((error) => {
-        res.status(400).send({ message: "error", error });
-      });
+    try {
+      // MB7a Slice 1 — draft cap: a user may hold at most 3 unfinalized drafts.
+      const ownerId = isAdmin ? user : user_id;
+      if (ownerId) {
+        const drafts = await OnboardingService.countDrafts(ownerId);
+        if (drafts >= OnboardingService.MAX_DRAFTS) {
+          return res.status(409).send({
+            message: `Draft limit reached (max ${OnboardingService.MAX_DRAFTS}) — finalize or delete a draft before creating another.`,
+          });
+        }
+      }
+      // Store the provided date both as date and eventDate to ensure consistency
+      const result = await new Event({
+        user: ownerId,
+        name,
+        brideName: brideName || null,
+        groomName: groomName || null,
+        community,
+        eventDate: date, // Add the eventDate field explicitly
+        // eventSpace is optional (additive) — existing callers that omit it get the schema default "".
+        eventDays: [{ name: eventDay, date, time, venue, eventSpace: eventSpace || "" }],
+      }).save();
+      res.status(200).send({ message: "success", _id: result._id });
+    } catch (error) {
+      res.status(400).send({ message: "error", error });
+    }
   }
 };
 
@@ -1736,6 +1745,11 @@ const FinalizeEvent = (req, res) => {
         )
           .then((result) => {
             if (result) {
+              // MB7a Slice 1 — client commits (key 1 of the two-key gate).
+              OnboardingService.recordEventJourney(event, "client_finalised", isAdmin ? user_id : null, {
+                eventId: String(_id),
+                by: isAdmin ? "admin" : "client",
+              });
               res.status(200).send({ message: "success" });
             } else {
               res.status(404).send({ message: "Event not found" });
@@ -1904,6 +1918,8 @@ const ApproveEvent = (req, res) => {
                   phone: event?.user?.phone,
                 },
               });
+              // MB7a Slice 1 — Wedsy validates (key 2); payment now unlocks.
+              OnboardingService.recordEventJourney(event, "wedsy_approved", user_id, { eventId: String(_id) });
               res.status(200).send({ message: "success" });
             } else {
               res.status(404).send({ message: "Event not found" });

--- a/controllers/onboarding.js
+++ b/controllers/onboarding.js
@@ -1,5 +1,6 @@
 const Config = require("../models/Config");
 const OnboardingService = require("../services/OnboardingService");
+const SettingsService = require("../services/SettingsService");
 
 const respond = (res, error) =>
   res.status(error.status || 500).json({ message: error.message || "Server error" });
@@ -54,4 +55,44 @@ const PreviewMilestones = async (req, res) => {
   }
 };
 
-module.exports = { GetMilestones, PutMilestones, PreviewMilestones };
+// GET /onboarding/agreement — the agreement text + version for the onboard flow.
+// CheckLogin so the CLIENT (wedsy-user) can read it (the admin-only
+// /settings/public can't be reached by client tokens).
+const GetAgreementText = async (req, res) => {
+  try {
+    const [terms, version] = await Promise.all([
+      SettingsService.get("agreement.terms"),
+      SettingsService.get("agreement.version"),
+    ]);
+    res.status(200).json({ terms, version });
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// POST /onboarding/agreement — client (or OS on their behalf) accepts the terms.
+// Body: { leadId, eventId?, acceptedName }. Records acceptance + journey.
+const AcceptAgreement = async (req, res) => {
+  try {
+    const { leadId, eventId, acceptedName } = req.body || {};
+    const actorId = req.auth && req.auth.isAdmin ? req.auth.user_id : null;
+    const doc = await OnboardingService.acceptAgreement({ leadId, eventId, acceptedName, actorId });
+    res.status(200).json({ message: "success", agreement: doc.agreement });
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// GET /onboarding?leadId=&eventId= — onboarding status (OS).
+const GetStatus = async (req, res) => {
+  try {
+    const { leadId, eventId } = req.query;
+    if (!leadId) return res.status(400).json({ message: "leadId is required" });
+    const doc = await OnboardingService.getOnboarding(leadId, eventId || null);
+    res.status(200).json({ onboarding: doc || null });
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+module.exports = { GetMilestones, PutMilestones, PreviewMilestones, GetAgreementText, AcceptAgreement, GetStatus };

--- a/controllers/onboarding.js
+++ b/controllers/onboarding.js
@@ -1,0 +1,57 @@
+const Config = require("../models/Config");
+const OnboardingService = require("../services/OnboardingService");
+
+const respond = (res, error) =>
+  res.status(error.status || 500).json({ message: error.message || "Server error" });
+
+// GET /onboarding/milestones — current milestone settings (defaults when unset).
+// Readable by any admin (operational — payment links + onboard read it).
+const GetMilestones = async (req, res) => {
+  try {
+    res.status(200).json(await OnboardingService.getMilestoneConfig());
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// PUT /onboarding/milestones — founder-editable (settings_onboarding:edit:all).
+// Reuses the /config {code,data} storage under code "OnboardingMilestones".
+// All amounts in RUPEES.
+const PutMilestones = async (req, res) => {
+  try {
+    const { onboardingFee, advancePercent, balanceDaysBeforeEvent } = req.body || {};
+    const num = (v, lo, hi, label) => {
+      const n = Number(v);
+      if (!Number.isFinite(n) || n < lo || n > hi) {
+        throw Object.assign(new Error(`${label} must be a number between ${lo} and ${hi}`), { status: 400 });
+      }
+      return n;
+    };
+    const data = {
+      onboardingFee: num(onboardingFee, 0, 10000000, "onboardingFee"),
+      advancePercent: num(advancePercent, 1, 100, "advancePercent"),
+      balanceDaysBeforeEvent: num(balanceDaysBeforeEvent, 0, 365, "balanceDaysBeforeEvent"),
+    };
+    await Config.findOneAndUpdate(
+      { code: OnboardingService.MILESTONE_CODE },
+      { $set: { code: OnboardingService.MILESTONE_CODE, data } },
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    );
+    res.status(200).json({ message: "success", data });
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// GET /onboarding/milestones/preview?total=NNN — compute the three milestones
+// for a given total (rupees), so the cockpit/onboard UI can show the breakdown.
+const PreviewMilestones = async (req, res) => {
+  try {
+    const cfg = await OnboardingService.getMilestoneConfig();
+    res.status(200).json(OnboardingService.computeMilestones(req.query.total, cfg));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+module.exports = { GetMilestones, PutMilestones, PreviewMilestones };

--- a/controllers/onboarding.js
+++ b/controllers/onboarding.js
@@ -151,4 +151,31 @@ const GetStatus = async (req, res) => {
   }
 };
 
-module.exports = { GetMilestones, PutMilestones, PreviewMilestones, GetAgreementText, AcceptAgreement, GetStatus, StartOnboarding, ClientState, CreatePaymentLink, RecordOfflinePayment, ConfirmOnlinePayment };
+// GET /onboarding/cs/clients — CS dashboard onboarded-clients list (scoped).
+const CSClients = async (req, res) => {
+  try {
+    res.status(200).json({ list: await OnboardingService.listOnboardedClients(req.scopeFilter || {}) });
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// GET /onboarding/cs/clients.csv — same list as a CSV download (xlsx deferred).
+const CSClientsCsv = async (req, res) => {
+  try {
+    const rows = await OnboardingService.listOnboardedClients(req.scopeFilter || {});
+    const esc = (v) => `"${String(v == null ? "" : v).replace(/"/g, '""')}"`;
+    const header = ["Client", "Phone", "Onboarded", "Total (₹)", "Paid (₹)", "Due (₹)", "Agreement"];
+    const lines = [header.map(esc).join(",")];
+    for (const r of rows) {
+      lines.push([r.name, r.phone, r.onboardedAt ? new Date(r.onboardedAt).toISOString().slice(0, 10) : "", r.totalRupees, r.paidRupees, r.dueRupees, r.agreementAccepted ? "accepted" : "pending"].map(esc).join(","));
+    }
+    res.setHeader("Content-Type", "text/csv");
+    res.setHeader("Content-Disposition", 'attachment; filename="onboarded-clients.csv"');
+    res.status(200).send(lines.join("\n"));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+module.exports = { GetMilestones, PutMilestones, PreviewMilestones, GetAgreementText, AcceptAgreement, GetStatus, StartOnboarding, ClientState, CreatePaymentLink, RecordOfflinePayment, ConfirmOnlinePayment, CSClients, CSClientsCsv };

--- a/controllers/onboarding.js
+++ b/controllers/onboarding.js
@@ -83,6 +83,29 @@ const AcceptAgreement = async (req, res) => {
   }
 };
 
+// POST /onboarding/start — Revenue Head onboards a client (leads:onboard).
+// Body: { leadId, eventId? }. Locks the client dashboard, snapshots milestones.
+const StartOnboarding = async (req, res) => {
+  try {
+    const { leadId, eventId } = req.body || {};
+    const result = await OnboardingService.startOnboarding({ leadId, eventId, actorId: req.auth.user_id });
+    res.status(200).json({ message: "success", ...result });
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// GET /onboarding/state?eventId= — CLIENT-facing lock/onboarded flags (wedsy-user).
+const ClientState = async (req, res) => {
+  try {
+    const { eventId } = req.query;
+    if (!eventId) return res.status(400).json({ message: "eventId is required" });
+    res.status(200).json(await OnboardingService.clientState(eventId, req.auth.user_id, !!(req.auth && req.auth.isAdmin)));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
 // GET /onboarding?leadId=&eventId= — onboarding status (OS).
 const GetStatus = async (req, res) => {
   try {
@@ -95,4 +118,4 @@ const GetStatus = async (req, res) => {
   }
 };
 
-module.exports = { GetMilestones, PutMilestones, PreviewMilestones, GetAgreementText, AcceptAgreement, GetStatus };
+module.exports = { GetMilestones, PutMilestones, PreviewMilestones, GetAgreementText, AcceptAgreement, GetStatus, StartOnboarding, ClientState };

--- a/controllers/onboarding.js
+++ b/controllers/onboarding.js
@@ -106,6 +106,39 @@ const ClientState = async (req, res) => {
   }
 };
 
+// POST /onboarding/payment-link — generate a Razorpay link for a milestone
+// (dormant-safe). Body: { leadId, eventId, milestone }.
+const CreatePaymentLink = async (req, res) => {
+  try {
+    const { leadId, eventId, milestone } = req.body || {};
+    res.status(200).json(await OnboardingService.createMilestonePaymentLink({ leadId, eventId, milestone, actorId: req.auth.user_id }));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// POST /onboarding/payment/offline — record an offline payment with proof.
+// Body: { leadId, eventId, milestone, amountRupees, method, txnId?, paidOn?, notes?, proofUrl? }.
+const RecordOfflinePayment = async (req, res) => {
+  try {
+    const b = req.body || {};
+    const out = await OnboardingService.recordOfflinePayment({ ...b, actorId: req.auth.user_id });
+    res.status(200).json({ message: "success", ...out });
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// POST /onboarding/payment/:paymentId/confirm — mark an online milestone paid
+// (the verification seam; e.g. called after a Razorpay callback).
+const ConfirmOnlinePayment = async (req, res) => {
+  try {
+    res.status(200).json(await OnboardingService.confirmOnlineMilestonePaid({ paymentId: req.params.paymentId, actorId: req.auth.user_id }));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
 // GET /onboarding?leadId=&eventId= — onboarding status (OS).
 const GetStatus = async (req, res) => {
   try {
@@ -118,4 +151,4 @@ const GetStatus = async (req, res) => {
   }
 };
 
-module.exports = { GetMilestones, PutMilestones, PreviewMilestones, GetAgreementText, AcceptAgreement, GetStatus, StartOnboarding, ClientState };
+module.exports = { GetMilestones, PutMilestones, PreviewMilestones, GetAgreementText, AcceptAgreement, GetStatus, StartOnboarding, ClientState, CreatePaymentLink, RecordOfflinePayment, ConfirmOnlinePayment };

--- a/controllers/payment.js
+++ b/controllers/payment.js
@@ -3,6 +3,7 @@ const Order = require("../models/Order");
 const Payment = require("../models/Payment");
 const ChatContent = require("../models/ChatContent");
 const { createInvoice } = require("../utils/invoice");
+const OnboardingService = require("../services/OnboardingService");
 const {
   CreatePayment,
   GetPaymentStatus,
@@ -17,9 +18,24 @@ function logCreateNewPaymentFailure(label, error, meta = {}) {
   });
 }
 
-const CreateNewPayment = (req, res) => {
+const CreateNewPayment = async (req, res) => {
   const { user_id, isAdmin } = req.auth;
   const { event, paymentFor, paymentMethod, amount, user, order } = req.body;
+  // MB7a Slice 1 — two-key gate: an event's payment flow unlocks only after the
+  // client finalised (status.finalized) AND Wedsy approved (status.approved).
+  if (paymentFor === "event" && event) {
+    try {
+      const ev = await Event.findById(event, { status: 1 }).lean();
+      if (!ev) return res.status(404).send({ message: "Event not found" });
+      if (!OnboardingService.paymentUnlocked(ev)) {
+        return res.status(422).send({
+          message: "Payment locked — the event must be client-finalised and Wedsy-approved first.",
+        });
+      }
+    } catch (error) {
+      return res.status(400).send({ message: "error", error });
+    }
+  }
   if (paymentFor === "event" && event && paymentMethod === "razporpay") {
     new Payment({
       user: user_id,

--- a/controllers/settings.js
+++ b/controllers/settings.js
@@ -1,7 +1,7 @@
 const SettingsService = require("../services/SettingsService");
 const AdminRepository = require("../repositories/AdminRepository");
 const RoleRepository = require("../repositories/RoleRepository");
-const { permissionSatisfies } = require("../middlewares/requirePermission");
+const { permissionSatisfies, permissionsForAdmin } = require("../middlewares/requirePermission");
 
 const respond = (res, error) => {
   const status = error.status || 500;
@@ -9,12 +9,10 @@ const respond = (res, error) => {
   res.status(status).json({ message: status === 500 ? "Server error" : error.message });
 };
 
-// Caller's resolved permission strings (empty array when role-less).
+// Caller's resolved permission strings — RBAC v2 union across all roles.
 const callerPermissions = async (adminId) => {
   const admin = await AdminRepository.findById(adminId);
-  if (!admin || !admin.roleId) return [];
-  const role = await RoleRepository.findById(admin.roleId);
-  return role && Array.isArray(role.permissions) ? role.permissions : [];
+  return permissionsForAdmin(admin);
 };
 
 const canEditCategory = (perms, category) =>

--- a/controllers/settings.js
+++ b/controllers/settings.js
@@ -70,6 +70,9 @@ const GetPublic = async (req, res) => {
       "cockpit.servicesScript",
       "cockpit.budgetScript",
       "cockpit.qualificationIntro",
+      // MB7a Slice 3: the onboard flow (and wedsy-user) read the agreement text.
+      "agreement.terms",
+      "agreement.version",
     ]);
     res.status(200).json(values);
   } catch (error) {

--- a/middlewares/requirePermission.js
+++ b/middlewares/requirePermission.js
@@ -12,6 +12,25 @@ const parsePermission = (str) => {
   return { resource, action, scope };
 };
 
+// ── RBAC v2 (MB7a) — multi-role permission UNION ─────────────────────────────
+// An admin's effective roles = roleIds[] when set, else the single roleId
+// (backward-compatible). permissionsForAdmin returns the UNION of every role's
+// permissions — the single source of truth used by the gate and every reader.
+const roleIdsOf = (admin) => {
+  if (admin && Array.isArray(admin.roleIds) && admin.roleIds.length) return admin.roleIds;
+  if (admin && admin.roleId) return [admin.roleId];
+  return [];
+};
+
+const permissionsForAdmin = async (admin) => {
+  const ids = roleIdsOf(admin);
+  if (!ids.length) return [];
+  const roles = await RoleRepository.findByIds(ids);
+  const set = new Set();
+  for (const r of roles) for (const p of (r && r.permissions) || []) set.add(p);
+  return [...set];
+};
+
 // Do the granted permission strings satisfy the required one?
 // Wildcards (*) allowed on resource and action. Scope expands: all >= department >= team >= own.
 // effectiveScope = broadest granted scope for the matched resource:action (used to build the filter).
@@ -91,12 +110,13 @@ const requirePermission = (requiredStr, options = {}) => {
       if (!adminId) return res.status(403).json({ message: "Forbidden" });
 
       const admin = await AdminRepository.findById(adminId);
-      if (!admin || !admin.roleId) return res.status(403).json({ message: "Forbidden" });
+      if (!admin || roleIdsOf(admin).length === 0) return res.status(403).json({ message: "Forbidden" });
 
-      const role = await RoleRepository.findById(admin.roleId);
-      if (!role || !Array.isArray(role.permissions)) return res.status(403).json({ message: "Forbidden" });
+      // RBAC v2: union of permissions across all of the admin's roles.
+      const perms = await permissionsForAdmin(admin);
+      if (!perms.length) return res.status(403).json({ message: "Forbidden" });
 
-      const { allowed, effectiveScope } = permissionSatisfies(role.permissions, requiredStr);
+      const { allowed, effectiveScope } = permissionSatisfies(perms, requiredStr);
       if (!allowed) return res.status(403).json({ message: "Forbidden", required: requiredStr });
 
       req.scope = effectiveScope;
@@ -112,6 +132,8 @@ module.exports = {
   requirePermission,
   parsePermission,
   permissionSatisfies,
+  permissionsForAdmin,
+  roleIdsOf,
   buildScopeFilter,
   getSubordinateIds,
   getDepartmentMemberIds,

--- a/models/Admin.js
+++ b/models/Admin.js
@@ -10,6 +10,9 @@ const AdminSchema = new mongoose.Schema(
     roles: { type: [String], required: true, enum: ["owner", "crm", "sales", "ops", "finance"] },
     // --- Wedsy OS RBAC Phase 2B (additive, optional — legacy roles[] unchanged) ---
     roleId: { type: ObjectId, ref: "Role", default: null },
+    // --- RBAC v2 (MB7a) — multi-role: permissions are the UNION of all roleIds.
+    // Additive + back-compat: empty roleIds falls back to the single roleId.
+    roleIds: { type: [{ type: ObjectId, ref: "Role" }], default: [] },
     departmentId: { type: ObjectId, ref: "Department", default: null },
     reportingManagerId: { type: ObjectId, ref: "Admin", default: null },
     status: { type: String, enum: ["active", "inactive", "on_leave"], default: "active" },

--- a/models/Onboarding.js
+++ b/models/Onboarding.js
@@ -1,0 +1,40 @@
+const mongoose = require("mongoose");
+const ObjectId = mongoose.Schema.Types.ObjectId;
+
+// MB7a — the onboarding record bridging a CRM lead (Enquiry) and its finalized
+// event into the money/agreement flow. One record per {leadId, eventId}.
+// Genuinely new state (lock, agreement, milestone payments) — NOT a parallel
+// copy of the event finalize/approve machine.
+const OnboardingSchema = new mongoose.Schema(
+  {
+    leadId: { type: ObjectId, ref: "Enquiry", required: true, index: true },
+    eventId: { type: ObjectId, ref: "Event", default: null },
+    startedBy: { type: ObjectId, ref: "Admin", default: null },
+    startedAt: { type: Date, default: null },
+    status: {
+      type: String,
+      enum: ["started", "onboarded", "cancelled"],
+      default: "started",
+    },
+    // CLIENT-side dashboard lock (wedsy-user reads this via the API contract).
+    // OS retains full access regardless.
+    lockActive: { type: Boolean, default: false },
+    // E-sign acceptance (Slice 3).
+    agreement: {
+      accepted: { type: Boolean, default: false },
+      acceptedAt: { type: Date, default: null },
+      acceptedName: { type: String, default: "" },
+      agreementVersion: { type: String, default: "" },
+    },
+    // Milestone snapshot at onboard time (RUPEES) — Slice 4.
+    milestones: { type: Object, default: null },
+    // ONBOARDED when the onboarding-fee payment lands (Slice 5).
+    onboardedAt: { type: Date, default: null },
+    onboardingPaymentId: { type: ObjectId, ref: "Payment", default: null },
+  },
+  { timestamps: true }
+);
+
+OnboardingSchema.index({ leadId: 1, eventId: 1 }, { unique: true });
+
+module.exports = mongoose.models.Onboarding || mongoose.model("Onboarding", OnboardingSchema);

--- a/models/Payment.js
+++ b/models/Payment.js
@@ -27,6 +27,22 @@ const PaymentSchema = new mongoose.Schema(
     },
     razporPayId: { type: String, default: "" },
     response: { type: [Object], default: [] },
+    // ── MB7a (additive) — onboarding & money engine ──────────────────────────
+    // Which milestone this payment is for (onboarding fee / advance / balance).
+    milestone: { type: String, enum: ["", "onboarding", "advance", "balance"], default: "" },
+    // Razorpay payment-link (when generated; dormant-safe).
+    paymentLinkId: { type: String, default: "" },
+    paymentLinkUrl: { type: String, default: "" },
+    // Offline payment proof. Screenshot URL (S3) mandatory for bank-transfer.
+    proof: {
+      url: { type: String, default: "" },
+      txnId: { type: String, default: "" },
+      paidOn: { type: Date, default: null },
+      notes: { type: String, default: "" },
+    },
+    recordedBy: { type: ObjectId, ref: "Admin", default: null },
+    // Reminder-due marker (the actual WhatsApp chase is template-gated/dormant).
+    reminderDueAt: { type: Date, default: null },
     // Payment Status: null, created, attempted, paid, partially paid, expired, cancelled
     status: {
       type: String,

--- a/models/Payment.js
+++ b/models/Payment.js
@@ -43,6 +43,10 @@ const PaymentSchema = new mongoose.Schema(
     recordedBy: { type: ObjectId, ref: "Admin", default: null },
     // Reminder-due marker (the actual WhatsApp chase is template-gated/dormant).
     reminderDueAt: { type: Date, default: null },
+    // Auto-invoice (Slice 6): stamped when the payment is recorded so the
+    // invoice is "available" (downloadable at GET /payment/:id/invoice), not
+    // only generated on demand.
+    invoiceReadyAt: { type: Date, default: null },
     // Payment Status: null, created, attempted, paid, partially paid, expired, cancelled
     status: {
       type: String,

--- a/repositories/RoleRepository.js
+++ b/repositories/RoleRepository.js
@@ -8,6 +8,12 @@ const findById = async (_id) => {
   return await Role.findById(_id).lean();
 };
 
+// RBAC v2 — fetch many roles at once (the permission-union read path).
+const findByIds = async (ids) => {
+  if (!Array.isArray(ids) || ids.length === 0) return [];
+  return await Role.find({ _id: { $in: ids } }).lean();
+};
+
 const updateById = async (_id, fields) => {
   return await Role.findByIdAndUpdate(
     _id,
@@ -19,5 +25,6 @@ const updateById = async (_id, fields) => {
 module.exports = {
   findAllActive,
   findById,
+  findByIds,
   updateById,
 };

--- a/routes/onboarding.js
+++ b/routes/onboarding.js
@@ -51,4 +51,19 @@ router.post(
   controller.ConfirmOnlinePayment
 );
 
+// CS dashboard (Slice 7) — onboarded clients list + CSV export, scoped by the
+// project's CS owner (projects:view).
+router.get(
+  "/cs/clients",
+  CheckAdminLogin,
+  requirePermission("projects:view:own", { ownerField: "csOwnerId" }),
+  controller.CSClients
+);
+router.get(
+  "/cs/clients.csv",
+  CheckAdminLogin,
+  requirePermission("projects:view:own", { ownerField: "csOwnerId" }),
+  controller.CSClientsCsv
+);
+
 module.exports = router;

--- a/routes/onboarding.js
+++ b/routes/onboarding.js
@@ -2,7 +2,7 @@ const express = require("express");
 const router = express.Router();
 
 const controller = require("../controllers/onboarding");
-const { CheckAdminLogin } = require("../middlewares/auth");
+const { CheckLogin, CheckAdminLogin } = require("../middlewares/auth");
 const { requirePermission } = require("../middlewares/requirePermission");
 
 // Milestone settings (Slice 2). GET readable by any admin (operational);
@@ -15,5 +15,10 @@ router.put(
   requirePermission("settings_onboarding:edit:all"),
   controller.PutMilestones
 );
+
+// E-sign (Slice 3). Client-readable terms + accept (CheckLogin); status is OS.
+router.get("/agreement", CheckLogin, controller.GetAgreementText);
+router.post("/agreement", CheckLogin, controller.AcceptAgreement);
+router.get("/", CheckAdminLogin, controller.GetStatus);
 
 module.exports = router;

--- a/routes/onboarding.js
+++ b/routes/onboarding.js
@@ -30,4 +30,25 @@ router.post(
 );
 router.get("/state", CheckLogin, controller.ClientState);
 
+// Payments (Slice 5) — Razorpay link gen + offline-with-proof + online confirm.
+// Gated to onboarders (Revenue Head / founder).
+router.post(
+  "/payment-link",
+  CheckAdminLogin,
+  requirePermission("leads:onboard:own"),
+  controller.CreatePaymentLink
+);
+router.post(
+  "/payment/offline",
+  CheckAdminLogin,
+  requirePermission("leads:onboard:own"),
+  controller.RecordOfflinePayment
+);
+router.post(
+  "/payment/:paymentId/confirm",
+  CheckAdminLogin,
+  requirePermission("leads:onboard:own"),
+  controller.ConfirmOnlinePayment
+);
+
 module.exports = router;

--- a/routes/onboarding.js
+++ b/routes/onboarding.js
@@ -21,4 +21,13 @@ router.get("/agreement", CheckLogin, controller.GetAgreementText);
 router.post("/agreement", CheckLogin, controller.AcceptAgreement);
 router.get("/", CheckAdminLogin, controller.GetStatus);
 
+// Onboard flow (Slice 4). Start = Revenue Head (leads:onboard); state = client.
+router.post(
+  "/start",
+  CheckAdminLogin,
+  requirePermission("leads:onboard:own"),
+  controller.StartOnboarding
+);
+router.get("/state", CheckLogin, controller.ClientState);
+
 module.exports = router;

--- a/routes/onboarding.js
+++ b/routes/onboarding.js
@@ -1,0 +1,19 @@
+const express = require("express");
+const router = express.Router();
+
+const controller = require("../controllers/onboarding");
+const { CheckAdminLogin } = require("../middlewares/auth");
+const { requirePermission } = require("../middlewares/requirePermission");
+
+// Milestone settings (Slice 2). GET readable by any admin (operational);
+// PUT founder-gated via settings_onboarding:edit:all.
+router.get("/milestones", CheckAdminLogin, controller.GetMilestones);
+router.get("/milestones/preview", CheckAdminLogin, controller.PreviewMilestones);
+router.put(
+  "/milestones",
+  CheckAdminLogin,
+  requirePermission("settings_onboarding:edit:all"),
+  controller.PutMilestones
+);
+
+module.exports = router;

--- a/routes/router.js
+++ b/routes/router.js
@@ -86,5 +86,6 @@ router.use("/calendar", require("./calendar")); // Team calendar + meeting mode 
 router.use("/admin-notifications", require("./notifications")); // in-OS staff notifications (MB5)
 router.use("/google", require("./google")); // Google Workspace (MB6 Slice 8 — dormant until env-wired)
 router.use("/saved-views", require("./savedViews")); // per-user leads filter sets (MB6 Slice 9)
+router.use("/onboarding", require("./onboarding")); // onboarding & money engine (MB7a)
 
 module.exports = router;

--- a/scripts/mb7a-migrate-roleids.js
+++ b/scripts/mb7a-migrate-roleids.js
@@ -1,0 +1,38 @@
+/* MB7a RBAC v2 migration — default each admin's single roleId into roleIds[].
+ *
+ * Idempotent + additive: only admins with a roleId and an empty roleIds[] are
+ * touched (roleIds set to [roleId]); roleId is left intact for back-compat.
+ * Re-running finds nothing to do. Dry-run by default; --confirm applies.
+ * Usage: node scripts/mb7a-migrate-roleids.js [--confirm]   (NOT run against prod here)
+ */
+require("dotenv").config();
+const mongoose = require("mongoose");
+
+const CONFIRM = process.argv.includes("--confirm");
+
+(async () => {
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Admin = require("../models/Admin");
+
+  const pending = await Admin.find(
+    { roleId: { $ne: null }, $or: [{ roleIds: { $exists: false } }, { roleIds: { $size: 0 } }] },
+    { _id: 1, name: 1, roleId: 1 }
+  ).lean();
+
+  console.log(`admins needing roleIds backfill: ${pending.length}`);
+  for (const a of pending) {
+    console.log(`+ ${a.name}: roleIds = [${a.roleId}]`);
+    if (CONFIRM) {
+      await Admin.updateOne({ _id: a._id }, { $set: { roleIds: [a.roleId] } });
+    }
+  }
+  console.log(
+    pending.length === 0
+      ? "\nNothing to do — every roled admin already has roleIds[]."
+      : CONFIRM
+        ? `\nBackfilled ${pending.length} admin(s).`
+        : `\nDRY RUN — ${pending.length} admin(s) pending. Re-run with --confirm.`
+  );
+  await mongoose.disconnect();
+  process.exit(0);
+})();

--- a/scripts/mb7a-seed-permissions.js
+++ b/scripts/mb7a-seed-permissions.js
@@ -1,0 +1,58 @@
+/* MB7a permission seed-diff (idempotent, append-only).
+ *
+ * Grants:
+ *   settings_onboarding:edit:all → CRM Admin           (milestone settings, Slice 2)
+ *   leads:onboard:all            → Revenue Head         (the Onboard button, Slice 4)
+ *   projects:view:all            → Client Servicing Manager  (CS dashboard onboarded list, Slice 7)
+ *   projects:view:team           → Client Servicing Executive
+ * Founder holds *:*:all, so it already covers every grant.
+ *
+ * Dry-run by default; --confirm applies. Prints a per-role diff either way.
+ * Usage: node scripts/mb7a-seed-permissions.js [--confirm]   (NOT run against prod here)
+ */
+require("dotenv").config();
+const mongoose = require("mongoose");
+
+const CONFIRM = process.argv.includes("--confirm");
+
+const GRANTS = [
+  { roles: ["CRM Admin"], permission: "settings_onboarding:edit:all" },
+  { roles: ["Revenue Head"], permission: "leads:onboard:all" },
+  { roles: ["Client Servicing Manager"], permission: "projects:view:all" },
+  { roles: ["Client Servicing Executive"], permission: "projects:view:team" },
+];
+
+(async () => {
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Role = require("../models/Role");
+
+  let changes = 0;
+  for (const grant of GRANTS) {
+    for (const roleName of grant.roles) {
+      const role = await Role.findOne({ name: roleName, deletedAt: null });
+      if (!role) {
+        console.log(`- ${roleName}: NOT FOUND (skipped)`);
+        continue;
+      }
+      if ((role.permissions || []).includes(grant.permission)) {
+        console.log(`= ${roleName}: already has ${grant.permission}`);
+        continue;
+      }
+      changes++;
+      console.log(`+ ${roleName}: grant ${grant.permission}`);
+      if (CONFIRM) {
+        role.permissions.push(grant.permission);
+        await role.save();
+      }
+    }
+  }
+  console.log(
+    changes === 0
+      ? "\nNothing to do."
+      : CONFIRM
+        ? `\nApplied ${changes} grant(s).`
+        : `\nDRY RUN — ${changes} grant(s) pending. Re-run with --confirm.`
+  );
+  await mongoose.disconnect();
+  process.exit(0);
+})();

--- a/scripts/verify-mb7a-s1.js
+++ b/scripts/verify-mb7a-s1.js
@@ -1,0 +1,102 @@
+/* MB7a Slice 1 — finalise gate: max-3-drafts, two-key (client finalise → wedsy
+ * approve → payment unlocks), journey events with actors. Boots the server on a
+ * TEST port; no external APIs. Cleans up. Run: node scripts/verify-mb7a-s1.js
+ */
+require("dotenv").config();
+const { spawn } = require("child_process");
+const mongoose = require("mongoose");
+const jwt = require("jsonwebtoken");
+
+const PORT = 8136;
+const BASE = `http://localhost:${PORT}`;
+const MARK = "MB7A-S1";
+
+let pass = 0, fail = 0; const failures = [];
+const ok = (c, l) => { if (c) { pass++; console.log(`  ✓ ${l}`); } else { fail++; failures.push(l); console.error(`  ✗ ${l}`); } };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const waitFor = async (fn, l, t = 30000) => { const u = Date.now() + t; while (Date.now() < u) { try { const v = await fn(); if (v) return v; } catch (_) {} await sleep(300); } throw new Error(`waitFor timed out: ${l}`); };
+
+(async () => {
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Event = require("../models/Event");
+  const User = require("../models/User");
+  const Enquiry = require("../models/Enquiry");
+  const Admin = require("../models/Admin");
+  const Role = require("../models/Role");
+  const Department = require("../models/Department");
+  const LeadInternalEvent = require("../models/LeadInternalEvent");
+  const Payment = require("../models/Payment");
+  const OnboardingService = require("../services/OnboardingService");
+
+  // Unique per-run phone (the resolver matches lead↔event by phone; a fixed
+  // phone could collide with debris if a prior run crashed before cleanup).
+  const PHONE = `9195${String(Date.now()).slice(-8)}`;
+  const user = await User.create({ name: "Onboard Couple", phone: PHONE });
+  const lead = await Enquiry.create({ name: "Onboard Couple", phone: PHONE, verified: false, source: "Website", stage: "meeting_scheduled", additionalInfo: {} });
+  const dept = await Department.create({ name: `${MARK} Dept` });
+  const adminRole = await Role.create({ name: `${MARK} Admin`, departmentId: dept._id, permissions: ["*:*:all"] });
+  const admin = await Admin.create({ name: `${MARK} Admin`, email: `s1-a-${Date.now()}@test.local`, phone: "919500000009", password: "x", roleId: adminRole._id, departmentId: dept._id, status: "active" });
+  const userToken = jwt.sign({ _id: String(user._id) }, process.env.JWT_SECRET);
+  const adminToken = jwt.sign({ _id: String(admin._id), isAdmin: true }, process.env.JWT_SECRET);
+
+  const child = spawn("node", ["server.js"], { cwd: `${__dirname}/..`, env: { ...process.env, PORT: String(PORT), GOOGLE_SHEETS_KEY_PATH: "/nonexistent/s1.json" }, stdio: ["ignore", "pipe", "pipe"] });
+  let log = ""; child.stdout.on("data", (d) => (log += d)); child.stderr.on("data", (d) => (log += d));
+  const api = async (method, path, token, body) => {
+    const res = await fetch(`${BASE}${path}`, { method, headers: { ...(token ? { Authorization: `Bearer ${token}` } : {}), ...(body ? { "Content-Type": "application/json" } : {}) }, body: body ? JSON.stringify(body) : undefined });
+    let data = null; try { data = await res.json(); } catch (_) {}
+    return { status: res.status, data };
+  };
+  const mkEvent = (n) => api("POST", "/event", userToken, { name: `Draft ${n}`, community: "Hindu", eventDay: "Wedding", date: "2026-12-12", time: "18:00", venue: "TBD" });
+  const eventIds = [];
+
+  try {
+    await waitFor(() => fetch(`${BASE}/`).then((r) => r.ok).catch(() => false), "boot");
+
+    console.log("\n── Max-3-drafts cap ──");
+    for (let i = 1; i <= 3; i++) { const r = await mkEvent(i); ok(r.status === 200, `draft ${i} created`); if (r.data?._id) eventIds.push(r.data._id); }
+    const fourth = await mkEvent(4);
+    ok(fourth.status === 409, `4th draft blocked (got ${fourth.status})`);
+    ok((await Event.countDocuments({ user: user._id })) === 3, "only 3 drafts exist");
+
+    console.log("\n── Two-key gate ──");
+    const ev = eventIds[0];
+    // Payment before finalise/approve → locked.
+    const payLocked = await api("POST", "/payment", adminToken, { paymentFor: "event", event: ev, paymentMethod: "cash", amount: 1000, user: String(user._id) });
+    ok(payLocked.status === 422, `payment locked before finalise/approve (got ${payLocked.status})`);
+
+    const fin = await api("POST", `/event/${ev}/finalize`, userToken);
+    ok(fin.status === 200, "client finalise → 200");
+    ok(!!(await waitFor(async () => LeadInternalEvent.findOne({ leadId: lead._id, type: "client_finalised" }).lean(), "client_finalised journey")), "journey client_finalised recorded");
+
+    // Still locked after finalise alone (needs approve too).
+    const payHalf = await api("POST", "/payment", adminToken, { paymentFor: "event", event: ev, paymentMethod: "cash", amount: 1000, user: String(user._id) });
+    ok(payHalf.status === 422, "payment still locked after finalise only (one key)");
+
+    const appr = await api("POST", `/event/${ev}/approve`, adminToken, { discount: 0 });
+    ok(appr.status === 200, "wedsy approve → 200");
+    const wevent = await waitFor(async () => LeadInternalEvent.findOne({ leadId: lead._id, type: "wedsy_approved" }).lean(), "wedsy_approved journey");
+    ok(!!wevent && String(wevent.actorId) === String(admin._id), "journey wedsy_approved recorded with admin actor");
+
+    console.log("\n── Payment unlocked after both keys ──");
+    // The gate boundary: after both keys, paymentUnlocked is true (the full
+    // offline/online payment flow is exercised in Slice 5).
+    const evDoc = await Event.findById(ev, { status: 1 }).lean();
+    ok(OnboardingService.paymentUnlocked(evDoc), "paymentUnlocked(event) true after finalise+approve");
+    ok(evDoc.status.finalized && evDoc.status.approved, "event is finalized + approved");
+  } catch (e) {
+    fail++; failures.push(`fatal: ${e.message}`); console.error("FATAL", e); console.error("log tail:", log.slice(-1500));
+  } finally {
+    await Event.deleteMany({ user: user._id });
+    await Payment.deleteMany({ user: user._id });
+    await LeadInternalEvent.deleteMany({ leadId: lead._id });
+    await Enquiry.deleteMany({ _id: lead._id });
+    await User.deleteMany({ _id: user._id });
+    await Admin.deleteMany({ _id: admin._id });
+    await Role.deleteMany({ _id: adminRole._id });
+    await Department.deleteMany({ _id: dept._id });
+    child.kill(); await mongoose.disconnect();
+    console.log(`\n══ RESULT: ${pass} passed, ${fail} failed ══`);
+    if (failures.length) console.log("failures:", failures.join(" | "));
+    process.exit(fail === 0 ? 0 : 1);
+  }
+})();

--- a/scripts/verify-mb7a-s2.js
+++ b/scripts/verify-mb7a-s2.js
@@ -1,0 +1,73 @@
+/* MB7a Slice 2 — milestone settings (/config OnboardingMilestones) + math + RBAC.
+ * Test port 8137. Cleans up. Run: node scripts/verify-mb7a-s2.js
+ */
+require("dotenv").config();
+const { spawn } = require("child_process");
+const mongoose = require("mongoose");
+const jwt = require("jsonwebtoken");
+
+const PORT = 8137; const BASE = `http://localhost:${PORT}`; const MARK = "MB7A-S2";
+let pass = 0, fail = 0; const failures = [];
+const ok = (c, l) => { if (c) { pass++; console.log(`  ✓ ${l}`); } else { fail++; failures.push(l); console.error(`  ✗ ${l}`); } };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const waitFor = async (fn, l, t = 30000) => { const u = Date.now() + t; while (Date.now() < u) { try { if (await fn()) return; } catch (_) {} await sleep(300); } throw new Error(`waitFor: ${l}`); };
+
+(async () => {
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Admin = require("../models/Admin"); const Role = require("../models/Role"); const Department = require("../models/Department"); const Config = require("../models/Config");
+  const dept = await Department.create({ name: `${MARK} Dept` });
+  const founderRole = await Role.create({ name: `${MARK} Founder`, departmentId: dept._id, permissions: ["settings_onboarding:edit:all"] });
+  const internRole = await Role.create({ name: `${MARK} Intern`, departmentId: dept._id, permissions: ["leads:view:own"] });
+  const founder = await Admin.create({ name: `${MARK} F`, email: `s2-f-${Date.now()}@test.local`, phone: "919600000001", password: "x", roleId: founderRole._id, departmentId: dept._id, status: "active" });
+  const intern = await Admin.create({ name: `${MARK} I`, email: `s2-i-${Date.now()}@test.local`, phone: "919600000002", password: "x", roleId: internRole._id, departmentId: dept._id, status: "active" });
+  const fTok = jwt.sign({ _id: String(founder._id), isAdmin: true }, process.env.JWT_SECRET);
+  const iTok = jwt.sign({ _id: String(intern._id), isAdmin: true }, process.env.JWT_SECRET);
+  const cfgBefore = await Config.findOne({ code: "OnboardingMilestones" }).lean();
+
+  const child = spawn("node", ["server.js"], { cwd: `${__dirname}/..`, env: { ...process.env, PORT: String(PORT), GOOGLE_SHEETS_KEY_PATH: "/nonexistent/s2.json" }, stdio: ["ignore", "pipe", "pipe"] });
+  let log = ""; child.stdout.on("data", (d) => (log += d)); child.stderr.on("data", (d) => (log += d));
+  const api = async (m, p, t, b) => { const r = await fetch(`${BASE}${p}`, { method: m, headers: { ...(t ? { Authorization: `Bearer ${t}` } : {}), ...(b ? { "Content-Type": "application/json" } : {}) }, body: b ? JSON.stringify(b) : undefined }); let d = null; try { d = await r.json(); } catch (_) {} return { status: r.status, data: d }; };
+
+  try {
+    await waitFor(() => fetch(`${BASE}/`).then((r) => r.ok).catch(() => false), "boot");
+
+    console.log("\n── Defaults + units ──");
+    // Remove any stored row so defaults apply in this run.
+    await Config.deleteMany({ code: "OnboardingMilestones" });
+    const def = await api("GET", "/onboarding/milestones", iTok);
+    ok(def.status === 200 && def.data.onboardingFee === 25000 && def.data.advancePercent === 25 && def.data.balanceDaysBeforeEvent === 14, "defaults: fee 25000, advance 25%, balance 14d");
+
+    console.log("\n── Math (preview) ──");
+    const prev = await api("GET", "/onboarding/milestones/preview?total=1000000", iTok);
+    // advance = 25% of 10L = 250000; onboardingFee 25000 counts toward it →
+    // advanceRemaining 225000; balance = 750000. Units rupees.
+    ok(prev.data.advance === 250000 && prev.data.onboardingFee === 25000 && prev.data.advanceRemaining === 225000 && prev.data.balance === 750000, `math correct (adv ${prev.data.advance}, rem ${prev.data.advanceRemaining}, bal ${prev.data.balance})`);
+    ok(prev.data.unit === "rupees" && prev.data.currency === "INR", "amounts are rupees/INR");
+
+    console.log("\n── RBAC on PUT ──");
+    const denied = await api("PUT", "/onboarding/milestones", iTok, { onboardingFee: 30000, advancePercent: 30, balanceDaysBeforeEvent: 10 });
+    ok(denied.status === 403, "admin without settings_onboarding → 403");
+    const bad = await api("PUT", "/onboarding/milestones", fTok, { onboardingFee: 30000, advancePercent: 500, balanceDaysBeforeEvent: 10 });
+    ok(bad.status === 400, "invalid advancePercent (500) → 400");
+
+    console.log("\n── PUT + persistence ──");
+    const put = await api("PUT", "/onboarding/milestones", fTok, { onboardingFee: 30000, advancePercent: 30, balanceDaysBeforeEvent: 10 });
+    ok(put.status === 200, "founder PUT → 200");
+    const after = await api("GET", "/onboarding/milestones", iTok);
+    ok(after.data.onboardingFee === 30000 && after.data.advancePercent === 30 && after.data.balanceDaysBeforeEvent === 10, "GET reflects the saved values");
+    const row = await Config.findOne({ code: "OnboardingMilestones" }).lean();
+    ok(!!row && row.data.advancePercent === 30, "stored in Config under OnboardingMilestones");
+  } catch (e) {
+    fail++; failures.push(`fatal: ${e.message}`); console.error("FATAL", e); console.error(log.slice(-1200));
+  } finally {
+    await Config.deleteMany({ code: "OnboardingMilestones" });
+    if (cfgBefore) await Config.create({ code: cfgBefore.code, data: cfgBefore.data });
+    await Admin.deleteMany({ _id: { $in: [founder._id, intern._id] } });
+    await Role.deleteMany({ _id: { $in: [founderRole._id, internRole._id] } });
+    await Department.deleteMany({ _id: dept._id });
+    child.kill(); await mongoose.disconnect();
+    console.log(`\n══ RESULT: ${pass} passed, ${fail} failed ══`);
+    if (failures.length) console.log("failures:", failures.join(" | "));
+    process.exit(fail === 0 ? 0 : 1);
+  }
+})();

--- a/scripts/verify-mb7a-s3.js
+++ b/scripts/verify-mb7a-s3.js
@@ -1,0 +1,84 @@
+/* MB7a Slice 3 — e-sign agreement: settings text → /settings/public → accept →
+ * stored + journey → mail seam dormant. Test port 8138. Cleans up.
+ */
+require("dotenv").config();
+const { spawn } = require("child_process");
+const mongoose = require("mongoose");
+const jwt = require("jsonwebtoken");
+
+const PORT = 8138; const BASE = `http://localhost:${PORT}`; const MARK = "MB7A-S3";
+let pass = 0, fail = 0; const failures = [];
+const ok = (c, l) => { if (c) { pass++; console.log(`  ✓ ${l}`); } else { fail++; failures.push(l); console.error(`  ✗ ${l}`); } };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const waitFor = async (fn, l, t = 30000) => { const u = Date.now() + t; while (Date.now() < u) { try { const v = await fn(); if (v) return v; } catch (_) {} await sleep(300); } throw new Error(`waitFor: ${l}`); };
+
+(async () => {
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Admin = require("../models/Admin"); const Role = require("../models/Role"); const Department = require("../models/Department");
+  const User = require("../models/User"); const Enquiry = require("../models/Enquiry");
+  const Onboarding = require("../models/Onboarding"); const LeadInternalEvent = require("../models/LeadInternalEvent"); const Setting = require("../models/Setting");
+  const MailSvc = require("../services/OnboardingMailService");
+
+  const PHONE = `9197${String(Date.now()).slice(-8)}`;
+  const dept = await Department.create({ name: `${MARK} Dept` });
+  const founderRole = await Role.create({ name: `${MARK} Founder`, departmentId: dept._id, permissions: ["settings_agreement:edit:all"] });
+  const founder = await Admin.create({ name: `${MARK} F`, email: `s3-f-${Date.now()}@test.local`, phone: "919700000001", password: "x", roleId: founderRole._id, departmentId: dept._id, status: "active" });
+  const user = await User.create({ name: "S3 Couple", phone: PHONE });
+  const lead = await Enquiry.create({ name: "S3 Couple", phone: PHONE, verified: false, source: "Website", stage: "meeting_scheduled", additionalInfo: {} });
+  const fTok = jwt.sign({ _id: String(founder._id), isAdmin: true }, process.env.JWT_SECRET);
+  const uTok = jwt.sign({ _id: String(user._id) }, process.env.JWT_SECRET);
+  const settingsBefore = await Setting.find({ key: { $in: ["agreement.terms", "agreement.version"] } }).lean();
+
+  const child = spawn("node", ["server.js"], { cwd: `${__dirname}/..`, env: { ...process.env, PORT: String(PORT), GOOGLE_SHEETS_KEY_PATH: "/nonexistent/s3.json", MAILJET_API_KEY: "", MAILJET_SECRET_KEY: "" }, stdio: ["ignore", "pipe", "pipe"] });
+  let log = ""; child.stdout.on("data", (d) => (log += d)); child.stderr.on("data", (d) => (log += d));
+  const api = async (m, p, t, b) => { const r = await fetch(`${BASE}${p}`, { method: m, headers: { ...(t ? { Authorization: `Bearer ${t}` } : {}), ...(b ? { "Content-Type": "application/json" } : {}) }, body: b ? JSON.stringify(b) : undefined }); let d = null; try { d = await r.json(); } catch (_) {} return { status: r.status, data: d }; };
+
+  try {
+    await waitFor(() => fetch(`${BASE}/`).then((r) => r.ok).catch(() => false), "boot");
+
+    console.log("\n── Agreement text in Settings + client-readable ──");
+    const pub0 = await api("GET", "/onboarding/agreement", uTok); // CLIENT token
+    ok(typeof pub0.data.terms === "string" && pub0.data.terms.includes("PLACEHOLDER"), "client reads default placeholder terms via /onboarding/agreement");
+    ok(pub0.data.version === "v1", "default agreement.version v1");
+    const edit = await api("PUT", "/settings", fTok, { key: "agreement.terms", value: "Wedsy terms v-test: pay milestones, etc." });
+    ok(edit.status === 200, "founder edits agreement.terms (settings_agreement gate)");
+    await api("PUT", "/settings", fTok, { key: "agreement.version", value: "v2" });
+    const pub1 = await api("GET", "/onboarding/agreement", uTok);
+    ok(pub1.data.terms.includes("v-test") && pub1.data.version === "v2", "edited terms + version surface to the client");
+
+    console.log("\n── Accept → stored + journey ──");
+    const noName = await api("POST", "/onboarding/agreement", uTok, { leadId: String(lead._id) });
+    ok(noName.status === 400, "accept without acceptedName → 400");
+    const acc = await api("POST", "/onboarding/agreement", uTok, { leadId: String(lead._id), acceptedName: "Aarav Sharma" });
+    ok(acc.status === 200 && acc.data.agreement.accepted === true, "client accepts → accepted true");
+    ok(acc.data.agreement.agreementVersion === "v2", "acceptance stamps current version (v2)");
+    const ob = await Onboarding.findOne({ leadId: lead._id }).lean();
+    ok(!!ob && ob.agreement.acceptedName === "Aarav Sharma" && ob.agreement.acceptedAt, "acceptance stored on the onboarding record");
+    ok(!!(await waitFor(async () => LeadInternalEvent.findOne({ leadId: lead._id, type: "agreement_signed" }).lean(), "agreement_signed")), "journey agreement_signed recorded");
+    const status = await api("GET", `/onboarding?leadId=${lead._id}`, fTok);
+    ok(status.data.onboarding && status.data.onboarding.agreement.accepted === true, "OS status reflects acceptance");
+
+    console.log("\n── Mail seam dormant (MAILJET unset) ──");
+    // Force-unset in THIS process so we exercise the dormant path (and never
+    // send a real email). The seam reads env at call time.
+    const savedKey = process.env.MAILJET_API_KEY, savedSecret = process.env.MAILJET_SECRET_KEY;
+    delete process.env.MAILJET_API_KEY; delete process.env.MAILJET_SECRET_KEY;
+    const mail = await MailSvc.sendAgreementEmail({ to: "couple@example.com", name: "Aarav", termsText: "x", version: "v2" });
+    if (savedKey !== undefined) process.env.MAILJET_API_KEY = savedKey;
+    if (savedSecret !== undefined) process.env.MAILJET_SECRET_KEY = savedSecret;
+    ok(mail.sent === false && mail.reason === "dormant", "agreement email seam is dormant + logs when Mailjet unset (no throw)");
+  } catch (e) {
+    fail++; failures.push(`fatal: ${e.message}`); console.error("FATAL", e); console.error(log.slice(-1200));
+  } finally {
+    await Onboarding.deleteMany({ leadId: lead._id });
+    await LeadInternalEvent.deleteMany({ leadId: lead._id });
+    await Enquiry.deleteMany({ _id: lead._id }); await User.deleteMany({ _id: user._id });
+    await Admin.deleteMany({ _id: founder._id }); await Role.deleteMany({ _id: founderRole._id }); await Department.deleteMany({ _id: dept._id });
+    await Setting.deleteMany({ key: { $in: ["agreement.terms", "agreement.version"] } });
+    if (settingsBefore.length) await Setting.insertMany(settingsBefore.map(({ _id, ...r }) => r));
+    child.kill(); await mongoose.disconnect();
+    console.log(`\n══ RESULT: ${pass} passed, ${fail} failed ══`);
+    if (failures.length) console.log("failures:", failures.join(" | "));
+    process.exit(fail === 0 ? 0 : 1);
+  }
+})();

--- a/scripts/verify-mb7a-s4.js
+++ b/scripts/verify-mb7a-s4.js
@@ -1,0 +1,74 @@
+/* MB7a Slice 4 — onboard flow + lock flag + leads:onboard RBAC. Port 8139. */
+require("dotenv").config();
+const { spawn } = require("child_process");
+const mongoose = require("mongoose");
+const jwt = require("jsonwebtoken");
+
+const PORT = 8139; const BASE = `http://localhost:${PORT}`; const MARK = "MB7A-S4";
+let pass = 0, fail = 0; const failures = [];
+const ok = (c, l) => { if (c) { pass++; console.log(`  ✓ ${l}`); } else { fail++; failures.push(l); console.error(`  ✗ ${l}`); } };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const waitFor = async (fn, l, t = 30000) => { const u = Date.now() + t; while (Date.now() < u) { try { const v = await fn(); if (v) return v; } catch (_) {} await sleep(300); } throw new Error(`waitFor: ${l}`); };
+
+(async () => {
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Admin = require("../models/Admin"); const Role = require("../models/Role"); const Department = require("../models/Department");
+  const User = require("../models/User"); const Enquiry = require("../models/Enquiry"); const Event = require("../models/Event");
+  const Onboarding = require("../models/Onboarding"); const LeadInternalEvent = require("../models/LeadInternalEvent");
+
+  const PHONE = `9198${String(Date.now()).slice(-8)}`;
+  const dept = await Department.create({ name: `${MARK} Dept` });
+  const rhRole = await Role.create({ name: `${MARK} RH`, departmentId: dept._id, permissions: ["leads:view:all", "leads:onboard:all"] });
+  const internRole = await Role.create({ name: `${MARK} Intern`, departmentId: dept._id, permissions: ["leads:view:own"] });
+  const rh = await Admin.create({ name: `${MARK} RH`, email: `s4-rh-${Date.now()}@test.local`, phone: "919800000001", password: "x", roleId: rhRole._id, departmentId: dept._id, status: "active" });
+  const intern = await Admin.create({ name: `${MARK} Intern`, email: `s4-in-${Date.now()}@test.local`, phone: "919800000002", password: "x", roleId: internRole._id, departmentId: dept._id, status: "active" });
+  const user = await User.create({ name: "S4 Couple", phone: PHONE });
+  const other = await User.create({ name: "S4 Other", phone: `9198${String(Date.now() + 1).slice(-8)}` });
+  const lead = await Enquiry.create({ name: "S4 Couple", phone: PHONE, verified: false, source: "Website", stage: "meeting_scheduled", additionalInfo: {} });
+  const event = await Event.create({ user: user._id, name: "S4 Wedding", community: "Hindu", eventDate: "2026-12-12", eventDays: [{ name: "W", date: "2026-12-12", time: "18:00", venue: "X" }], amount: { total: 1000000, due: 1000000, paid: 0 }, status: { finalized: true, approved: true } });
+  const rhTok = jwt.sign({ _id: String(rh._id), isAdmin: true }, process.env.JWT_SECRET);
+  const inTok = jwt.sign({ _id: String(intern._id), isAdmin: true }, process.env.JWT_SECRET);
+  const uTok = jwt.sign({ _id: String(user._id) }, process.env.JWT_SECRET);
+  const oTok = jwt.sign({ _id: String(other._id) }, process.env.JWT_SECRET);
+
+  const child = spawn("node", ["server.js"], { cwd: `${__dirname}/..`, env: { ...process.env, PORT: String(PORT), GOOGLE_SHEETS_KEY_PATH: "/nonexistent/s4.json" }, stdio: ["ignore", "pipe", "pipe"] });
+  let log = ""; child.stdout.on("data", (d) => (log += d)); child.stderr.on("data", (d) => (log += d));
+  const api = async (m, p, t, b) => { const r = await fetch(`${BASE}${p}`, { method: m, headers: { ...(t ? { Authorization: `Bearer ${t}` } : {}), ...(b ? { "Content-Type": "application/json" } : {}) }, body: b ? JSON.stringify(b) : undefined }); let d = null; try { d = await r.json(); } catch (_) {} return { status: r.status, data: d }; };
+
+  try {
+    await waitFor(() => fetch(`${BASE}/`).then((r) => r.ok).catch(() => false), "boot");
+
+    console.log("\n── leads:onboard RBAC ──");
+    const denied = await api("POST", "/onboarding/start", inTok, { leadId: String(lead._id), eventId: String(event._id) });
+    ok(denied.status === 403, "intern (no leads:onboard) → 403");
+    ok((await Onboarding.countDocuments({ leadId: lead._id })) === 0, "no onboarding created on denied attempt");
+
+    console.log("\n── Revenue Head onboards ──");
+    const start = await api("POST", "/onboarding/start", rhTok, { leadId: String(lead._id), eventId: String(event._id) });
+    ok(start.status === 200, "Revenue Head start → 200");
+    ok(start.data.onboarding.lockActive === true, "client dashboard lock active");
+    ok(start.data.onboarding.milestones && start.data.onboarding.milestones.advance === 250000, "milestones snapshotted (advance 250000 of 10L)");
+    ok(!!(await waitFor(async () => LeadInternalEvent.findOne({ leadId: lead._id, type: "onboarding_started" }).lean(), "onboarding_started")), "journey onboarding_started recorded");
+
+    console.log("\n── Client lock flag (wedsy-user contract) ──");
+    const st = await api("GET", `/onboarding/state?eventId=${event._id}`, uTok);
+    ok(st.status === 200 && st.data.onboardingLockActive === true && st.data.onboarded === false, "client reads onboardingLockActive true, onboarded false");
+    const foreign = await api("GET", `/onboarding/state?eventId=${event._id}`, oTok);
+    ok(foreign.status === 403, "another user can't read this event's onboarding state (403)");
+
+    console.log("\n── Idempotent restart ──");
+    const start2 = await api("POST", "/onboarding/start", rhTok, { leadId: String(lead._id), eventId: String(event._id) });
+    ok(start2.status === 200 && (await Onboarding.countDocuments({ leadId: lead._id })) === 1, "re-start is idempotent (single record)");
+  } catch (e) {
+    fail++; failures.push(`fatal: ${e.message}`); console.error("FATAL", e); console.error(log.slice(-1200));
+  } finally {
+    await Onboarding.deleteMany({ leadId: lead._id }); await LeadInternalEvent.deleteMany({ leadId: lead._id });
+    await Event.deleteMany({ _id: event._id }); await Enquiry.deleteMany({ _id: lead._id });
+    await User.deleteMany({ _id: { $in: [user._id, other._id] } });
+    await Admin.deleteMany({ _id: { $in: [rh._id, intern._id] } }); await Role.deleteMany({ _id: { $in: [rhRole._id, internRole._id] } }); await Department.deleteMany({ _id: dept._id });
+    child.kill(); await mongoose.disconnect();
+    console.log(`\n══ RESULT: ${pass} passed, ${fail} failed ══`);
+    if (failures.length) console.log("failures:", failures.join(" | "));
+    process.exit(fail === 0 ? 0 : 1);
+  }
+})();

--- a/scripts/verify-mb7a-s5.js
+++ b/scripts/verify-mb7a-s5.js
@@ -1,0 +1,108 @@
+/* MB7a Slice 5 — Razorpay link (dormant), offline-with-proof, ONBOARDED, online
+ * confirm, RBAC, rupee units. RAZORPAY keys unset → no live calls. Test users
+ * have no email → no real mail. Port 8140. Cleans up. */
+require("dotenv").config();
+const { spawn } = require("child_process");
+const mongoose = require("mongoose");
+const jwt = require("jsonwebtoken");
+
+const PORT = 8140; const BASE = `http://localhost:${PORT}`; const MARK = "MB7A-S5";
+let pass = 0, fail = 0; const failures = [];
+const ok = (c, l) => { if (c) { pass++; console.log(`  ✓ ${l}`); } else { fail++; failures.push(l); console.error(`  ✗ ${l}`); } };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const waitFor = async (fn, l, t = 30000) => { const u = Date.now() + t; while (Date.now() < u) { try { const v = await fn(); if (v) return v; } catch (_) {} await sleep(300); } throw new Error(`waitFor: ${l}`); };
+
+(async () => {
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Admin = require("../models/Admin"); const Role = require("../models/Role"); const Department = require("../models/Department");
+  const User = require("../models/User"); const Enquiry = require("../models/Enquiry"); const Event = require("../models/Event");
+  const Onboarding = require("../models/Onboarding"); const LeadInternalEvent = require("../models/LeadInternalEvent"); const Payment = require("../models/Payment");
+
+  const mk = async (suffix) => {
+    const phone = `9199${String(Date.now()).slice(-7)}${suffix}`;
+    const user = await User.create({ name: `S5 ${suffix}`, phone }); // no email → no real mail
+    const lead = await Enquiry.create({ name: `S5 ${suffix}`, phone, verified: false, source: "Website", stage: "meeting_scheduled", additionalInfo: {} });
+    const event = await Event.create({ user: user._id, name: `S5 ${suffix}`, community: "Hindu", eventDate: "2026-12-12", eventDays: [{ name: "W", date: "2026-12-12", time: "18:00", venue: "X" }], amount: { total: 1000000, due: 1000000, paid: 0 }, status: { finalized: true, approved: true } });
+    await Onboarding.create({ leadId: lead._id, eventId: event._id, status: "started", lockActive: true, milestones: { onboardingFee: 25000, advancePercent: 25, advance: 250000, advanceRemaining: 225000, balance: 750000, balanceDaysBeforeEvent: 14, total: 1000000, unit: "rupees", currency: "INR" } });
+    return { user, lead, event };
+  };
+
+  const dept = await Department.create({ name: `${MARK} Dept` });
+  const rhRole = await Role.create({ name: `${MARK} RH`, departmentId: dept._id, permissions: ["leads:onboard:all", "leads:view:all"] });
+  const internRole = await Role.create({ name: `${MARK} Intern`, departmentId: dept._id, permissions: ["leads:view:own"] });
+  const rh = await Admin.create({ name: `${MARK} RH`, email: `s5-rh-${Date.now()}@test.local`, phone: "919900000001", password: "x", roleId: rhRole._id, departmentId: dept._id, status: "active" });
+  const intern = await Admin.create({ name: `${MARK} In`, email: `s5-in-${Date.now()}@test.local`, phone: "919900000002", password: "x", roleId: internRole._id, departmentId: dept._id, status: "active" });
+  const rhTok = jwt.sign({ _id: String(rh._id), isAdmin: true }, process.env.JWT_SECRET);
+  const inTok = jwt.sign({ _id: String(intern._id), isAdmin: true }, process.env.JWT_SECRET);
+  const A = await mk("a"); const B = await mk("b"); const C = await mk("c");
+
+  const child = spawn("node", ["server.js"], { cwd: `${__dirname}/..`, env: { ...process.env, PORT: String(PORT), GOOGLE_SHEETS_KEY_PATH: "/nonexistent/s5.json", RAZORPAY_KEY_ID: "", RAZORPAY_KEY_SECRET: "" }, stdio: ["ignore", "pipe", "pipe"] });
+  let log = ""; child.stdout.on("data", (d) => (log += d)); child.stderr.on("data", (d) => (log += d));
+  const api = async (m, p, t, b) => { const r = await fetch(`${BASE}${p}`, { method: m, headers: { ...(t ? { Authorization: `Bearer ${t}` } : {}), ...(b ? { "Content-Type": "application/json" } : {}) }, body: b ? JSON.stringify(b) : undefined }); let d = null; try { d = await r.json(); } catch (_) {} return { status: r.status, data: d }; };
+  const cleanupLeads = [A.lead._id, B.lead._id, C.lead._id];
+
+  try {
+    await waitFor(() => fetch(`${BASE}/`).then((r) => r.ok).catch(() => false), "boot");
+
+    console.log("\n── Razorpay link DORMANT (keys unset) ──");
+    const link = await api("POST", "/onboarding/payment-link", rhTok, { leadId: String(A.lead._id), eventId: String(A.event._id), milestone: "onboarding" });
+    ok(link.status === 200 && link.data.dormant === true && link.data.mode === "dormant", "payment-link dormant when keys unset (no live call)");
+    ok(link.data.amountRupees === 25000 && link.data.amountPaise === 2500000, "onboarding link amount = ₹25000 (2,500,000 paise)");
+    const linkPay = await Payment.findById(link.data.paymentId).lean();
+    ok(linkPay && linkPay.milestone === "onboarding" && linkPay.amount === 2500000 && linkPay.status === "created", "payment row created (milestone, paise, status)");
+
+    console.log("\n── RBAC ──");
+    const denied = await api("POST", "/onboarding/payment-link", inTok, { leadId: String(A.lead._id), eventId: String(A.event._id), milestone: "onboarding" });
+    ok(denied.status === 403, "intern (no leads:onboard) → 403 on payment-link");
+
+    console.log("\n── Offline-with-proof + mandatory screenshot ──");
+    const noProof = await api("POST", "/onboarding/payment/offline", rhTok, { leadId: String(A.lead._id), eventId: String(A.event._id), milestone: "onboarding", amountRupees: 25000, method: "bank-transfer" });
+    ok(noProof.status === 422, "bank-transfer without proof → 422 (screenshot mandatory)");
+    const cashNoProof = await api("POST", "/onboarding/payment/offline", rhTok, { leadId: String(A.lead._id), eventId: String(A.event._id), milestone: "advance", amountRupees: 225000, method: "cash" });
+    ok(cashNoProof.status === 200, "cash without proof → 200 (optional for cash)");
+
+    console.log("\n── Onboarding fee offline (with proof) → ONBOARDED ──");
+    const paid = await api("POST", "/onboarding/payment/offline", rhTok, { leadId: String(A.lead._id), eventId: String(A.event._id), milestone: "onboarding", amountRupees: 25000, method: "bank-transfer", txnId: "TXN123", proofUrl: "https://s3.example.com/proof.jpg", notes: "NEFT" });
+    ok(paid.status === 200 && paid.data.amountPaise === 2500000, "onboarding payment recorded (rupees→paise)");
+    const payDoc = await Payment.findById(paid.data.paymentId).lean();
+    ok(payDoc.status === "paid" && payDoc.proof.url === "https://s3.example.com/proof.jpg" && payDoc.proof.txnId === "TXN123", "proof image + txnId stored");
+    const obA = await waitFor(async () => { const o = await Onboarding.findOne({ leadId: A.lead._id }).lean(); return o && o.status === "onboarded" ? o : null; }, "onboarded");
+    ok(obA.status === "onboarded" && obA.lockActive === false && obA.onboardedAt, "ONBOARDED: status onboarded, lock cleared, stamped");
+    ok(!!(await LeadInternalEvent.findOne({ leadId: A.lead._id, type: "onboarded" }).lean()), "journey onboarded recorded");
+    ok(!!(await LeadInternalEvent.findOne({ leadId: A.lead._id, type: "onboarding_payment_recorded" }).lean()), "journey onboarding_payment_recorded");
+    const stA = await api("GET", `/onboarding/state?eventId=${A.event._id}`, jwt.sign({ _id: String(A.user._id) }, process.env.JWT_SECRET));
+    ok(stA.data.onboarded === true && stA.data.onboardingLockActive === false, "client state: onboarded true, lock cleared");
+
+    console.log("\n── Online confirm seam → ONBOARDED (lead B) ──");
+    const linkB = await api("POST", "/onboarding/payment-link", rhTok, { leadId: String(B.lead._id), eventId: String(B.event._id), milestone: "onboarding" });
+    const conf = await api("POST", `/onboarding/payment/${linkB.data.paymentId}/confirm`, rhTok);
+    ok(conf.status === 200, "confirm online payment → 200");
+    const obB = await waitFor(async () => { const o = await Onboarding.findOne({ leadId: B.lead._id }).lean(); return o && o.status === "onboarded" ? o : null; }, "B onboarded");
+    ok(obB.status === "onboarded", "online onboarding-fee confirm marks ONBOARDED");
+    const payB = await Payment.findById(linkB.data.paymentId).lean();
+    ok(payB.status === "paid", "confirmed payment marked paid");
+
+    console.log("\n── Advance milestone amount (lead C) ──");
+    const advC = await api("POST", "/onboarding/payment/offline", rhTok, { leadId: String(C.lead._id), eventId: String(C.event._id), milestone: "advance", amountRupees: 225000, method: "upi", txnId: "UPI1" });
+    ok(advC.status === 200 && advC.data.amountPaise === 22500000, "advance offline (₹225000 → 22,500,000 paise)");
+    const obC = await Onboarding.findOne({ leadId: C.lead._id }).lean();
+    ok(obC.status === "started", "advance payment does NOT onboard (only onboarding fee does)");
+  } catch (e) {
+    fail++; failures.push(`fatal: ${e.message}`); console.error("FATAL", e); console.error(log.slice(-1500));
+  } finally {
+    const uids = [A.user._id, B.user._id, C.user._id];
+    await Payment.deleteMany({ user: { $in: uids } });
+    await Onboarding.deleteMany({ leadId: { $in: cleanupLeads } });
+    await LeadInternalEvent.deleteMany({ leadId: { $in: cleanupLeads } });
+    await Event.deleteMany({ user: { $in: uids } });
+    await Enquiry.deleteMany({ _id: { $in: cleanupLeads } });
+    await User.deleteMany({ _id: { $in: uids } });
+    await Admin.deleteMany({ _id: { $in: [rh._id, intern._id] } });
+    await Role.deleteMany({ _id: { $in: [rhRole._id, internRole._id] } });
+    await Department.deleteMany({ _id: dept._id });
+    child.kill(); await mongoose.disconnect();
+    console.log(`\n══ RESULT: ${pass} passed, ${fail} failed ══`);
+    if (failures.length) console.log("failures:", failures.join(" | "));
+    process.exit(fail === 0 ? 0 : 1);
+  }
+})();

--- a/scripts/verify-mb7a-s6.js
+++ b/scripts/verify-mb7a-s6.js
@@ -1,0 +1,61 @@
+/* MB7a Slice 6 — auto-invoice on payment record + client-downloadable PDF.
+ * Port 8141. Cleans up. */
+require("dotenv").config();
+const { spawn } = require("child_process");
+const mongoose = require("mongoose");
+const jwt = require("jsonwebtoken");
+
+const PORT = 8141; const BASE = `http://localhost:${PORT}`; const MARK = "MB7A-S6";
+let pass = 0, fail = 0; const failures = [];
+const ok = (c, l) => { if (c) { pass++; console.log(`  ✓ ${l}`); } else { fail++; failures.push(l); console.error(`  ✗ ${l}`); } };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const waitFor = async (fn, l, t = 30000) => { const u = Date.now() + t; while (Date.now() < u) { try { const v = await fn(); if (v) return v; } catch (_) {} await sleep(300); } throw new Error(`waitFor: ${l}`); };
+
+(async () => {
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Admin = require("../models/Admin"); const Role = require("../models/Role"); const Department = require("../models/Department");
+  const User = require("../models/User"); const Enquiry = require("../models/Enquiry"); const Event = require("../models/Event");
+  const Onboarding = require("../models/Onboarding"); const LeadInternalEvent = require("../models/LeadInternalEvent"); const Payment = require("../models/Payment");
+
+  const PHONE = `9196${String(Date.now()).slice(-8)}`;
+  const dept = await Department.create({ name: `${MARK} Dept` });
+  const rhRole = await Role.create({ name: `${MARK} RH`, departmentId: dept._id, permissions: ["leads:onboard:all", "leads:view:all"] });
+  const rh = await Admin.create({ name: `${MARK} RH`, email: `s6-rh-${Date.now()}@test.local`, phone: "919600000001", password: "x", roleId: rhRole._id, departmentId: dept._id, status: "active" });
+  const user = await User.create({ name: "S6 Couple", phone: PHONE });
+  const lead = await Enquiry.create({ name: "S6 Couple", phone: PHONE, verified: false, source: "Website", stage: "meeting_scheduled", additionalInfo: {} });
+  const event = await Event.create({ user: user._id, name: "S6 Wedding", community: "Hindu", eventDate: "2026-12-12", eventDays: [{ name: "W", date: "2026-12-12", time: "18:00", venue: "X", decorItems: [], packages: [], customItems: [], mandatoryItems: [] }], amount: { total: 1000000, due: 1000000, paid: 0 }, status: { finalized: true, approved: true } });
+  await Onboarding.create({ leadId: lead._id, eventId: event._id, status: "started", lockActive: true, milestones: { onboardingFee: 25000, advancePercent: 25, advance: 250000, advanceRemaining: 225000, balance: 750000, balanceDaysBeforeEvent: 14, total: 1000000, unit: "rupees", currency: "INR" } });
+  const rhTok = jwt.sign({ _id: String(rh._id), isAdmin: true }, process.env.JWT_SECRET);
+  const uTok = jwt.sign({ _id: String(user._id) }, process.env.JWT_SECRET);
+
+  const child = spawn("node", ["server.js"], { cwd: `${__dirname}/..`, env: { ...process.env, PORT: String(PORT), GOOGLE_SHEETS_KEY_PATH: "/nonexistent/s6.json", RAZORPAY_KEY_ID: "", RAZORPAY_KEY_SECRET: "" }, stdio: ["ignore", "pipe", "pipe"] });
+  let log = ""; child.stdout.on("data", (d) => (log += d)); child.stderr.on("data", (d) => (log += d));
+  const api = async (m, p, t, b) => { const r = await fetch(`${BASE}${p}`, { method: m, headers: { ...(t ? { Authorization: `Bearer ${t}` } : {}), ...(b ? { "Content-Type": "application/json" } : {}) }, body: b ? JSON.stringify(b) : undefined }); let d = null; try { d = await r.json(); } catch (_) {} return { status: r.status, data: d }; };
+
+  try {
+    await waitFor(() => fetch(`${BASE}/`).then((r) => r.ok).catch(() => false), "boot");
+
+    console.log("\n── Auto-invoice on payment record ──");
+    const paid = await api("POST", "/onboarding/payment/offline", rhTok, { leadId: String(lead._id), eventId: String(event._id), milestone: "advance", amountRupees: 225000, method: "bank-transfer", txnId: "T6", proofUrl: "https://s3.example.com/p6.jpg" });
+    ok(paid.status === 200 && paid.data.invoicePath === `/payment/${paid.data.paymentId}/invoice`, "record returns invoicePath (auto-trigger)");
+    const payDoc = await Payment.findById(paid.data.paymentId).lean();
+    ok(!!payDoc.invoiceReadyAt, "invoiceReadyAt stamped on the payment");
+
+    console.log("\n── Client downloads the invoice PDF ──");
+    const res = await fetch(`${BASE}/payment/${paid.data.paymentId}/invoice`, { headers: { Authorization: `Bearer ${uTok}` } });
+    const ct = res.headers.get("content-type") || "";
+    const buf = Buffer.from(await res.arrayBuffer());
+    ok(res.status === 200 && ct.includes("application/pdf"), `GET /payment/:id/invoice → 200 application/pdf (got ${res.status}, ${ct})`);
+    ok(buf.length > 800 && buf.slice(0, 4).toString() === "%PDF", "response is a real PDF (%PDF header, non-trivial size)");
+  } catch (e) {
+    fail++; failures.push(`fatal: ${e.message}`); console.error("FATAL", e); console.error(log.slice(-1500));
+  } finally {
+    await Payment.deleteMany({ user: user._id }); await Onboarding.deleteMany({ leadId: lead._id }); await LeadInternalEvent.deleteMany({ leadId: lead._id });
+    await Event.deleteMany({ user: user._id }); await Enquiry.deleteMany({ _id: lead._id }); await User.deleteMany({ _id: user._id });
+    await Admin.deleteMany({ _id: rh._id }); await Role.deleteMany({ _id: rhRole._id }); await Department.deleteMany({ _id: dept._id });
+    child.kill(); await mongoose.disconnect();
+    console.log(`\n══ RESULT: ${pass} passed, ${fail} failed ══`);
+    if (failures.length) console.log("failures:", failures.join(" | "));
+    process.exit(fail === 0 ? 0 : 1);
+  }
+})();

--- a/scripts/verify-mb7a-s7.js
+++ b/scripts/verify-mb7a-s7.js
@@ -1,0 +1,101 @@
+/* MB7a Slice 7 — RBAC v2 roleIds[] permission UNION (+ back-compat + migration
+ * idempotency) and the CS onboarded-clients dashboard + CSV. Port 8142. */
+require("dotenv").config();
+const { spawn } = require("child_process");
+const mongoose = require("mongoose");
+const jwt = require("jsonwebtoken");
+
+const PORT = 8142; const BASE = `http://localhost:${PORT}`; const MARK = "MB7A-S7";
+let pass = 0, fail = 0; const failures = [];
+const ok = (c, l) => { if (c) { pass++; console.log(`  ✓ ${l}`); } else { fail++; failures.push(l); console.error(`  ✗ ${l}`); } };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const waitFor = async (fn, l, t = 30000) => { const u = Date.now() + t; while (Date.now() < u) { try { const v = await fn(); if (v) return v; } catch (_) {} await sleep(300); } throw new Error(`waitFor: ${l}`); };
+
+(async () => {
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Admin = require("../models/Admin"); const Role = require("../models/Role"); const Department = require("../models/Department");
+  const User = require("../models/User"); const Enquiry = require("../models/Enquiry"); const Event = require("../models/Event");
+  const Onboarding = require("../models/Onboarding"); const Project = require("../models/Project"); const Config = require("../models/Config");
+
+  const dept = await Department.create({ name: `${MARK} Dept` });
+  const roleA = await Role.create({ name: `${MARK} A`, departmentId: dept._id, permissions: ["leads:view:all"] });
+  const roleB = await Role.create({ name: `${MARK} B`, departmentId: dept._id, permissions: ["settings_onboarding:edit:all"] });
+  const csRole = await Role.create({ name: `${MARK} CS`, departmentId: dept._id, permissions: ["projects:view:all"] });
+  // M: multi-role (A ∪ B). S: single-role legacy (roleId only, no roleIds). S2: roleIds=[A] only. CS: projects:view:all.
+  const M = await Admin.create({ name: `${MARK} M`, email: `s7-m-${Date.now()}@test.local`, phone: "919500000071", password: "x", roleIds: [roleA._id, roleB._id], departmentId: dept._id, status: "active" });
+  const S = await Admin.create({ name: `${MARK} S`, email: `s7-s-${Date.now()}@test.local`, phone: "919500000072", password: "x", roleId: roleA._id, departmentId: dept._id, status: "active" });
+  const S2 = await Admin.create({ name: `${MARK} S2`, email: `s7-s2-${Date.now()}@test.local`, phone: "919500000073", password: "x", roleIds: [roleA._id], departmentId: dept._id, status: "active" });
+  const CS = await Admin.create({ name: `${MARK} CS`, email: `s7-cs-${Date.now()}@test.local`, phone: "919500000074", password: "x", roleIds: [csRole._id], departmentId: dept._id, status: "active" });
+  const mTok = jwt.sign({ _id: String(M._id), isAdmin: true }, process.env.JWT_SECRET);
+  const sTok = jwt.sign({ _id: String(S._id), isAdmin: true }, process.env.JWT_SECRET);
+  const s2Tok = jwt.sign({ _id: String(S2._id), isAdmin: true }, process.env.JWT_SECRET);
+  const csTok = jwt.sign({ _id: String(CS._id), isAdmin: true }, process.env.JWT_SECRET);
+  const cfgBefore = await Config.findOne({ code: "OnboardingMilestones" }).lean();
+
+  // Onboarded client fixture for the CS dashboard.
+  const phone = `9195${String(Date.now()).slice(-8)}`;
+  const cuser = await User.create({ name: "CS Couple", phone });
+  const clead = await Enquiry.create({ name: "CS Couple", phone, verified: false, source: "Website", stage: "won", additionalInfo: {} });
+  const cevent = await Event.create({ user: cuser._id, name: "CS Wedding", community: "Hindu", eventDate: "2026-12-12", eventDays: [{ name: "W", date: "2026-12-12", time: "18:00", venue: "X" }], amount: { total: 1000000 }, status: { finalized: true, approved: true } });
+  await Project.create({ leadId: clead._id, coupleNames: "CS Couple", eventIds: [cevent._id], csOwnerId: CS._id, value: 1000000 });
+  await Onboarding.create({ leadId: clead._id, eventId: cevent._id, status: "onboarded", onboardedAt: new Date(), milestones: { total: 1000000 }, agreement: { accepted: true } });
+
+  const child = spawn("node", ["server.js"], { cwd: `${__dirname}/..`, env: { ...process.env, PORT: String(PORT), GOOGLE_SHEETS_KEY_PATH: "/nonexistent/s7.json" }, stdio: ["ignore", "pipe", "pipe"] });
+  let log = ""; child.stdout.on("data", (d) => (log += d)); child.stderr.on("data", (d) => (log += d));
+  const api = async (m, p, t, b) => { const r = await fetch(`${BASE}${p}`, { method: m, headers: { ...(t ? { Authorization: `Bearer ${t}` } : {}), ...(b ? { "Content-Type": "application/json" } : {}) }, body: b ? JSON.stringify(b) : undefined }); let d = null; try { d = await r.json(); } catch (_) {} return { status: r.status, data: d }; };
+
+  try {
+    await waitFor(() => fetch(`${BASE}/`).then((r) => r.ok).catch(() => false), "boot");
+
+    console.log("\n── Multi-role permission UNION ──");
+    const mPerms = await api("GET", "/auth/admin/permissions", mTok);
+    ok(mPerms.data.permissions.includes("leads:view:all") && mPerms.data.permissions.includes("settings_onboarding:edit:all"), "union: permissions from BOTH roles present");
+    ok(Array.isArray(mPerms.data.roleNames) && mPerms.data.roleNames.length === 2, "roleNames lists both roles");
+    const mPut = await api("PUT", "/onboarding/milestones", mTok, { onboardingFee: 25000, advancePercent: 25, balanceDaysBeforeEvent: 14 });
+    ok(mPut.status === 200, "multi-role admin can PUT milestones (settings_onboarding from role B)");
+
+    console.log("\n── Single-role back-compat (roleId only) ──");
+    const sPerms = await api("GET", "/auth/admin/permissions", sTok);
+    ok(sPerms.data.permissions.includes("leads:view:all") && sPerms.data.permissions.length === 1, "legacy roleId-only admin resolves its role's perms");
+    const sPut = await api("PUT", "/onboarding/milestones", sTok, { onboardingFee: 25000, advancePercent: 25, balanceDaysBeforeEvent: 14 });
+    ok(sPut.status === 403, "single-role admin without settings_onboarding → 403 (gate still enforces)");
+
+    console.log("\n── roleIds without the perm → 403 ──");
+    const s2Put = await api("PUT", "/onboarding/milestones", s2Tok, { onboardingFee: 25000, advancePercent: 25, balanceDaysBeforeEvent: 14 });
+    ok(s2Put.status === 403, "roleIds=[A] (no settings_onboarding) → 403");
+
+    console.log("\n── CS dashboard (scoped) + CSV ──");
+    const csList = await api("GET", "/onboarding/cs/clients", csTok);
+    ok(csList.status === 200 && (csList.data.list || []).some((c) => String(c.leadId) === String(clead._id)), "CS sees the onboarded client in scope");
+    const row = (csList.data.list || []).find((c) => String(c.leadId) === String(clead._id));
+    ok(row && row.totalRupees === 1000000 && row.agreementAccepted === true, "CS row carries total + agreement status");
+    const csCsv = await fetch(`${BASE}/onboarding/cs/clients.csv`, { headers: { Authorization: `Bearer ${csTok}` } });
+    const csvText = await csCsv.text();
+    ok(csCsv.status === 200 && (csCsv.headers.get("content-type") || "").includes("text/csv") && csvText.includes("CS Couple"), "CSV export downloads with the client row");
+    const denied = await api("GET", "/onboarding/cs/clients", sTok); // S has leads:view only, no projects:view
+    ok(denied.status === 403, "admin without projects:view → 403 on CS list");
+
+    console.log("\n── Migration idempotency (roleId → roleIds[]) ──");
+    const pendingBefore = await Admin.countDocuments({ _id: S._id, $or: [{ roleIds: { $exists: false } }, { roleIds: { $size: 0 } }] });
+    ok(pendingBefore === 1, "legacy admin S is pending backfill");
+    await Admin.updateOne({ _id: S._id, $or: [{ roleIds: { $exists: false } }, { roleIds: { $size: 0 } }] }, { $set: { roleIds: [S.roleId] } });
+    const sAfter = await Admin.findById(S._id).lean();
+    ok(sAfter.roleIds.length === 1 && String(sAfter.roleIds[0]) === String(roleA._id), "backfill sets roleIds=[roleId]");
+    const pendingAfter = await Admin.countDocuments({ _id: S._id, $or: [{ roleIds: { $exists: false } }, { roleIds: { $size: 0 } }] });
+    ok(pendingAfter === 0, "re-run is a no-op (idempotent)");
+  } catch (e) {
+    fail++; failures.push(`fatal: ${e.message}`); console.error("FATAL", e); console.error(log.slice(-1500));
+  } finally {
+    await Onboarding.deleteMany({ leadId: clead._id }); await Project.deleteMany({ leadId: clead._id });
+    await Event.deleteMany({ user: cuser._id }); await Enquiry.deleteMany({ _id: clead._id }); await User.deleteMany({ _id: cuser._id });
+    await Admin.deleteMany({ _id: { $in: [M._id, S._id, S2._id, CS._id] } });
+    await Role.deleteMany({ _id: { $in: [roleA._id, roleB._id, csRole._id] } });
+    await Department.deleteMany({ _id: dept._id });
+    await Config.deleteMany({ code: "OnboardingMilestones" });
+    if (cfgBefore) await Config.create({ code: cfgBefore.code, data: cfgBefore.data });
+    child.kill(); await mongoose.disconnect();
+    console.log(`\n══ RESULT: ${pass} passed, ${fail} failed ══`);
+    if (failures.length) console.log("failures:", failures.join(" | "));
+    process.exit(fail === 0 ? 0 : 1);
+  }
+})();

--- a/services/AdminService.js
+++ b/services/AdminService.js
@@ -13,8 +13,9 @@ const { permissionSatisfies } = require("../middlewares/requirePermission");
 //                           assignee dropdowns, no emails/phones/status leakage.
 const listAdmins = async (callerId) => {
   const caller = callerId ? await AdminRepository.findById(callerId) : null;
-  const role = caller && caller.roleId ? await RoleRepository.findById(caller.roleId) : null;
-  const perms = role && Array.isArray(role.permissions) ? role.permissions : [];
+  // RBAC v2: union of permissions across all of the caller's roles.
+  const { permissionsForAdmin } = require("../middlewares/requirePermission");
+  const perms = await permissionsForAdmin(caller);
 
   if (permissionSatisfies(perms, "users:view:all").allowed) {
     return await AdminRepository.findAll();

--- a/services/CalendarEventService.js
+++ b/services/CalendarEventService.js
@@ -39,14 +39,15 @@ const liveMeetingAdminIds = async (now = new Date()) => {
 
 // ── Follow-up mirror + huddle + handoff (hooked from addFollowUp) ─────────────
 
-// Detect the intern class: role names configured as the auto-assignment pool.
+// Detect the intern class: ANY of the admin's roles (RBAC v2) is in the pool.
 const isInternOwner = async (admin) => {
-  if (!admin || !admin.roleId) return false;
+  const { roleIdsOf } = require("../middlewares/requirePermission");
+  const ids = roleIdsOf(admin);
+  if (!ids.length) return false;
   const Role = require("../models/Role");
-  const role = await Role.findById(admin.roleId, { name: 1 }).lean();
-  if (!role) return false;
+  const roles = await Role.find({ _id: { $in: ids } }, { name: 1 }).lean();
   const poolRoles = (await SettingsService.get("assignment.poolRoles")) || [];
-  return poolRoles.includes(role.name);
+  return roles.some((r) => poolRoles.includes(r.name));
 };
 
 // HANDOFF RULE: a meet follow-up booked on an intern-owned lead auto-transfers
@@ -54,7 +55,7 @@ const isInternOwner = async (admin) => {
 // via the set-once qualifiedBy field. Both sides get notified.
 const handoffIfInternOwned = async (lead, actorId) => {
   const owner = lead.assignedTo
-    ? await Admin.findById(lead.assignedTo, { name: 1, roleId: 1, reportingManagerId: 1, status: 1 }).lean()
+    ? await Admin.findById(lead.assignedTo, { name: 1, roleId: 1, roleIds: 1, reportingManagerId: 1, status: 1 }).lean()
     : null;
   if (!owner || !owner.reportingManagerId) return { transferred: false, owner };
   if (!(await isInternOwner(owner))) return { transferred: false, owner };

--- a/services/GoogleWorkspaceService.js
+++ b/services/GoogleWorkspaceService.js
@@ -139,13 +139,15 @@ const disconnect = async (adminId) => {
 // book on their reporting manager's calendar) and the Revenue-Head admin.
 const meetingAttendees = async (lead) => {
   let salesLeadAdmin = lead.assignedTo
-    ? await Admin.findById(lead.assignedTo, { name: 1, email: 1, roleId: 1, reportingManagerId: 1 }).lean()
+    ? await Admin.findById(lead.assignedTo, { name: 1, email: 1, roleId: 1, roleIds: 1, reportingManagerId: 1 }).lean()
     : null;
-  if (salesLeadAdmin && salesLeadAdmin.roleId && salesLeadAdmin.reportingManagerId) {
+  if (salesLeadAdmin && salesLeadAdmin.reportingManagerId) {
     const poolRoles = (await SettingsService.get("assignment.poolRoles")) || [];
-    const role = await Role.findById(salesLeadAdmin.roleId, { name: 1 }).lean();
-    if (role && poolRoles.includes(role.name)) {
-      // Intern-owned lead: the meet lives on the sales lead's calendar.
+    const { roleIdsOf } = require("../middlewares/requirePermission");
+    const ownerRoles = await Role.find({ _id: { $in: roleIdsOf(salesLeadAdmin) } }, { name: 1 }).lean();
+    if (ownerRoles.some((r) => poolRoles.includes(r.name))) {
+      // Intern-owned lead (any of their roles is a pool role): the meet lives on
+      // the sales lead's calendar.
       const manager = await Admin.findById(salesLeadAdmin.reportingManagerId, { name: 1, email: 1 }).lean();
       if (manager) salesLeadAdmin = manager;
     }
@@ -153,7 +155,7 @@ const meetingAttendees = async (lead) => {
   let revenueHead = null;
   const rhRole = await Role.findOne({ name: "Revenue Head", deletedAt: null }, { _id: 1 }).lean();
   if (rhRole) {
-    revenueHead = await Admin.findOne({ roleId: rhRole._id, status: "active" }, { name: 1, email: 1 }).lean();
+    revenueHead = await Admin.findOne({ status: "active", $or: [{ roleId: rhRole._id }, { roleIds: rhRole._id }] }, { name: 1, email: 1 }).lean();
   }
   return { salesLeadAdmin, revenueHead };
 };

--- a/services/JourneyService.js
+++ b/services/JourneyService.js
@@ -50,6 +50,14 @@ const EVENT_TITLES = {
   huddle_completed: "Huddle complete — team onboarded 🤝",
   kiara_safety_net_engaged: "Kiara safety net engaged ✦",
   meet_refused: "Refusing a meeting — tagged no-meet",
+  // MB7a — onboarding & money engine.
+  client_finalised: "Client finalised the plan",
+  wedsy_approved: "Wedsy approved the plan ✦",
+  agreement_signed: "Agreement accepted",
+  onboarding_started: "Onboarding started",
+  onboarding_payment_recorded: "Onboarding payment received ✦",
+  onboarded: "Onboarded — client is live ✦",
+  payment_recorded: "Payment recorded",
 };
 
 // Payload keys that carry an Admin id of a SECOND party (not the actor) — these

--- a/services/OnboardingMailService.js
+++ b/services/OnboardingMailService.js
@@ -1,0 +1,51 @@
+// MB7a — onboarding emails behind a seam. Reuses Mailjet (the existing mail
+// provider) when configured; otherwise dormant (logs and returns, never throws).
+// The agreement is emailed to the client on SUCCESSFUL payment; the invoice
+// link rides the same path. Mailjet's template sends don't carry our
+// dynamic agreement text/attachment cleanly, so these use a raw v3.1 message.
+const FROM_EMAIL = process.env.MAILJET_FROM_EMAIL || "notifications@wedsy.in";
+const FROM_NAME = process.env.MAILJET_FROM_NAME || "Wedsy";
+
+const isConfigured = () => !!(process.env.MAILJET_API_KEY && process.env.MAILJET_SECRET_KEY);
+
+const sendRaw = async ({ to, name, subject, textPart, htmlPart, attachments }) => {
+  if (!to) return { sent: false, reason: "no-recipient" };
+  if (!isConfigured()) {
+    // Dormant: no provider wired. Log so it's traceable and flag in the report.
+    console.warn(`[onboarding-mail] DORMANT (Mailjet unset) — would email "${subject}" to ${to}`);
+    return { sent: false, reason: "dormant" };
+  }
+  try {
+    const { Client: MailjetClient } = require("node-mailjet");
+    const client = new MailjetClient({ apiKey: process.env.MAILJET_API_KEY, apiSecret: process.env.MAILJET_SECRET_KEY });
+    await client.post("send", { version: "v3.1" }).request({
+      Messages: [
+        {
+          From: { Email: FROM_EMAIL, Name: FROM_NAME },
+          To: [{ Email: to, Name: name || "" }],
+          Subject: subject,
+          TextPart: textPart || "",
+          ...(htmlPart ? { HTMLPart: htmlPart } : {}),
+          ...(attachments && attachments.length ? { Attachments: attachments } : {}),
+        },
+      ],
+    });
+    return { sent: true };
+  } catch (e) {
+    console.error("[onboarding-mail] send failed:", e.message);
+    return { sent: false, reason: "error", error: e.message };
+  }
+};
+
+// Email the accepted agreement on successful payment. Fire-safe.
+const sendAgreementEmail = async ({ to, name, termsText, version, invoiceUrl }) => {
+  const body =
+    `Hi ${name || "there"},\n\nThank you — your payment is confirmed.\n\n` +
+    `Here is the Wedsy service agreement (version ${version || "v1"}) you accepted:\n\n` +
+    `${termsText || ""}\n\n` +
+    (invoiceUrl ? `Your invoice: ${invoiceUrl}\n\n` : "") +
+    `Warmly,\nTeam Wedsy`;
+  return sendRaw({ to, name, subject: "Your Wedsy agreement & payment confirmation", textPart: body });
+};
+
+module.exports = { isConfigured, sendRaw, sendAgreementEmail };

--- a/services/OnboardingService.js
+++ b/services/OnboardingService.js
@@ -367,6 +367,53 @@ const confirmOnlineMilestonePaid = async ({ paymentId, actorId = null }) => {
   return { ok: true, invoicePath: `/payment/${payment._id}/invoice` };
 };
 
+// ── CS dashboard (Slice 7) ──────────────────────────────────────────────────
+// Onboarded clients in the caller's scope. scopeFilter is built on the Project
+// (ownerField csOwnerId): {} = all (CS manager), else narrowed to the CS owner.
+const listOnboardedClients = async (scopeFilter = {}) => {
+  const Project = require("../models/Project");
+  const projects = await Project.find(scopeFilter, { leadId: 1, coupleNames: 1, csOwnerId: 1, value: 1, eventIds: 1 }).lean();
+  const leadIds = projects.map((p) => p.leadId).filter(Boolean);
+  // Onboarded records whose lead is an in-scope project.
+  const onboardings = await Onboarding.find({ leadId: { $in: leadIds }, status: "onboarded" }).sort({ onboardedAt: -1 }).lean();
+  if (!onboardings.length) return [];
+
+  const Enquiry = require("../models/Enquiry");
+  const leads = await Enquiry.find({ _id: { $in: onboardings.map((o) => o.leadId) } }, { name: 1, phone: 1 }).lean();
+  const leadById = new Map(leads.map((l) => [String(l._id), l]));
+  const projByLead = new Map(projects.map((p) => [String(p.leadId), p]));
+
+  // Paid totals (rupees) per event from paid payments.
+  const eventIds = onboardings.map((o) => o.eventId).filter(Boolean);
+  const payments = eventIds.length
+    ? await Payment.find({ event: { $in: eventIds }, status: "paid" }, { event: 1, amountPaid: 1 }).lean()
+    : [];
+  const paidByEvent = new Map();
+  for (const p of payments) {
+    const k = String(p.event);
+    paidByEvent.set(k, (paidByEvent.get(k) || 0) + (p.amountPaid || 0) / 100);
+  }
+
+  return onboardings.map((o) => {
+    const lead = leadById.get(String(o.leadId));
+    const proj = projByLead.get(String(o.leadId));
+    const total = (o.milestones && o.milestones.total) || (proj && proj.value) || 0;
+    const paid = paidByEvent.get(String(o.eventId)) || 0;
+    return {
+      onboardingId: o._id,
+      leadId: o.leadId,
+      eventId: o.eventId,
+      name: (proj && proj.coupleNames) || (lead && lead.name) || "",
+      phone: lead ? lead.phone : "",
+      onboardedAt: o.onboardedAt,
+      totalRupees: total,
+      paidRupees: paid,
+      dueRupees: Math.max(0, total - paid),
+      agreementAccepted: !!(o.agreement && o.agreement.accepted),
+    };
+  });
+};
+
 // Flip the onboarding record to ONBOARDED, clear the client lock, journal, and
 // email the accepted agreement (seam — dormant-safe).
 const markOnboarded = async ({ leadId, eventId, paymentId, actorId = null }) => {
@@ -415,4 +462,5 @@ module.exports = {
   recordOfflinePayment,
   confirmOnlineMilestonePaid,
   markOnboarded,
+  listOnboardedClients,
 };

--- a/services/OnboardingService.js
+++ b/services/OnboardingService.js
@@ -328,6 +328,7 @@ const recordOfflinePayment = async ({ leadId, eventId, milestone, amountRupees, 
     status: "paid",
     recordedBy: actorId,
     proof: { url: proofUrl || "", txnId: txnId || "", paidOn: paidOn ? new Date(paidOn) : new Date(), notes: notes || "" },
+    invoiceReadyAt: new Date(), // Slice 6: invoice available on record
   });
 
   await LeadInternalEventService.record({
@@ -340,7 +341,7 @@ const recordOfflinePayment = async ({ leadId, eventId, milestone, amountRupees, 
   if (milestone === "onboarding") {
     await markOnboarded({ leadId, eventId, paymentId: payment._id, actorId });
   }
-  return { paymentId: payment._id, amountRupees: rupees, amountPaise };
+  return { paymentId: payment._id, amountRupees: rupees, amountPaise, invoicePath: `/payment/${payment._id}/invoice` };
 };
 
 // Online milestone confirmation seam: when a Razorpay link is verified paid,
@@ -351,6 +352,7 @@ const confirmOnlineMilestonePaid = async ({ paymentId, actorId = null }) => {
   payment.status = "paid";
   payment.amountPaid = payment.amount;
   payment.amountDue = 0;
+  if (!payment.invoiceReadyAt) payment.invoiceReadyAt = new Date(); // Slice 6
   await payment.save();
   const leadId = await (async () => {
     const ev = payment.event ? await Event.findById(payment.event).lean() : null;
@@ -362,7 +364,7 @@ const confirmOnlineMilestonePaid = async ({ paymentId, actorId = null }) => {
       await markOnboarded({ leadId, eventId: payment.event, paymentId: payment._id, actorId });
     }
   }
-  return { ok: true };
+  return { ok: true, invoicePath: `/payment/${payment._id}/invoice` };
 };
 
 // Flip the onboarding record to ONBOARDED, clear the client lock, journal, and
@@ -385,7 +387,8 @@ const markOnboarded = async ({ leadId, eventId, paymentId, actorId = null }) => 
     if (user && user.email) {
       const terms = await SettingsService.get("agreement.terms");
       const version = (ob.agreement && ob.agreement.agreementVersion) || (await SettingsService.get("agreement.version"));
-      await OnboardingMailService.sendAgreementEmail({ to: user.email, name: user.name, termsText: terms, version });
+      const invoiceUrl = paymentId ? `/payment/${paymentId}/invoice` : null;
+      await OnboardingMailService.sendAgreementEmail({ to: user.email, name: user.name, termsText: terms, version, invoiceUrl });
     }
   } catch (e) {
     console.error("[onboarding] agreement email on onboard failed:", e.message);

--- a/services/OnboardingService.js
+++ b/services/OnboardingService.js
@@ -1,0 +1,58 @@
+const mongoose = require("mongoose");
+const Event = require("../models/Event");
+const User = require("../models/User");
+const Enquiry = require("../models/Enquiry");
+const LeadInternalEventService = require("./LeadInternalEventService");
+
+// MB7a — onboarding & money engine. Cross-cutting helpers shared by the finalise
+// gate, milestone settings, e-sign, onboard flow, payments, and invoices. The
+// CRM lead (Enquiry) and the client planner (Event, keyed by User) are linked
+// through the shared phone number — resolveLeadIdForEvent bridges them so
+// event-stage actions land on the lead's journey.
+
+const MAX_DRAFTS = 3; // a user may hold at most 3 unfinalized event drafts
+
+// Resolve the CRM lead behind an event (event.user → User → Enquiry by phone).
+// Best-effort: returns null when there's no linked lead (journey is advisory).
+const resolveLeadIdForEvent = async (event) => {
+  try {
+    if (!event) return null;
+    const user = event.user
+      ? await User.findById(event.user, { phone: 1 }).lean()
+      : null;
+    if (!user || !user.phone) return null;
+    const lead = await Enquiry.findOne({ phone: user.phone }, { _id: 1 }).lean();
+    return lead ? lead._id : null;
+  } catch (e) {
+    console.error("[onboarding] resolveLeadIdForEvent failed:", e.message);
+    return null;
+  }
+};
+
+// Record a journey event for an event-stage action, resolving the lead first.
+// Fire-safe — never throws into the caller's flow.
+const recordEventJourney = async (event, type, actorId, payload = {}) => {
+  try {
+    const leadId = await resolveLeadIdForEvent(event);
+    if (!leadId) return;
+    await LeadInternalEventService.record({ leadId, type, actorId: actorId || null, payload });
+  } catch (e) {
+    console.error("[onboarding] recordEventJourney failed:", e.message);
+  }
+};
+
+// Count a user's unfinalized event drafts (the draft-cap denominator).
+const countDrafts = async (userId) =>
+  Event.countDocuments({ user: userId, "status.finalized": false, "status.lost": { $ne: true } });
+
+// Both keys turned: the client finalised AND Wedsy approved → payment unlocks.
+const paymentUnlocked = (event) =>
+  !!(event && event.status && event.status.finalized && event.status.approved);
+
+module.exports = {
+  MAX_DRAFTS,
+  resolveLeadIdForEvent,
+  recordEventJourney,
+  countDrafts,
+  paymentUnlocked,
+};

--- a/services/OnboardingService.js
+++ b/services/OnboardingService.js
@@ -222,6 +222,177 @@ const clientState = async (eventId, callerUserId, isAdmin) => {
   };
 };
 
+// ── Payments (Slice 5) ──────────────────────────────────────────────────────
+const Payment = require("../models/Payment");
+const { CreatePaymentLink, razorpayMode } = require("../utils/payment");
+
+const toPaise = (rupees) => Math.round((Number(rupees) || 0) * 100);
+
+// The three milestone amounts (RUPEES), summing to the total:
+//   onboarding = onboardingFee · advance = advanceRemaining · balance = balance
+const milestoneAmountRupees = (ms, milestone) => {
+  if (!ms) return 0;
+  if (milestone === "onboarding") return ms.onboardingFee || 0;
+  if (milestone === "advance") return ms.advanceRemaining || 0;
+  if (milestone === "balance") return ms.balance || 0;
+  return 0;
+};
+
+const _onboardingWithMilestones = async (leadId, eventId) => {
+  let ob = await Onboarding.findOne({ leadId, eventId: eventId || null });
+  let ms = ob && ob.milestones;
+  if (!ms && eventId) {
+    const event = await Event.findById(eventId).lean();
+    if (event) ms = computeMilestones((event.amount && event.amount.total) || 0, await getMilestoneConfig());
+  }
+  return { ob, ms };
+};
+
+// Generate a Razorpay payment link for a milestone. Dormant-safe.
+const createMilestonePaymentLink = async ({ leadId, eventId, milestone, actorId = null }) => {
+  if (!["onboarding", "advance", "balance"].includes(milestone)) {
+    throw Object.assign(new Error("milestone must be onboarding|advance|balance"), { status: 400 });
+  }
+  if (!eventId) throw Object.assign(new Error("eventId is required"), { status: 400 });
+  const event = await Event.findById(eventId).lean();
+  if (!event) throw Object.assign(new Error("Event not found"), { status: 404 });
+  const { ms } = await _onboardingWithMilestones(leadId, eventId);
+  const amountRupees = milestoneAmountRupees(ms, milestone);
+  if (amountRupees <= 0) throw Object.assign(new Error("Milestone amount is zero — check the event total/milestones"), { status: 422 });
+  const amountPaise = toPaise(amountRupees);
+
+  const user = event.user ? await User.findById(event.user, { name: 1, phone: 1, email: 1 }).lean() : null;
+  const payment = await Payment.create({
+    user: event.user,
+    event: eventId,
+    paymentFor: "event",
+    paymentMethod: "razporpay",
+    milestone,
+    amount: amountPaise,
+    amountDue: amountPaise,
+    amountPaid: 0,
+    status: "created",
+    reminderDueAt: new Date(),
+  });
+
+  const link = await CreatePaymentLink({
+    amountPaise,
+    description: `Wedsy ${milestone} payment`,
+    reference: String(payment._id),
+    customer: { name: user ? user.name : "", contact: user ? user.phone : "", email: user ? user.email : "" },
+  });
+  if (link && link.id) {
+    await Payment.findByIdAndUpdate(payment._id, { $set: { paymentLinkId: link.id, paymentLinkUrl: link.url, razporPayId: link.id } });
+  }
+  return {
+    paymentId: payment._id,
+    milestone,
+    amountRupees,
+    amountPaise,
+    dormant: !!(link && link.dormant),
+    mode: (link && link.mode) || razorpayMode(),
+    url: (link && link.url) || null,
+    error: (link && link.error) || null,
+  };
+};
+
+// Record an OFFLINE milestone payment with proof. Screenshot mandatory for
+// bank-transfer. Amount in RUPEES (→ paise on store). Marks ONBOARDED when the
+// onboarding-fee milestone is recorded.
+const recordOfflinePayment = async ({ leadId, eventId, milestone, amountRupees, method, txnId, paidOn, notes, proofUrl, actorId = null }) => {
+  if (!["onboarding", "advance", "balance"].includes(milestone)) {
+    throw Object.assign(new Error("milestone must be onboarding|advance|balance"), { status: 400 });
+  }
+  if (!["cash", "upi", "bank-transfer"].includes(method)) {
+    throw Object.assign(new Error("method must be cash|upi|bank-transfer"), { status: 400 });
+  }
+  if (method === "bank-transfer" && !proofUrl) {
+    throw Object.assign(new Error("A payment screenshot (proofUrl) is mandatory for bank transfers"), { status: 422 });
+  }
+  if (!eventId) throw Object.assign(new Error("eventId is required"), { status: 400 });
+  const event = await Event.findById(eventId, { user: 1 }).lean();
+  if (!event) throw Object.assign(new Error("Event not found"), { status: 404 });
+  const rupees = Number(amountRupees);
+  if (!Number.isFinite(rupees) || rupees <= 0) throw Object.assign(new Error("amount must be a positive number (rupees)"), { status: 400 });
+  const amountPaise = toPaise(rupees);
+
+  const payment = await Payment.create({
+    user: event.user,
+    event: eventId,
+    paymentFor: "event",
+    paymentMethod: method,
+    milestone,
+    amount: amountPaise,
+    amountPaid: amountPaise,
+    amountDue: 0,
+    status: "paid",
+    recordedBy: actorId,
+    proof: { url: proofUrl || "", txnId: txnId || "", paidOn: paidOn ? new Date(paidOn) : new Date(), notes: notes || "" },
+  });
+
+  await LeadInternalEventService.record({
+    leadId,
+    type: "payment_recorded",
+    actorId,
+    payload: { milestone, method, amountRupees: rupees, offline: true, hasProof: !!proofUrl },
+  });
+
+  if (milestone === "onboarding") {
+    await markOnboarded({ leadId, eventId, paymentId: payment._id, actorId });
+  }
+  return { paymentId: payment._id, amountRupees: rupees, amountPaise };
+};
+
+// Online milestone confirmation seam: when a Razorpay link is verified paid,
+// mark onboarded if it was the onboarding fee. Fire-safe.
+const confirmOnlineMilestonePaid = async ({ paymentId, actorId = null }) => {
+  const payment = await Payment.findById(paymentId);
+  if (!payment) throw Object.assign(new Error("Payment not found"), { status: 404 });
+  payment.status = "paid";
+  payment.amountPaid = payment.amount;
+  payment.amountDue = 0;
+  await payment.save();
+  const leadId = await (async () => {
+    const ev = payment.event ? await Event.findById(payment.event).lean() : null;
+    return ev ? resolveLeadIdForEvent(ev) : null;
+  })();
+  if (leadId) {
+    await LeadInternalEventService.record({ leadId, type: "payment_recorded", actorId, payload: { milestone: payment.milestone, method: "razorpay", online: true } });
+    if (payment.milestone === "onboarding") {
+      await markOnboarded({ leadId, eventId: payment.event, paymentId: payment._id, actorId });
+    }
+  }
+  return { ok: true };
+};
+
+// Flip the onboarding record to ONBOARDED, clear the client lock, journal, and
+// email the accepted agreement (seam — dormant-safe).
+const markOnboarded = async ({ leadId, eventId, paymentId, actorId = null }) => {
+  const now = new Date();
+  const ob = await Onboarding.findOneAndUpdate(
+    { leadId, eventId: eventId || null },
+    { $set: { status: "onboarded", onboardedAt: now, lockActive: false, onboardingPaymentId: paymentId || null } },
+    { new: true, upsert: true, setDefaultsOnInsert: true }
+  );
+  await LeadInternalEventService.record({ leadId, type: "onboarding_payment_recorded", actorId, payload: { eventId: eventId ? String(eventId) : null } });
+  await LeadInternalEventService.record({ leadId, type: "onboarded", actorId, payload: {} });
+
+  // Email the accepted agreement on success (fire-safe; dormant when Mailjet unset).
+  try {
+    const OnboardingMailService = require("./OnboardingMailService");
+    const event = eventId ? await Event.findById(eventId, { user: 1 }).lean() : null;
+    const user = event && event.user ? await User.findById(event.user, { name: 1, email: 1 }).lean() : null;
+    if (user && user.email) {
+      const terms = await SettingsService.get("agreement.terms");
+      const version = (ob.agreement && ob.agreement.agreementVersion) || (await SettingsService.get("agreement.version"));
+      await OnboardingMailService.sendAgreementEmail({ to: user.email, name: user.name, termsText: terms, version });
+    }
+  } catch (e) {
+    console.error("[onboarding] agreement email on onboard failed:", e.message);
+  }
+  return ob;
+};
+
 module.exports = {
   MAX_DRAFTS,
   MILESTONE_CODE,
@@ -236,4 +407,9 @@ module.exports = {
   acceptAgreement,
   startOnboarding,
   clientState,
+  milestoneAmountRupees,
+  createMilestonePaymentLink,
+  recordOfflinePayment,
+  confirmOnlineMilestonePaid,
+  markOnboarded,
 };

--- a/services/OnboardingService.js
+++ b/services/OnboardingService.js
@@ -102,6 +102,50 @@ const countDrafts = async (userId) =>
 const paymentUnlocked = (event) =>
   !!(event && event.status && event.status.finalized && event.status.approved);
 
+// ── Onboarding record helpers (Slices 3–6) ──────────────────────────────────
+const Onboarding = require("../models/Onboarding");
+const SettingsService = require("./SettingsService");
+
+const getOnboarding = async (leadId, eventId = null) =>
+  Onboarding.findOne({ leadId, eventId: eventId || null }).lean();
+
+// E-sign acceptance (Slice 3). Upserts the onboarding record (works whether or
+// not onboarding was formally started), stamps the accepted version, journals
+// agreement_signed. Returns the onboarding doc.
+const acceptAgreement = async ({ leadId, eventId = null, acceptedName, actorId = null }) => {
+  if (!mongoose.Types.ObjectId.isValid(leadId)) {
+    throw Object.assign(new Error("Invalid lead id"), { status: 400 });
+  }
+  const name = String(acceptedName || "").trim();
+  if (!name) throw Object.assign(new Error("acceptedName is required"), { status: 400 });
+
+  let version = "v1";
+  try { version = await SettingsService.get("agreement.version"); } catch (_) { /* default */ }
+
+  const now = new Date();
+  const doc = await Onboarding.findOneAndUpdate(
+    { leadId, eventId: eventId || null },
+    {
+      $setOnInsert: { leadId, eventId: eventId || null, status: "started" },
+      $set: {
+        "agreement.accepted": true,
+        "agreement.acceptedAt": now,
+        "agreement.acceptedName": name,
+        "agreement.agreementVersion": version,
+      },
+    },
+    { upsert: true, new: true, setDefaultsOnInsert: true }
+  );
+
+  await LeadInternalEventService.record({
+    leadId,
+    type: "agreement_signed",
+    actorId,
+    payload: { acceptedName: name, agreementVersion: version, eventId: eventId ? String(eventId) : null },
+  });
+  return doc;
+};
+
 module.exports = {
   MAX_DRAFTS,
   MILESTONE_CODE,
@@ -112,4 +156,6 @@ module.exports = {
   recordEventJourney,
   countDrafts,
   paymentUnlocked,
+  getOnboarding,
+  acceptAgreement,
 };

--- a/services/OnboardingService.js
+++ b/services/OnboardingService.js
@@ -2,7 +2,60 @@ const mongoose = require("mongoose");
 const Event = require("../models/Event");
 const User = require("../models/User");
 const Enquiry = require("../models/Enquiry");
+const Config = require("../models/Config");
 const LeadInternalEventService = require("./LeadInternalEventService");
+
+// ── Milestone settings (Slice 2) ────────────────────────────────────────────
+// Stored via the existing /config pattern under code "OnboardingMilestones".
+// ALL AMOUNTS ARE IN RUPEES here and across the onboarding layer — we convert to
+// paise only at the Payment/Razorpay boundary (×100), fixing the paise/rupee
+// ambiguity the audit flagged.
+const MILESTONE_CODE = "OnboardingMilestones";
+const MILESTONE_DEFAULTS = {
+  onboardingFee: 25000, // rupees — token to start onboarding; counts toward the advance
+  advancePercent: 25, // % of total due as advance
+  balanceDaysBeforeEvent: 14, // balance falls due this many days before the event
+};
+
+const getMilestoneConfig = async () => {
+  try {
+    const row = await Config.findOne({ code: MILESTONE_CODE }).lean();
+    const d = (row && row.data) || {};
+    return {
+      onboardingFee: Number.isFinite(d.onboardingFee) ? d.onboardingFee : MILESTONE_DEFAULTS.onboardingFee,
+      advancePercent: Number.isFinite(d.advancePercent) ? d.advancePercent : MILESTONE_DEFAULTS.advancePercent,
+      balanceDaysBeforeEvent: Number.isFinite(d.balanceDaysBeforeEvent) ? d.balanceDaysBeforeEvent : MILESTONE_DEFAULTS.balanceDaysBeforeEvent,
+    };
+  } catch (_) {
+    return { ...MILESTONE_DEFAULTS };
+  }
+};
+
+// Compute the three milestones for a total (rupees). The onboarding fee counts
+// TOWARD the advance; the balance is the remainder, due before the event; the
+// full amount is due before the event day.
+//   advance  = round(advancePercent% of total)
+//   onboardingFee (capped at advance) is the first slice of the advance
+//   advanceRemaining = advance − onboardingFee  (the rest of the 25%)
+//   balance  = total − advance
+const computeMilestones = (totalRupees, cfg) => {
+  const total = Math.max(0, Math.round(Number(totalRupees) || 0));
+  const advance = Math.round((total * cfg.advancePercent) / 100);
+  const onboardingFee = Math.min(cfg.onboardingFee, advance || cfg.onboardingFee);
+  const advanceRemaining = Math.max(0, advance - onboardingFee);
+  const balance = Math.max(0, total - advance);
+  return {
+    currency: "INR",
+    unit: "rupees",
+    total,
+    advancePercent: cfg.advancePercent,
+    advance, // 25% of total
+    onboardingFee, // counts toward the advance
+    advanceRemaining, // advance left after the onboarding fee
+    balance, // remainder, due before the event
+    balanceDaysBeforeEvent: cfg.balanceDaysBeforeEvent,
+  };
+};
 
 // MB7a — onboarding & money engine. Cross-cutting helpers shared by the finalise
 // gate, milestone settings, e-sign, onboard flow, payments, and invoices. The
@@ -51,6 +104,10 @@ const paymentUnlocked = (event) =>
 
 module.exports = {
   MAX_DRAFTS,
+  MILESTONE_CODE,
+  MILESTONE_DEFAULTS,
+  getMilestoneConfig,
+  computeMilestones,
   resolveLeadIdForEvent,
   recordEventJourney,
   countDrafts,

--- a/services/OnboardingService.js
+++ b/services/OnboardingService.js
@@ -146,6 +146,82 @@ const acceptAgreement = async ({ leadId, eventId = null, acceptedName, actorId =
   return doc;
 };
 
+// ── Onboard flow (Slice 4) ──────────────────────────────────────────────────
+// Revenue Head starts onboarding from the lead: locks the CLIENT dashboard,
+// snapshots the milestones from the event total, journals onboarding_started.
+// The 2-day-window / draft-shared rule is surfaced as info (warn), not a hard
+// block. Idempotent: re-starting returns the existing record.
+const startOnboarding = async ({ leadId, eventId = null, actorId = null }) => {
+  if (!mongoose.Types.ObjectId.isValid(leadId)) {
+    throw Object.assign(new Error("Invalid lead id"), { status: 400 });
+  }
+  let milestones = null;
+  let event = null;
+  if (eventId) {
+    if (!mongoose.Types.ObjectId.isValid(eventId)) {
+      throw Object.assign(new Error("Invalid event id"), { status: 400 });
+    }
+    event = await Event.findById(eventId).lean();
+    if (!event) throw Object.assign(new Error("Event not found"), { status: 404 });
+    const cfg = await getMilestoneConfig();
+    const total = (event.amount && event.amount.total) || 0; // rupees
+    milestones = computeMilestones(total, cfg);
+  }
+
+  const now = new Date();
+  const doc = await Onboarding.findOneAndUpdate(
+    { leadId, eventId: eventId || null },
+    {
+      $setOnInsert: { leadId, eventId: eventId || null },
+      $set: {
+        status: "started",
+        lockActive: true,
+        startedBy: actorId || null,
+        startedAt: now,
+        ...(milestones ? { milestones } : {}),
+      },
+    },
+    { upsert: true, new: true, setDefaultsOnInsert: true }
+  );
+
+  await LeadInternalEventService.record({
+    leadId,
+    type: "onboarding_started",
+    actorId,
+    payload: { eventId: eventId ? String(eventId) : null, milestones },
+  });
+
+  // Soft window note (info only — never blocks).
+  let windowNote = null;
+  if (event) {
+    const ageDays = (Date.now() - +new Date(event.createdAt)) / 86400000;
+    if (ageDays < 2) windowNote = "Heads up: the draft was shared less than 2 days ago — confirm the client is ready.";
+    if (!paymentUnlocked(event)) windowNote = "Note: the event isn't client-finalised + Wedsy-approved yet — payment stays locked until it is.";
+  }
+  return { onboarding: doc, windowNote };
+};
+
+// Client-facing onboarding state (wedsy-user reads this to gate the planner).
+// Resolved by eventId; verifies the event belongs to the caller unless admin.
+const clientState = async (eventId, callerUserId, isAdmin) => {
+  if (!mongoose.Types.ObjectId.isValid(eventId)) {
+    throw Object.assign(new Error("Invalid event id"), { status: 400 });
+  }
+  const event = await Event.findById(eventId, { user: 1 }).lean();
+  if (!event) throw Object.assign(new Error("Event not found"), { status: 404 });
+  if (!isAdmin && String(event.user) !== String(callerUserId)) {
+    throw Object.assign(new Error("Out of your scope"), { status: 403 });
+  }
+  const doc = await Onboarding.findOne({ eventId }).lean();
+  return {
+    eventId: String(eventId),
+    onboardingLockActive: !!(doc && doc.lockActive && doc.status !== "onboarded"),
+    onboarded: !!(doc && doc.status === "onboarded"),
+    agreementAccepted: !!(doc && doc.agreement && doc.agreement.accepted),
+    status: doc ? doc.status : "none",
+  };
+};
+
 module.exports = {
   MAX_DRAFTS,
   MILESTONE_CODE,
@@ -158,4 +234,6 @@ module.exports = {
   paymentUnlocked,
   getOnboarding,
   acceptAgreement,
+  startOnboarding,
+  clientState,
 };

--- a/services/RoleService.js
+++ b/services/RoleService.js
@@ -16,8 +16,12 @@ const isFounderRole = (role) =>
 const callerContext = async (callerId) => {
   if (!callerId) return { admin: null, role: null, isFounder: false };
   const admin = await Admin.findById(callerId).lean();
-  const role = admin && admin.roleId ? await Role.findById(admin.roleId).lean() : null;
-  return { admin, role, isFounder: isFounderRole(role) };
+  // RBAC v2: founder if ANY of the caller's roles is the founder role.
+  const { roleIdsOf } = require("../middlewares/requirePermission");
+  const ids = roleIdsOf(admin);
+  const roles = ids.length ? await Role.find({ _id: { $in: ids } }).lean() : [];
+  const founderRole = roles.find(isFounderRole) || null;
+  return { admin, role: founderRole || roles[0] || null, isFounder: roles.some(isFounderRole) };
 };
 
 // Roles list: the founder role (and therefore its matrix row) is INVISIBLE to any
@@ -51,8 +55,9 @@ const updatePermissions = async (_id, { permissions, description } = {}, callerI
     throw err(403, "This role is protected and cannot be edited.");
   }
   const { admin, isFounder } = await callerContext(callerId);
-  if (admin && admin.roleId && String(admin.roleId) === String(_id)) {
-    throw err(403, "You cannot edit the role you yourself hold.");
+  const { roleIdsOf } = require("../middlewares/requirePermission");
+  if (admin && roleIdsOf(admin).map(String).includes(String(_id))) {
+    throw err(403, "You cannot edit a role you yourself hold.");
   }
   const { valid, errors } = validatePermissions(permissions);
   if (!valid) {
@@ -115,7 +120,7 @@ const deleteRole = async (_id, callerId) => {
   if (!role || role.deletedAt) throw err(404, "Role not found.");
   if (isFounderRole(role)) throw err(422, "Founder role is immutable");
   if (role.protected === true) throw err(403, "This role is protected and cannot be deleted.");
-  const holders = await Admin.find({ roleId: _id }, { name: 1 }).lean();
+  const holders = await Admin.find({ $or: [{ roleId: _id }, { roleIds: _id }] }, { name: 1 }).lean();
   if (holders.length > 0) {
     throw err(
       422,

--- a/services/SettingsService.js
+++ b/services/SettingsService.js
@@ -78,6 +78,16 @@ const DEFAULTS = {
     "both your names, the date or month you're aiming for, whether the venue is sorted, and the best email " +
     "to send our ideas to (yours and your partner's, if you like — that way nobody misses anything). " +
     "Two quick minutes, promise!",
+  // MB7a Slice 3 — e-sign agreement terms (founder-editable, settings_agreement).
+  // PLACEHOLDER, not legal text — the founder pastes the real terms later.
+  "agreement.terms":
+    "[PLACEHOLDER — replace with Wedsy's real service agreement before going live.] " +
+    "This Wedsy wedding services agreement sets out what we'll deliver, the payment " +
+    "milestones (onboarding fee, advance, and balance), timelines, and cancellation " +
+    "terms. By accepting, you confirm you've read and agree to these terms. " +
+    "Edit this in Settings → Agreement.",
+  // Bump when the terms change materially — stamped onto each acceptance.
+  "agreement.version": "v1",
 };
 
 // key → settings permission category. Every write is gated by ITS category.
@@ -114,6 +124,8 @@ const KEY_CATEGORY = {
   "cockpit.servicesScript": "settings_scripts",
   "cockpit.budgetScript": "settings_scripts",
   "cockpit.qualificationIntro": "settings_scripts",
+  "agreement.terms": "settings_agreement",
+  "agreement.version": "settings_agreement",
 };
 
 const err = (status, message) => Object.assign(new Error(message), { status });
@@ -141,6 +153,16 @@ const validateValue = (key, value) => {
         throw err(400, `${key} must be a string of at most 5000 chars`);
       }
       return value;
+    case "agreement.terms":
+      if (typeof value !== "string" || value.trim().length === 0 || value.length > 50000) {
+        throw err(400, "agreement.terms must be a non-empty string of at most 50000 chars");
+      }
+      return value;
+    case "agreement.version":
+      if (typeof value !== "string" || value.trim().length === 0 || value.length > 40) {
+        throw err(400, "agreement.version must be a non-empty string of at most 40 chars");
+      }
+      return value.trim();
     case "assignment.dailyCap":
       if (!isIntInRange(value, 1, 100)) throw err(400, "assignment.dailyCap must be an integer 1–100");
       return value;

--- a/services/TriageService.js
+++ b/services/TriageService.js
@@ -25,7 +25,8 @@ const triageHolderIds = async () => {
     .filter((r) => permissionSatisfies(r.permissions || [], "leads:triage:own").allowed)
     .map((r) => r._id);
   const holders = holderRoleIds.length
-    ? await Admin.find({ roleId: { $in: holderRoleIds }, status: "active" }, { _id: 1 }).lean()
+    // RBAC v2: match the role on roleId OR any of roleIds[] (multi-role).
+    ? await Admin.find({ status: "active", $or: [{ roleId: { $in: holderRoleIds } }, { roleIds: { $in: holderRoleIds } }] }, { _id: 1 }).lean()
     : [];
   const ids = holders.map((h) => h._id);
   holderCache = { ids, expires: Date.now() + HOLDER_CACHE_TTL_MS };
@@ -36,8 +37,9 @@ const triageHolderIds = async () => {
 const internsWithStatus = async () => {
   const poolRoles = (await SettingsService.get("assignment.poolRoles")) || [];
   const roles = await Role.find({ name: { $in: poolRoles }, deletedAt: null }, { _id: 1 }).lean();
+  const roleIds = roles.map((r) => r._id);
   const interns = await Admin.find(
-    { roleId: { $in: roles.map((r) => r._id) }, status: "active" },
+    { status: "active", $or: [{ roleId: { $in: roleIds } }, { roleIds: { $in: roleIds } }] },
     { name: 1, reportingManagerId: 1, lastAssignedAt: 1 }
   ).lean();
   const CalendarEventService = require("./CalendarEventService");
@@ -161,7 +163,7 @@ const inWorkingHours = async (now = new Date()) => {
 const revenueHeadIds = async () => {
   const role = await Role.findOne({ name: "Revenue Head", deletedAt: null }, { _id: 1 }).lean();
   if (!role) return [];
-  const heads = await Admin.find({ roleId: role._id, status: "active" }, { _id: 1 }).lean();
+  const heads = await Admin.find({ status: "active", $or: [{ roleId: role._id }, { roleIds: role._id }] }, { _id: 1 }).lean();
   return heads.map((h) => h._id);
 };
 

--- a/utils/payment.js
+++ b/utils/payment.js
@@ -31,10 +31,25 @@ console.log("[payment:config] Razorpay", {
   keySecretSet: Boolean(_keySecret),
 });
 
-var instance = new Razorpay({
-  key_id: process.env.RAZORPAY_KEY_ID,
-  key_secret: process.env.RAZORPAY_KEY_SECRET,
-});
+// MB7a — dormant-until-armed: the Razorpay SDK throws at construction when
+// key_id is empty, so build it LAZILY (only when configured). This lets the
+// server boot with no keys (dormant), mirroring Google/Meta. Existing callers
+// (orders.create/fetch) get the instance on demand via getInstance().
+const razorpayConfigured = () =>
+  !!((process.env.RAZORPAY_KEY_ID || "").trim() && (process.env.RAZORPAY_KEY_SECRET || "").trim());
+
+let _instance = null;
+const getInstance = () => {
+  if (_instance) return _instance;
+  if (!razorpayConfigured()) {
+    throw Object.assign(new Error("Razorpay is not configured (RAZORPAY_KEY_ID/SECRET unset)"), { statusCode: 503 });
+  }
+  _instance = new Razorpay({
+    key_id: process.env.RAZORPAY_KEY_ID,
+    key_secret: process.env.RAZORPAY_KEY_SECRET,
+  });
+  return _instance;
+};
 
 const CreatePayment = ({ _id }) => {
   return new Promise((resolve, reject) => {
@@ -52,7 +67,7 @@ const CreatePayment = ({ _id }) => {
             notes: { user, paymentFor, event: event || "" },
             partial_payment: false, // indicates whether the customer can make a partial payment.
           };
-          instance.orders.create(options, function (err, order) {
+          getInstance().orders.create(options, function (err, order) {
             if (err) {
               logPaymentError("CreatePayment:razorpay_orders_create", {
                 err,
@@ -89,7 +104,7 @@ const CreatePayment = ({ _id }) => {
 
 const GetPaymentStatus = ({ order_id, response }) => {
   return new Promise((resolve, reject) => {
-    instance.orders.fetch(order_id, function (err, order) {
+    getInstance().orders.fetch(order_id, function (err, order) {
       if (err) {
         logPaymentError("GetPaymentStatus:razorpay_orders_fetch", { err, order_id });
         reject({ message: "error", err });
@@ -119,7 +134,7 @@ const GetPaymentStatus = ({ order_id, response }) => {
 
 const GetPaymentTransactions = ({ order_id }) => {
   return new Promise((resolve, reject) => {
-    instance.orders.fetchPayments(order_id, function (err, transactions) {
+    getInstance().orders.fetchPayments(order_id, function (err, transactions) {
       if (err) {
         logPaymentError("GetPaymentTransactions:razorpay", { err, order_id });
         reject({ message: "error", err });
@@ -134,8 +149,41 @@ const GetPaymentTransactions = ({ order_id }) => {
   });
 };
 
+// Razorpay mode: dormant (unset), live (rzp_live_*), else test. Test keys
+// operate in Razorpay test mode automatically; going live = swapping prod keys.
+const razorpayMode = () => {
+  if (!razorpayConfigured()) return "dormant";
+  return (process.env.RAZORPAY_KEY_ID || "").trim().startsWith("rzp_live_") ? "live" : "test";
+};
+
+// Create a Razorpay payment link for a milestone. amountPaise is in PAISE.
+// Dormant when keys are unset → returns { dormant: true } (no API call), so the
+// flow works pre-config and the sales lead chases manually. Never throws.
+const CreatePaymentLink = async ({ amountPaise, description, customer = {}, reference }) => {
+  if (!razorpayConfigured()) return { dormant: true, mode: "dormant" };
+  try {
+    const link = await getInstance().paymentLink.create({
+      amount: amountPaise,
+      currency: "INR",
+      accept_partial: false,
+      description: description || "Wedsy payment",
+      reference_id: reference || undefined,
+      customer: { name: customer.name || "", contact: customer.contact || "", email: customer.email || "" },
+      notify: { sms: false, email: false }, // we chase via our own channels
+      reminder_enable: false,
+    });
+    return { dormant: false, mode: razorpayMode(), id: link.id, url: link.short_url, raw: link };
+  } catch (error) {
+    logPaymentError("CreatePaymentLink", { error });
+    return { dormant: false, mode: razorpayMode(), error: error?.error?.description || error?.message || "link creation failed" };
+  }
+};
+
 module.exports = {
   CreatePayment,
   GetPaymentStatus,
   GetPaymentTransactions,
+  CreatePaymentLink,
+  razorpayConfigured,
+  razorpayMode,
 };


### PR DESCRIPTION
## MEGA-BUILD 7a — Onboarding & Money Engine (backend)

Companion frontend in WedsyOrg/wedsy-os (`claude/mb7a-ui`). Reuses the existing event state machine, /config + Settings patterns, Payment + invoice-PDF engine, S3, and Mailjet — extended, not reinvented. Regression: MB4 e2e 85/85, MB5+6 e2e 200/200, journey/kiara/bug-a green; new slice suites 75/75 on test ports.

### The 7 slices
1. **Finalise gate** — extends the EXISTING event status machine (no parallel one): max-3 unfinalized drafts per user (4th → 409); two-key gate (client `finalize` → Wedsy `approve`) before an event's payment unlocks (422 until both); journey `client_finalised` + `wedsy_approved` with actor names.
2. **Milestone settings** — `/config` code `OnboardingMilestones` `{onboardingFee 25000, advancePercent 25, balanceDaysBeforeEvent 14}`, founder-gated (`settings_onboarding`). All RUPEES end-to-end; ×100 to paise only at the Payment/Razorpay boundary (fixes the paise/rupee ambiguity). Math: advance = 25% of total; onboarding fee counts toward it; balance = remainder.
3. **E-sign agreement** — `agreement.terms` (+ `agreement.version`) founder-editable in Settings (ships a placeholder, not legal text); client-readable `GET /onboarding/agreement`; `POST /onboarding/agreement` stores `{acceptedAt, acceptedName, agreementVersion}` + journey `agreement_signed`; agreement emailed on successful payment via a dormant-safe Mailjet seam.
4. **Onboard flow + dashboard lock** — `POST /onboarding/start` (Revenue-Head-only, new `leads:onboard` perm) locks the client dashboard (`onboardingLockActive`) and snapshots the milestones; `GET /onboarding/state?eventId=` is the wedsy-user client contract; OS keeps full access.
5. **Razorpay (dormant-until-armed) + offline-with-proof + ONBOARDED** — `utils/payment.js` Razorpay client made lazy (boots with no keys); per-milestone payment links, dormant when keys unset (test keys → test mode, swap `rzp_live_*` to go live); offline recording with txnId/date/notes + proof screenshot (MANDATORY for bank-transfer); marks ONBOARDED when the onboarding fee is recorded (online verified OR offline-with-proof). Reminder-due marker set; the WhatsApp chase stays template-gated/dormant (flagged).
6. **Auto-invoices** — reuses the existing `GET /payment/:id/invoice` PDF engine; `invoiceReadyAt` stamped on record so the invoice is available (not only on-demand); download path returned + emailed; client downloads via the same endpoint.
7. **RBAC v2 + CS dashboard** — `Admin.roleIds[]` with a permission UNION; `CS dashboard` (`GET /onboarding/cs/clients` + CSV) of onboarded clients scoped by the project's CS owner.

### Dedicated Onboarding model
Onboarding (lock, agreement, milestone payments — genuinely new state) lives in `models/Onboarding.js` keyed `{leadId, eventId}`, bridging the CRM lead (`Enquiry`) and the client planner (`Event`, keyed by `User`) via the shared phone. The event finalize/approve machine was extended, not duplicated.

### RBAC v2 — backward-compatible
`requirePermission` centralizes resolution: an admin's effective roles = `roleIds[]` when set, else `[roleId]`; `permissionsForAdmin` returns the UNION (the single source of truth). Every role/permission read site migrated (auth permissions endpoint, settings, disqualify, AdminService/RoleService, and the Triage/Google/Calendar role-membership queries now match `roleId` OR `roleIds[]`). `permissionSatisfies`/`buildScopeFilter` unchanged. Migration `scripts/mb7a-migrate-roleids.js --confirm` backfills `roleIds=[roleId]` (idempotent, additive). Seed `scripts/mb7a-seed-permissions.js --confirm` grants `leads:onboard`, `settings_onboarding`, CS `projects:view`.

### Dormant posture
- **Razorpay**: `RAZORPAY_KEY_ID/SECRET` unset → dormant (server boots, links return `{dormant:true}`, no API call). Test keys → test mode; swap prod keys to go live. Never hardcoded.
- **Mailjet**: agreement/invoice email seam logs and no-ops when `MAILJET_*` unset (never throws).
- Both follow the Google/Meta dormant-until-armed pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)