### PR TITLE
Password management + access control: self change-password, admin set-password, disable/enable access with audit

### DIFF
--- a/controllers/admin.js
+++ b/controllers/admin.js
@@ -4,6 +4,7 @@ const Admin = require("../models/Admin");
 const Role = require("../models/Role");
 const Department = require("../models/Department");
 const { CreateHash } = require("../utils/password");
+const ActivityLogService = require("../services/ActivityLogService");
 
 // Legacy roles[] kept in sync with the RBAC role's department so legacy gates
 // stay consistent (schema enum: owner|crm|sales|ops|finance).
@@ -217,8 +218,96 @@ const UpdateAdmin = async (req, res) => {
   }
 };
 
+// POST /admin/set-password (Slice 2) — an access-manager sets a NEW password for
+// ANY team member (forgot-password case): no current password required. Gated by
+// requirePermission("team:manage_access:all"). Audited (never the password).
+const SetMemberPassword = async (req, res) => {
+  try {
+    const { targetAdminId, newPassword } = req.body || {};
+    if (!mongoose.Types.ObjectId.isValid(targetAdminId)) {
+      return res.status(400).json({ message: "Invalid targetAdminId." });
+    }
+    if (typeof newPassword !== "string" || newPassword.length < 8) {
+      return res.status(400).json({ message: "Password must be at least 8 characters" });
+    }
+    const target = await Admin.findById(targetAdminId);
+    if (!target) return res.status(404).json({ message: "Target admin not found." });
+
+    target.password = await CreateHash(newPassword);
+    // The member now has a known password — clear any forced-reset flag.
+    target.mustResetPassword = false;
+    await target.save();
+
+    await ActivityLogService.record({
+      actorId: req.auth.user_id,
+      action: "admin.password_set",
+      entityType: "admin",
+      entityId: String(target._id),
+      summary: `Set a new password for ${target.name}`,
+      meta: { targetAdminId: String(target._id), targetName: target.name }, // NO password
+    });
+    console.log(`[admin] Password set for ${target._id} by ${req.auth.user_id}`);
+    return res.status(200).json({ message: "Password set" });
+  } catch (error) {
+    return res.status(500).json({ message: "Server error" });
+  }
+};
+
+// POST /admin/access (Slice 3) — disable / re-enable a team member's access.
+// Gated by requirePermission("team:manage_access:all"). A disabled admin cannot
+// log in AND existing tokens are rejected by CheckAdminLogin. Safety: cannot
+// disable self; a non-founder cannot disable a founder (wildcard) account.
+const SetMemberAccess = async (req, res) => {
+  try {
+    const { targetAdminId, disabled } = req.body || {};
+    if (!mongoose.Types.ObjectId.isValid(targetAdminId)) {
+      return res.status(400).json({ message: "Invalid targetAdminId." });
+    }
+    if (typeof disabled !== "boolean") {
+      return res.status(400).json({ message: "disabled must be a boolean." });
+    }
+    // Safety: never let an admin lock themselves out.
+    if (String(targetAdminId) === String(req.auth.user_id)) {
+      return res.status(400).json({ message: "You cannot disable your own access." });
+    }
+    const target = await Admin.findById(targetAdminId);
+    if (!target) return res.status(404).json({ message: "Target admin not found." });
+
+    // Protect the top account: a non-founder cannot disable a founder.
+    if (disabled) {
+      const { permissionsForAdmin } = require("../middlewares/requirePermission");
+      const acting = await Admin.findById(req.auth.user_id);
+      const [targetPerms, actingPerms] = await Promise.all([
+        permissionsForAdmin(target),
+        permissionsForAdmin(acting),
+      ]);
+      const isFounder = (perms) => (perms || []).includes("*:*:all");
+      if (isFounder(targetPerms) && !isFounder(actingPerms)) {
+        return res.status(403).json({ message: "You cannot disable a founder account." });
+      }
+    }
+
+    target.isDisabled = disabled;
+    await target.save();
+
+    await ActivityLogService.record({
+      actorId: req.auth.user_id,
+      action: disabled ? "admin.disabled" : "admin.enabled",
+      entityType: "admin",
+      entityId: String(target._id),
+      summary: `${disabled ? "Disabled" : "Re-enabled"} access for ${target.name}`,
+      meta: { targetAdminId: String(target._id), targetName: target.name, disabled },
+    });
+    return res.status(200).json({ message: disabled ? "Access disabled" : "Access enabled", isDisabled: disabled });
+  } catch (error) {
+    return res.status(500).json({ message: "Server error" });
+  }
+};
+
 module.exports = {
   GetAll,
   CreateAdmin,
   UpdateAdmin,
+  SetMemberPassword,
+  SetMemberAccess,
 };

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -780,6 +780,38 @@ const FirstResetPassword = async (req, res) => {
   }
 };
 
+// POST /auth/admin/change-password — SELF password change (Slice 1). Acts ONLY
+// on req.auth.user_id, so it can never target another admin. Verifies the
+// current password against the stored bcrypt hash, then validates + saves the
+// new one. Never logs or returns password values.
+const ChangeOwnPassword = async (req, res) => {
+  try {
+    const { currentPassword, newPassword } = req.body || {};
+    if (typeof currentPassword !== "string" || typeof newPassword !== "string" || !currentPassword || !newPassword) {
+      return res.status(400).send({ message: "currentPassword and newPassword are required" });
+    }
+    if (newPassword.length < 8) {
+      return res.status(400).send({ message: "Password must be at least 8 characters" });
+    }
+    const admin = await Admin.findById(req.auth.user_id);
+    if (!admin) return res.status(401).send({ message: "invalid user" });
+    if (!admin.password || !(await CheckHash(currentPassword, admin.password))) {
+      return res.status(401).send({ message: "Current password is incorrect" });
+    }
+    if (await CheckHash(newPassword, admin.password)) {
+      return res.status(400).send({ message: "New password cannot be the same as the current one" });
+    }
+    admin.password = await CreateHash(newPassword);
+    admin.mustResetPassword = false;
+    await admin.save();
+    console.log(`[auth] Password changed by admin ${admin._id}`);
+    return res.status(200).send({ message: "Password updated" });
+  } catch (error) {
+    console.error("[auth] ChangeOwnPassword error:", error.message);
+    return res.status(500).send({ message: "Server error" });
+  }
+};
+
 // GET /auth/admin/permissions — the caller's resolved permission strings.
 // Drives which Settings sections the frontend renders.
 const GetPermissions = async (req, res) => {
@@ -824,4 +856,5 @@ module.exports = {
   ResetPassword,
   GetPermissions,
   FirstResetPassword,
+  ChangeOwnPassword,
 };

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -510,6 +510,12 @@ const AdminLogin = (req, res) => {
       .then(async (user) => {
         if (user) {
           const { _id } = user;
+          // Access control (password-mgmt Slice 3): a disabled admin cannot log in.
+          if (user.isDisabled) {
+            return res
+              .status(403)
+              .send({ message: "Your access has been disabled. Contact your administrator." });
+          }
           if (
             password &&
             user.password &&

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -193,6 +193,10 @@ function CheckLogin(req, res, next) {
           .then((user) => {
             if (!user) {
               res.status(401).send({ message: "invalid user" });
+            } else if (user.isDisabled) {
+              // Access control (password-mgmt Slice 3): disabling cuts access
+              // IMMEDIATELY — an existing token is rejected here, not just at login.
+              res.status(403).send({ message: "Your access has been disabled. Contact your administrator." });
             } else {
               req.auth = {
                 user_id: _id,
@@ -290,6 +294,10 @@ function CheckAdminLogin(req, res, next) {
           .then((user) => {
             if (!user) {
               res.status(401).send({ message: "invalid user" });
+            } else if (user.isDisabled) {
+              // Access control (password-mgmt Slice 3): disabling cuts access
+              // IMMEDIATELY — an existing token is rejected here, not just at login.
+              res.status(403).send({ message: "Your access has been disabled. Contact your administrator." });
             } else {
               req.auth = {
                 user_id: _id,

--- a/models/Admin.js
+++ b/models/Admin.js
@@ -24,6 +24,9 @@ const AdminSchema = new mongoose.Schema(
     resetTokenExpiresAt: { type: Date, default: null },
     // Settings Suite (additive): force a password change on first login.
     mustResetPassword: { type: Boolean, default: false },
+    // Access control (additive): a disabled admin cannot log in AND existing
+    // tokens are rejected by CheckAdminLogin — disabling cuts access immediately.
+    isDisabled: { type: Boolean, default: false },
     meta: {
       designation: { type: String, default: "" },
       employeeId: { type: String, default: "" },

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -15,6 +15,11 @@ router.post("/", CheckAdminLogin, requirePermission("users:create:all"), admin.C
 // management) and are intentionally left auth-only — see classification notes.
 router.get("/enquiries/:enquiryId/venue-journey", CheckAdminLogin, venueJourney.GetVenueJourney);
 router.get("/venue-conversations/:conversationId/messages", CheckAdminLogin, venueJourney.GetVenueConversationMessages);
+// ACCESS CONTROL (password-mgmt) — gated to the new team:manage_access permission
+// (founder *:*:all + the Admin role; NOT regular members). Literal paths, kept
+// above the PUT /:id param route.
+router.post("/set-password", CheckAdminLogin, requirePermission("team:manage_access:all"), admin.SetMemberPassword);
+router.post("/access", CheckAdminLogin, requirePermission("team:manage_access:all"), admin.SetMemberAccess);
 // PUT /:id is method-distinct from the GETs above, but kept last so any future
 // param routes stay below the literal paths.
 router.put("/:id", CheckAdminLogin, requirePermission("users:edit:all"), admin.UpdateAdmin);

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -34,6 +34,8 @@ router.post("/admin/forgot", forgotLimiter, auth.ForgotPassword);
 router.post("/admin/reset", auth.ResetPassword);
 // Forced first-login password change (Settings Suite Slice 9).
 router.post("/admin/first-reset", CheckAdminLogin, auth.FirstResetPassword);
+// Self password change — any logged-in admin, own password only (password-mgmt Slice 1).
+router.post("/admin/change-password", CheckAdminLogin, auth.ChangeOwnPassword);
 
 // Vendor Auth
 router.post("/vendor", auth.VendorLogin);

--- a/scripts/password-mgmt-seed-permissions.js
+++ b/scripts/password-mgmt-seed-permissions.js
@@ -1,0 +1,58 @@
+/* Password-management permission seed-diff (idempotent, append-only).
+ *
+ * Grants:
+ *   team:manage_access:all → CRM Admin (and "Admin" if present)
+ * This permission gates BOTH admin-set-password (Slice 2) and disable/enable
+ * (Slice 3). The founder holds *:*:all, which already covers it — regular
+ * members do NOT get it.
+ *
+ * NOTE on the name: the brief calls it "team:manage-access"; the codebase's
+ * requirePermission parses "resource:action:scope" (3 colon-parts), so it is
+ * encoded as "team:manage_access:all".
+ *
+ * Dry-run by default; --confirm applies. Prints a per-role diff either way.
+ * Usage: node scripts/password-mgmt-seed-permissions.js [--confirm]   (NOT run against prod here)
+ */
+require("dotenv").config();
+const mongoose = require("mongoose");
+
+const CONFIRM = process.argv.includes("--confirm");
+
+const GRANTS = [
+  { roles: ["CRM Admin", "Admin"], permission: "team:manage_access:all" },
+];
+
+(async () => {
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Role = require("../models/Role");
+
+  let changes = 0;
+  for (const grant of GRANTS) {
+    for (const roleName of grant.roles) {
+      const role = await Role.findOne({ name: roleName, deletedAt: null });
+      if (!role) {
+        console.log(`- ${roleName}: NOT FOUND (skipped)`);
+        continue;
+      }
+      if ((role.permissions || []).includes(grant.permission)) {
+        console.log(`= ${roleName}: already has ${grant.permission}`);
+        continue;
+      }
+      changes++;
+      console.log(`+ ${roleName}: grant ${grant.permission}`);
+      if (CONFIRM) {
+        role.permissions.push(grant.permission);
+        await role.save();
+      }
+    }
+  }
+  console.log(
+    changes === 0
+      ? "\nNothing to do."
+      : CONFIRM
+        ? `\nApplied ${changes} grant(s).`
+        : `\nDRY RUN — ${changes} grant(s) pending. Re-run with --confirm.`
+  );
+  await mongoose.disconnect();
+  process.exit(0);
+})();

--- a/scripts/verify-password-mgmt.js
+++ b/scripts/verify-password-mgmt.js
@@ -1,0 +1,114 @@
+/* Password management + access control verification. Port 8160.
+ * Slice 1 self-change · Slice 2 admin-set · Slice 3 disable/enable enforcement.
+ * Boots the real server; exercises the real login + CheckAdminLogin paths. */
+require("dotenv").config();
+const { spawn } = require("child_process");
+const mongoose = require("mongoose");
+
+const PORT = 8160; const BASE = `http://localhost:${PORT}`; const MARK = "PWMGMT";
+let pass = 0, fail = 0; const failures = [];
+const ok = (c, l) => { if (c) { pass++; console.log(`  ✓ ${l}`); } else { fail++; failures.push(l); console.error(`  ✗ ${l}`); } };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const waitFor = async (fn, l, t = 30000) => { const u = Date.now() + t; while (Date.now() < u) { try { const v = await fn(); if (v) return v; } catch (_) {} await sleep(300); } throw new Error(`waitFor: ${l}`); };
+
+(async () => {
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Admin = require("../models/Admin"); const Role = require("../models/Role"); const Department = require("../models/Department");
+  const ActivityLog = require("../models/ActivityLog");
+  const { CreateHash } = require("../utils/password");
+
+  const dept = await Department.create({ name: `${MARK} Dept` });
+  const founderRole = await Role.create({ name: `${MARK} Founder`, departmentId: dept._id, permissions: ["*:*:all"] });
+  const mgrRole = await Role.create({ name: `${MARK} Manager`, departmentId: dept._id, permissions: ["team:manage_access:all", "leads:view:all"] });
+  const memberRole = await Role.create({ name: `${MARK} Member`, departmentId: dept._id, permissions: ["leads:view:own"] });
+  const OLD = "OldPass123";
+  const mk = async (label, role) => Admin.create({ name: `${MARK} ${label}`, email: `pwm-${label.toLowerCase()}-${Date.now()}@test.local`, phone: `9193${String(Date.now()).slice(-6)}${label.length}`, password: await CreateHash(OLD), roleIds: [role._id], departmentId: dept._id, status: "active" });
+  const FOUNDER = await mk("Founder", founderRole);
+  const MANAGER = await mk("Manager", mgrRole);
+  const MEMBER = await mk("Member", memberRole);
+  const TARGET = await mk("Target", memberRole);
+
+  const child = spawn("node", ["server.js"], { cwd: `${__dirname}/..`, env: { ...process.env, PORT: String(PORT) }, stdio: ["ignore", "pipe", "pipe"] });
+  let log = ""; child.stdout.on("data", (d) => (log += d)); child.stderr.on("data", (d) => (log += d));
+  const api = async (m, p, t, b) => { const r = await fetch(`${BASE}${p}`, { method: m, headers: { ...(t ? { Authorization: `Bearer ${t}` } : {}), ...(b ? { "Content-Type": "application/json" } : {}) }, body: b ? JSON.stringify(b) : undefined }); let d = null; try { d = await r.json(); } catch (_) {} return { status: r.status, data: d }; };
+  const login = async (admin, password) => api("POST", "/auth/admin", null, { email: admin.email, password });
+
+  try {
+    await waitFor(() => fetch(`${BASE}/`).then((r) => r.ok).catch(() => false), "boot");
+    const mgrLogin = await login(MANAGER, OLD); const mgrTok = mgrLogin.data.token;
+    const memberLogin = await login(MEMBER, OLD); const memberTok = memberLogin.data.token;
+    const founderLogin = await login(FOUNDER, OLD); const founderTok = founderLogin.data.token;
+    ok(mgrTok && memberTok && founderTok, "baseline: all admins log in with the seeded password");
+
+    console.log("\n── Slice 1: self password change ──");
+    const wrongCur = await api("POST", "/auth/admin/change-password", memberTok, { currentPassword: "WrongCurrent", newPassword: "BrandNew123" });
+    ok(wrongCur.status === 401, "wrong current password → 401");
+    const tooShort = await api("POST", "/auth/admin/change-password", memberTok, { currentPassword: OLD, newPassword: "short" });
+    ok(tooShort.status === 400, "new password < 8 chars → 400");
+    const same = await api("POST", "/auth/admin/change-password", memberTok, { currentPassword: OLD, newPassword: OLD });
+    ok(same.status === 400, "new == current → 400");
+    const changed = await api("POST", "/auth/admin/change-password", memberTok, { currentPassword: OLD, newPassword: "MemberNew123" });
+    ok(changed.status === 200, "self change succeeds with correct current");
+    ok((await login(MEMBER, OLD)).status === 401, "old password no longer works");
+    ok((await login(MEMBER, "MemberNew123")).status === 200, "new password works");
+    // Self-only: MEMBER's change did not touch TARGET (no target field exists).
+    ok((await login(TARGET, OLD)).status === 200, "another admin's password is untouched (self-only)");
+
+    console.log("\n── Slice 2: admin sets a member's password ──");
+    const noPerm = await api("POST", "/admin/set-password", memberTok, { targetAdminId: String(TARGET._id), newPassword: "Hacked123" });
+    ok(noPerm.status === 403, "member WITHOUT team:manage_access → 403");
+    const shortSet = await api("POST", "/admin/set-password", mgrTok, { targetAdminId: String(TARGET._id), newPassword: "short" });
+    ok(shortSet.status === 400, "set-password < 8 → 400");
+    const setPw = await api("POST", "/admin/set-password", mgrTok, { targetAdminId: String(TARGET._id), newPassword: "SetByMgr123" });
+    ok(setPw.status === 200, "manager WITH permission sets the target's password");
+    ok((await login(TARGET, "SetByMgr123")).status === 200, "target logs in with the manager-set password");
+    ok((await login(TARGET, OLD)).status === 401, "target's old password no longer works");
+    const auditPw = await ActivityLog.findOne({ action: "admin.password_set", entityId: String(TARGET._id) }).lean();
+    ok(!!auditPw && String(auditPw.actorId) === String(MANAGER._id), "audit entry written (who set whose password)");
+    ok(auditPw && !JSON.stringify(auditPw).includes("SetByMgr123"), "audit entry does NOT contain the password");
+
+    console.log("\n── Slice 3: disable / re-enable enforcement ──");
+    const targetTok = (await login(TARGET, "SetByMgr123")).data.token;
+    ok(!!targetTok, "target has a live token before disable");
+    const memberDisable = await api("POST", "/admin/access", memberTok, { targetAdminId: String(TARGET._id), disabled: true });
+    ok(memberDisable.status === 403, "member WITHOUT permission cannot disable → 403");
+    const disable = await api("POST", "/admin/access", mgrTok, { targetAdminId: String(TARGET._id), disabled: true });
+    ok(disable.status === 200, "manager disables the target");
+    ok((await login(TARGET, "SetByMgr123")).status === 403, "disabled admin CANNOT log in → 403");
+    const tokenAfterDisable = await api("GET", "/auth/admin/permissions", targetTok);
+    ok(tokenAfterDisable.status === 403, "EXISTING token rejected by CheckAdminLogin after disable (immediate cut)");
+    const auditDisable = await ActivityLog.findOne({ action: "admin.disabled", entityId: String(TARGET._id) }).lean();
+    ok(!!auditDisable && String(auditDisable.actorId) === String(MANAGER._id), "disable audited (who disabled whom)");
+
+    const reenable = await api("POST", "/admin/access", mgrTok, { targetAdminId: String(TARGET._id), disabled: false });
+    ok(reenable.status === 200, "manager re-enables the target");
+    ok((await login(TARGET, "SetByMgr123")).status === 200, "re-enabled admin can log in again");
+    ok(!!(await ActivityLog.findOne({ action: "admin.enabled", entityId: String(TARGET._id) }).lean()), "re-enable audited");
+
+    console.log("\n── Slice 3: safety guards ──");
+    const selfDisable = await api("POST", "/admin/access", mgrTok, { targetAdminId: String(MANAGER._id), disabled: true });
+    ok(selfDisable.status === 400, "cannot disable yourself → 400");
+    const disableFounder = await api("POST", "/admin/access", mgrTok, { targetAdminId: String(FOUNDER._id), disabled: true });
+    ok(disableFounder.status === 403, "non-founder cannot disable a founder → 403");
+    ok((await login(FOUNDER, OLD)).status === 200, "founder still logs in (was never disabled)");
+    // Founder CAN disable a regular member (positive control).
+    const founderDisablesMember = await api("POST", "/admin/access", founderTok, { targetAdminId: String(TARGET._id), disabled: true });
+    ok(founderDisablesMember.status === 200, "founder can disable a member (positive control)");
+    await api("POST", "/admin/access", founderTok, { targetAdminId: String(TARGET._id), disabled: false });
+
+    console.log("\n── Regression: normal admins unaffected ──");
+    ok((await login(MANAGER, OLD)).status === 200, "normal admin login still works");
+    ok((await api("GET", "/auth/admin/permissions", mgrTok)).status === 200, "auth-protected route works for an enabled admin");
+  } catch (e) {
+    fail++; failures.push(`fatal: ${e.message}`); console.error("FATAL", e); console.error(log.slice(-1500));
+  } finally {
+    await ActivityLog.deleteMany({ entityType: "admin", entityId: { $in: [FOUNDER, MANAGER, MEMBER, TARGET].map((a) => String(a._id)) } });
+    await Admin.deleteMany({ _id: { $in: [FOUNDER._id, MANAGER._id, MEMBER._id, TARGET._id] } });
+    await Role.deleteMany({ _id: { $in: [founderRole._id, mgrRole._id, memberRole._id] } });
+    await Department.deleteMany({ _id: dept._id });
+    child.kill(); await mongoose.disconnect();
+    console.log(`\n══ RESULT: ${pass} passed, ${fail} failed ══`);
+    if (failures.length) console.log("failures:", failures.join(" | "));
+    process.exit(fail === 0 ? 0 : 1);
+  }
+})();


### PR DESCRIPTION
Self password change; admin set-password for any member (team:manage_access gated); disable/enable access enforced in auth middleware (existing tokens rejected immediately); self/founder lockout guards; ActivityLog audit; bcrypt reused.