### PR TITLE
MB8a Lead Team Roster: append-only LeadTeamMember, assign-team panel, soft visibility (no 403 gating), full-context transfer

### DIFF
--- a/controllers/leadTeam.js
+++ b/controllers/leadTeam.js
@@ -1,0 +1,85 @@
+const mongoose = require("mongoose");
+const Enquiry = require("../models/Enquiry");
+const LeadTeamService = require("../services/LeadTeamService");
+
+const respond = (res, error) => {
+  const status = error.status || 500;
+  res.status(status).json({ message: status === 500 ? "Server error" : error.message });
+};
+
+// Lead-scope guard (mirrors leadChat): the lead must satisfy the caller's scope
+// filter (built by requirePermission with ownerField assignedTo). all-scope →
+// {} → no narrowing. SOFT visibility: this only narrows by the caller's normal
+// lead scope — it adds NO roster-based 403 gating (v1 is additive, not blocking).
+const assertInScope = async (id, scopeFilter = {}) => {
+  if (!mongoose.Types.ObjectId.isValid(id))
+    throw Object.assign(new Error("Invalid lead id"), { status: 400 });
+  const inScope = await Enquiry.findOne({ $and: [{ _id: id }, scopeFilter || {}] }, { _id: 1 }).lean();
+  if (!inScope) throw Object.assign(new Error("Out of your scope"), { status: 403 });
+};
+
+// GET /enquiry/:_id/team — current roster + full append-only history.
+const Get = async (req, res) => {
+  try {
+    await assertInScope(req.params._id, req.scopeFilter);
+    res.status(200).json(await LeadTeamService.listRoster(req.params._id));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// GET /enquiry/:_id/team/options — people grouped by department (the add control).
+const Options = async (req, res) => {
+  try {
+    await assertInScope(req.params._id, req.scopeFilter);
+    res.status(200).json(await LeadTeamService.peopleOptions());
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// POST /enquiry/:_id/team — { personId, departmentId? } → add to roster.
+const Add = async (req, res) => {
+  try {
+    await assertInScope(req.params._id, req.scopeFilter);
+    const member = await LeadTeamService.addMember(
+      req.params._id,
+      { personId: req.body?.personId, departmentId: req.body?.departmentId },
+      req.auth.user_id
+    );
+    res.status(201).json(member);
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// DELETE /enquiry/:_id/team/:memberId — close the active membership (kept in history).
+const Remove = async (req, res) => {
+  try {
+    await assertInScope(req.params._id, req.scopeFilter);
+    const member = await LeadTeamService.removeMember(req.params._id, req.params.memberId, req.auth.user_id);
+    res.status(200).json(member);
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// GET /enquiry/team/mine — leads the CALLER is currently rostered on. SOFT,
+// ADDITIVE surface (Slice 3): this is deliberately NOT narrowed by the caller's
+// ownership scope — being on the roster is itself the (soft) grant, so a member
+// sees leads they're on the team for ALONGSIDE their normal access. No 403
+// gating is introduced anywhere; requirePermission only confirms the caller is
+// an authenticated lead-viewer.
+const MyLeads = async (req, res) => {
+  try {
+    const ids = await LeadTeamService.myTeamLeadIds(req.auth.user_id);
+    const list = ids.length
+      ? await Enquiry.find({ _id: { $in: ids } }).sort({ updatedAt: -1 }).lean()
+      : [];
+    res.status(200).json({ list, total: list.length, page: 1, totalPages: 1 });
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+module.exports = { Get, Options, Add, Remove, MyLeads };

--- a/models/LeadTeamMember.js
+++ b/models/LeadTeamMember.js
@@ -1,0 +1,45 @@
+const mongoose = require("mongoose");
+const ObjectId = mongoose.Schema.Types.ObjectId;
+
+// ── MB8a Slice 1 — the lead TEAM ROSTER (Client Journey Engine foundation) ────
+// A lead can have a team: a roster of members drawn from the company's
+// departments, assembled by the sales lead (the lead's owner) or anyone with a
+// broader manage-team scope (Revenue Head) after their offline huddle.
+//
+// APPEND-ONLY by design. A row is NEVER hard-deleted:
+//   • CURRENT team  = rows with activeTo == null.
+//   • HISTORY       = the full sequence; removing a member sets activeTo +
+//                     removedBy and keeps the record. Re-adding the same person
+//                     writes a fresh row.
+// There are intentionally NO update/hard-delete repository helpers.
+//
+// A dedicated collection (NOT embedded on Enquiry) because: the gated Enquiry
+// document stays untouched; the append-only history is unbounded and shouldn't
+// bloat the hot lead doc; and "leads I'm on the team for" is a cheap indexed
+// read ({ personId, activeTo: null }). Mirrors the existing VenueTeamMember shape.
+const LeadTeamMemberSchema = new mongoose.Schema(
+  {
+    leadId: { type: ObjectId, ref: "Enquiry", required: true },
+    personId: { type: ObjectId, ref: "Admin", required: true },
+    // The department this person is SERVING on this lead. An admin can belong to
+    // multiple departments (via their roles) — this captures which one applies
+    // here. Name is denormalized at write time so history reads survive renames.
+    departmentId: { type: ObjectId, ref: "Department", default: null },
+    departmentName: { type: String, default: "" },
+    addedBy: { type: ObjectId, ref: "Admin", default: null },
+    addedAt: { type: Date, default: Date.now },
+    activeFrom: { type: Date, default: Date.now },
+    // null == still on the team. Set (with removedBy) when removed — never deleted.
+    activeTo: { type: Date, default: null },
+    removedBy: { type: ObjectId, ref: "Admin", default: null },
+  },
+  { timestamps: true }
+);
+
+// Current-team reads and "leads I'm on" reads are the hot paths.
+LeadTeamMemberSchema.index({ leadId: 1, activeTo: 1 });
+LeadTeamMemberSchema.index({ personId: 1, activeTo: 1 });
+
+module.exports =
+  mongoose.models.LeadTeamMember ||
+  mongoose.model("LeadTeamMember", LeadTeamMemberSchema);

--- a/repositories/LeadTeamMemberRepository.js
+++ b/repositories/LeadTeamMemberRepository.js
@@ -1,0 +1,60 @@
+const LeadTeamMember = require("../models/LeadTeamMember");
+
+// ── MB8a Slice 1 — append-only roster repository ──────────────────────────────
+// Add a row, close a row (remove), and read. There are deliberately NO update or
+// hard-delete helpers — the roster is append-only history.
+
+const create = async (entry) => {
+  return await LeadTeamMember.create(entry);
+};
+
+// Full timeline for a lead, oldest-first (the history view reads this).
+const findByLead = async (leadId) => {
+  return await LeadTeamMember.find({ leadId }).sort({ activeFrom: 1, createdAt: 1 }).lean();
+};
+
+// Current team for a lead — rows still active (activeTo null).
+const findCurrentByLead = async (leadId) => {
+  return await LeadTeamMember.find({ leadId, activeTo: null }).sort({ addedAt: 1 }).lean();
+};
+
+// A specific active membership (used for dup-checks and to resolve a remove).
+const findActiveById = async (memberId) => {
+  return await LeadTeamMember.findOne({ _id: memberId, activeTo: null }).lean();
+};
+
+// Is this person already actively serving this department on this lead?
+// departmentId may be null (no-department membership) — match that too.
+const findActiveMembership = async (leadId, personId, departmentId) => {
+  return await LeadTeamMember.findOne({
+    leadId,
+    personId,
+    departmentId: departmentId || null,
+    activeTo: null,
+  }).lean();
+};
+
+// Close an active row: set activeTo + removedBy. The record is retained.
+const close = async (memberId, removedBy, when) => {
+  return await LeadTeamMember.findOneAndUpdate(
+    { _id: memberId, activeTo: null },
+    { $set: { activeTo: when || new Date(), removedBy: removedBy || null } },
+    { new: true }
+  ).lean();
+};
+
+// Lead ids this person is CURRENTLY on the team for (the "my leads" surface).
+const findActiveLeadIdsByPerson = async (personId) => {
+  const rows = await LeadTeamMember.find({ personId, activeTo: null }, { leadId: 1 }).lean();
+  return rows.map((r) => r.leadId);
+};
+
+module.exports = {
+  create,
+  findByLead,
+  findCurrentByLead,
+  findActiveById,
+  findActiveMembership,
+  close,
+  findActiveLeadIdsByPerson,
+};

--- a/routes/enquiry.js
+++ b/routes/enquiry.js
@@ -79,6 +79,16 @@ router.post(
   requirePermission("leads:edit:team", { ownerField: "assignedTo" }),
   lifecycle.BulkTransfer
 );
+// ── MB8a Slice 3 — leads I'm on the team for (additive "my leads" surface).
+// Literal path: MUST stay above /:_id. Roster-scoped inside the controller; no
+// ownerField narrowing (the roster IS the soft grant), no 403 gating added.
+const leadTeam = require("../controllers/leadTeam");
+router.get(
+  "/team/mine",
+  CheckAdminLogin,
+  requirePermission("leads:view:own", { ownerField: "assignedTo" }),
+  leadTeam.MyLeads
+);
 router.get("/:_id", CheckAdminLogin, requirePermission("leads:view:own", { ownerField: "assignedTo" }), enquiry.Get);
 router.post("/:_id/user", CheckAdminLogin, enquiry.CreateUser);
 router.post("/:_id/conversations", CheckAdminLogin, enquiry.AddConversation);
@@ -175,6 +185,37 @@ router.delete(
   CheckAdminLogin,
   requirePermission("leads:edit:own"),
   leadChat.Remove
+);
+
+// ── MB8a Slices 1–2 — lead TEAM ROSTER (Client Journey Engine foundation) ─────
+// Read routes: leads:view scope. Modify routes: leads:edit scope. BOTH gate via
+// ownerField assignedTo, so the lead's OWNER (the sales lead, own-scope) manages
+// their own lead's team, while a broader-scope role (Revenue Head, team scope)
+// manages teams across the leads in their scope. No new permission, no RBAC
+// vocabulary change, no roster-based 403 gating — visibility stays soft (v1).
+router.get(
+  "/:_id/team",
+  CheckAdminLogin,
+  requirePermission("leads:view:own", { ownerField: "assignedTo" }),
+  leadTeam.Get
+);
+router.get(
+  "/:_id/team/options",
+  CheckAdminLogin,
+  requirePermission("leads:view:own", { ownerField: "assignedTo" }),
+  leadTeam.Options
+);
+router.post(
+  "/:_id/team",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own", { ownerField: "assignedTo" }),
+  leadTeam.Add
+);
+router.delete(
+  "/:_id/team/:memberId",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own", { ownerField: "assignedTo" }),
+  leadTeam.Remove
 );
 
 // ── MB7b Slice 4 — WhatsApp-group one-tap toggle (red-flag → Yes) ─────────────

--- a/scripts/verify-mb8a.js
+++ b/scripts/verify-mb8a.js
@@ -1,0 +1,141 @@
+/* MB8a — Lead Team Roster layer. Verifies the append-only roster, the
+ * department-grouped people options (multi-department), actor-named journey
+ * events, SOFT additive visibility (my-team + notification, NO 403 gating), and
+ * full-context (untruncated history for a broad member). Test port 8155. */
+require("dotenv").config();
+const { spawn } = require("child_process");
+const mongoose = require("mongoose");
+const jwt = require("jsonwebtoken");
+
+const PORT = 8155; const BASE = `http://localhost:${PORT}`; const MARK = "MB8A";
+let pass = 0, fail = 0; const failures = [];
+const ok = (c, l) => { if (c) { pass++; console.log(`  ✓ ${l}`); } else { fail++; failures.push(l); console.error(`  ✗ ${l}`); } };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const waitFor = async (fn, l, t = 30000) => { const u = Date.now() + t; while (Date.now() < u) { try { const v = await fn(); if (v) return v; } catch (_) {} await sleep(300); } throw new Error(`waitFor: ${l}`); };
+
+(async () => {
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Admin = require("../models/Admin"); const Role = require("../models/Role"); const Department = require("../models/Department");
+  const Enquiry = require("../models/Enquiry"); const LeadTeamMember = require("../models/LeadTeamMember");
+  const AdminNotification = require("../models/AdminNotification"); const LeadInternalEvent = require("../models/LeadInternalEvent");
+
+  const sales = await Department.create({ name: `${MARK} Sales` });
+  const ops = await Department.create({ name: `${MARK} Operations` });
+  const cs = await Department.create({ name: `${MARK} ClientServicing` });
+
+  const ownRoleSales = await Role.create({ name: `${MARK} SalesExec`, departmentId: sales._id, permissions: ["leads:view:own", "leads:edit:own"] });
+  const revHeadRole = await Role.create({ name: `${MARK} RevHead`, departmentId: sales._id, permissions: ["leads:view:all", "leads:edit:all"] });
+  const opsRole = await Role.create({ name: `${MARK} OpsExec`, departmentId: ops._id, permissions: ["leads:view:own", "leads:edit:own"] });
+
+  const u = (s) => `9197${String(Date.now()).slice(-7)}${s}`;
+  const mk = (name, roleIds, departmentId) => Admin.create({ name, email: `${name.replace(/\s/g, "")}-${Date.now()}@t.local`, phone: u(Math.floor(Math.random() * 9)), password: "x", roleIds, departmentId, status: "active" });
+  const OWNER = await mk(`${MARK} Owner`, [ownRoleSales._id], sales._id);          // sales lead (owns the lead)
+  const REVHEAD = await mk(`${MARK} RevHead`, [revHeadRole._id], sales._id);        // broad manage-team
+  const OPS = await mk(`${MARK} OpsPerson`, [opsRole._id], ops._id);                // narrow, will be rostered
+  const MULTI = await mk(`${MARK} MultiDept`, [ownRoleSales._id, opsRole._id], sales._id); // two departments
+
+  const tok = (a) => jwt.sign({ _id: String(a._id), isAdmin: true }, process.env.JWT_SECRET);
+  const ownerT = tok(OWNER), revT = tok(REVHEAD), opsT = tok(OPS);
+
+  const phone = `9190${String(Date.now()).slice(-8)}`;
+  const lead = await Enquiry.create({ name: "Roster Couple", phone, verified: false, source: "Website", stage: "lead", assignedTo: OWNER._id, additionalInfo: {} });
+
+  const child = spawn("node", ["server.js"], { cwd: `${__dirname}/..`, env: { ...process.env, PORT: String(PORT) }, stdio: ["ignore", "pipe", "pipe"] });
+  let log = ""; child.stdout.on("data", (d) => (log += d)); child.stderr.on("data", (d) => (log += d));
+  const api = async (m, p, t, b) => { const r = await fetch(`${BASE}${p}`, { method: m, headers: { ...(t ? { Authorization: `Bearer ${t}` } : {}), ...(b ? { "Content-Type": "application/json" } : {}) }, body: b ? JSON.stringify(b) : undefined }); let d = null; try { d = await r.json(); } catch (_) {} return { status: r.status, data: d }; };
+
+  try {
+    await waitFor(() => fetch(`${BASE}/`).then((r) => r.ok).catch(() => false), "boot");
+
+    console.log("\n── Slice 2: people options grouped by department (multi-dept) ──");
+    const opt = await api("GET", `/enquiry/${lead._id}/team/options`, ownerT);
+    ok(opt.status === 200 && Array.isArray(opt.data.groups), "options returns department groups");
+    const byName = Object.fromEntries((opt.data.groups || []).map((g) => [g.departmentName, g.people.map((p) => p._id)]));
+    ok((byName[`${MARK} Sales`] || []).includes(String(MULTI._id)), "multi-dept person appears under Sales");
+    ok((byName[`${MARK} Operations`] || []).includes(String(MULTI._id)), "multi-dept person appears under Operations (same person, both groups)");
+    ok((byName[`${MARK} Operations`] || []).includes(String(OPS._id)), "ops person appears under Operations");
+
+    console.log("\n── Slice 1: add member → current team + actor-named journey ──");
+    const add1 = await api("POST", `/enquiry/${lead._id}/team`, ownerT, { personId: String(OPS._id), departmentId: String(ops._id) });
+    ok(add1.status === 201 && add1.data.personId === String(OPS._id) && add1.data.active === true, "owner adds ops person → active roster row");
+    ok(add1.data.departmentName === `${MARK} Operations`, "serving department captured + denormalized");
+
+    const roster1 = await api("GET", `/enquiry/${lead._id}/team`, ownerT);
+    ok(roster1.status === 200 && roster1.data.current.length === 1, "current team has 1 member");
+
+    const journey1 = await api("GET", `/enquiry/${lead._id}/journey`, ownerT);
+    const added = (journey1.data.entries || []).find((e) => e.type === "team_member_added");
+    ok(!!added, "journey has team_member_added event");
+    ok(added && added.actor === `${MARK} Owner`, "journey event actor is the person who added (Owner)");
+    ok(added && /Added .*OpsPerson.*Operations.*team/.test(added.title), `journey title names person + department ("${added && added.title}")`);
+
+    console.log("\n── Slice 3: notification + additive my-team (NO 403 gating) ──");
+    const note = await waitFor(async () => { const n = await AdminNotification.findOne({ adminId: OPS._id, type: "team_added" }).lean(); return n || false; }, "team_added notification");
+    ok(!!note && String(note.leadId) === String(lead._id), "added member receives a team_added notification for this lead");
+
+    const mine = await api("GET", `/enquiry/team/mine`, opsT);
+    ok(mine.status === 200 && (mine.data.list || []).some((l) => String(l._id) === String(lead._id)), "ops sees the lead in /team/mine (additive — they don't own it)");
+
+    // SOFT: roster does NOT bypass scope. OPS is own-scope and does NOT own the
+    // lead → the scoped single read stays out-of-scope (existing behavior: 404,
+    // "does not reveal it exists"). Roster is additive (surfaces via /team/mine),
+    // never a scope-bypass; requirePermission is untouched.
+    const opsDirect = await api("GET", `/enquiry/${lead._id}`, opsT);
+    ok(opsDirect.status === 404, "rostered own-scope non-owner stays out-of-scope on the scoped lead read (404, unchanged) — roster never bypasses scope");
+
+    // NON-rostered broad-permission user can STILL open the lead — no roster gating added.
+    const revLead = await api("GET", `/enquiry/${lead._id}`, revT);
+    ok(revLead.status === 200, "non-rostered broad-permission user can still open the lead (no 403 gating)");
+    const revTeam = await api("GET", `/enquiry/${lead._id}/team`, revT);
+    ok(revTeam.status === 200, "non-rostered broad user can read the roster (no 403 gating)");
+
+    console.log("\n── Slice 2: Revenue Head manages a lead they don't own + dup guard ──");
+    const add2 = await api("POST", `/enquiry/${lead._id}/team`, revT, { personId: String(MULTI._id), departmentId: String(sales._id) });
+    ok(add2.status === 201, "Revenue Head (broad) adds a member to a lead they don't own");
+    const dup = await api("POST", `/enquiry/${lead._id}/team`, ownerT, { personId: String(OPS._id), departmentId: String(ops._id) });
+    ok(dup.status === 409, "duplicate active membership (same person+dept) is rejected");
+    const ambiguous = await api("POST", `/enquiry/${lead._id}/team`, ownerT, { personId: String(MULTI._id) });
+    ok(ambiguous.status === 400, "multi-department person without a chosen department → 400");
+
+    console.log("\n── Slice 1: remove keeps history (append-only) ──");
+    const beforeRows = await LeadTeamMember.countDocuments({ leadId: lead._id });
+    const rm = await api("DELETE", `/enquiry/${lead._id}/team/${add1.data._id}`, ownerT);
+    ok(rm.status === 200 && rm.data.active === false && !!rm.data.activeTo, "remove sets activeTo (row closed, not deleted)");
+    const afterRows = await LeadTeamMember.countDocuments({ leadId: lead._id });
+    ok(beforeRows === afterRows, "row count unchanged after remove → record retained (append-only)");
+    const closedRow = await LeadTeamMember.findById(add1.data._id).lean();
+    ok(closedRow && closedRow.activeTo && String(closedRow.removedBy) === String(OWNER._id), "closed row keeps removedBy + activeTo");
+
+    const roster2 = await api("GET", `/enquiry/${lead._id}/team`, ownerT);
+    ok(roster2.data.current.length === 1 && roster2.data.current[0].personId === String(MULTI._id), "current team reflects removal (only MULTI remains)");
+    ok(roster2.data.history.length === 2, "history retains BOTH the removed and active rows");
+
+    // Re-add the removed person → a NEW row (append-only), old row retained.
+    const readd = await api("POST", `/enquiry/${lead._id}/team`, ownerT, { personId: String(OPS._id), departmentId: String(ops._id) });
+    ok(readd.status === 201 && readd.data._id !== add1.data._id, "re-adding writes a NEW row (append-only), old row untouched");
+    const roster3 = await api("GET", `/enquiry/${lead._id}/team`, ownerT);
+    ok(roster3.data.history.length === 3, "history now has 3 rows (removed + active + re-added)");
+
+    console.log("\n── Slice 4: full-context — broad member sees untruncated history ──");
+    // REVHEAD joined AFTER the lead was created; they must still see the lead's
+    // creation event and every team event — nothing truncated by activeFrom.
+    const revJourney = await api("GET", `/enquiry/${lead._id}/journey`, revT);
+    const types = (revJourney.data.entries || []).map((e) => e.type);
+    ok(revJourney.status === 200 && types.includes("created"), "broad member sees the lead's creation event (history not truncated to join time)");
+    ok(types.filter((t) => t === "team_member_added").length >= 2, "broad member sees all prior team events");
+  } catch (e) {
+    fail++; failures.push(`fatal: ${e.message}`); console.error("FATAL", e); console.error(log.slice(-1800));
+  } finally {
+    await LeadTeamMember.deleteMany({ leadId: lead._id });
+    await LeadInternalEvent.deleteMany({ leadId: lead._id });
+    await AdminNotification.deleteMany({ adminId: { $in: [OWNER._id, REVHEAD._id, OPS._id, MULTI._id] } });
+    await Enquiry.deleteMany({ _id: lead._id });
+    await Admin.deleteMany({ _id: { $in: [OWNER._id, REVHEAD._id, OPS._id, MULTI._id] } });
+    await Role.deleteMany({ _id: { $in: [ownRoleSales._id, revHeadRole._id, opsRole._id] } });
+    await Department.deleteMany({ _id: { $in: [sales._id, ops._id, cs._id] } });
+    child.kill(); await mongoose.disconnect();
+    console.log(`\n══ RESULT: ${pass} passed, ${fail} failed ══`);
+    if (failures.length) console.log("failures:", failures.join(" | "));
+    process.exit(fail === 0 ? 0 : 1);
+  }
+})();

--- a/services/JourneyService.js
+++ b/services/JourneyService.js
@@ -65,6 +65,9 @@ const EVENT_TITLES = {
   wa_group_created: "WhatsApp group created with the couple ✦",
   wa_group_missing: "No WhatsApp group yet — flagged",
   nurture_touch: "Nurture touch",
+  // MB8a — lead team roster (Client Journey Engine foundation).
+  team_member_added: "Team member added 🤝",
+  team_member_removed: "Team member removed",
 };
 
 // Payload keys that carry an Admin id of a SECOND party (not the actor) — these
@@ -101,6 +104,15 @@ const dynamicTitle = (type, payload = {}, nameOf) => {
     case "resurfaced_by_reenquiry": {
       const re = payload.reassignedTo ? id("reassignedTo") : null;
       return `Resurfaced — they re-enquired${re ? ` · back to ${re}` : ""}`;
+    }
+    // MB8a — name the person + their serving department (actor shown separately).
+    case "team_member_added": {
+      const who = payload.personName || id("personId") || "someone";
+      return `Added ${who}${payload.departmentName ? ` (${payload.departmentName})` : ""} to the team`;
+    }
+    case "team_member_removed": {
+      const who = payload.personName || id("personId") || "someone";
+      return `Removed ${who}${payload.departmentName ? ` (${payload.departmentName})` : ""} from the team`;
     }
     default:
       return null;

--- a/services/LeadTeamService.js
+++ b/services/LeadTeamService.js
@@ -1,0 +1,219 @@
+const mongoose = require("mongoose");
+const Admin = require("../models/Admin");
+const Department = require("../models/Department");
+const Role = require("../models/Role");
+const LeadTeamMemberRepository = require("../repositories/LeadTeamMemberRepository");
+const LeadInternalEventService = require("./LeadInternalEventService");
+const AdminNotificationService = require("./AdminNotificationService");
+const { roleIdsOf } = require("../middlewares/requirePermission");
+
+const err = (status, message) => Object.assign(new Error(message), { status });
+
+// An admin's departments = their direct departmentId UNION the department of
+// every role they hold (roles are department-scoped — RBAC v2 multi-role). This
+// is how multi-department is real per HRMS: a person under two roles in two
+// departments belongs to both.
+const departmentsOfAdmin = (admin, roleById) => {
+  const ids = new Set();
+  if (admin.departmentId) ids.add(String(admin.departmentId));
+  for (const rid of roleIdsOf(admin)) {
+    const role = roleById.get(String(rid));
+    if (role && role.departmentId) ids.add(String(role.departmentId));
+  }
+  return ids;
+};
+
+// People grouped by department for the Assign-Team dropdown. An admin in
+// multiple departments appears under EACH (no de-dup across groups) — multi-
+// department is intentional. Source: RBAC Departments + active admins.
+const peopleOptions = async () => {
+  const [departments, admins] = await Promise.all([
+    Department.find({ deletedAt: null }, { name: 1 }).sort({ name: 1 }).lean(),
+    Admin.find({ status: "active" }, { name: 1, departmentId: 1, roleId: 1, roleIds: 1, "meta.designation": 1 })
+      .sort({ name: 1 })
+      .lean(),
+  ]);
+
+  const roleIds = new Set();
+  for (const a of admins) for (const rid of roleIdsOf(a)) roleIds.add(String(rid));
+  const roles = roleIds.size
+    ? await Role.find({ _id: { $in: [...roleIds] } }, { departmentId: 1 }).lean()
+    : [];
+  const roleById = new Map(roles.map((r) => [String(r._id), r]));
+
+  const groups = departments.map((d) => ({
+    departmentId: String(d._id),
+    departmentName: d.name,
+    people: [],
+  }));
+  const groupByDept = new Map(groups.map((g) => [g.departmentId, g]));
+  const noDept = { departmentId: null, departmentName: "No department", people: [] };
+
+  for (const a of admins) {
+    const depIds = departmentsOfAdmin(a, roleById);
+    const person = { _id: String(a._id), name: a.name, designation: a.meta?.designation || "" };
+    if (depIds.size === 0) {
+      noDept.people.push(person);
+      continue;
+    }
+    for (const did of depIds) {
+      const g = groupByDept.get(did);
+      if (g) g.people.push(person);
+    }
+  }
+
+  const out = groups.filter((g) => g.people.length);
+  if (noDept.people.length) out.push(noDept);
+  return { groups: out };
+};
+
+// Resolve admin + department names for a set of roster rows.
+const decorate = async (rows) => {
+  const adminIds = new Set();
+  for (const r of rows) {
+    if (r.personId) adminIds.add(String(r.personId));
+    if (r.addedBy) adminIds.add(String(r.addedBy));
+    if (r.removedBy) adminIds.add(String(r.removedBy));
+  }
+  const admins = adminIds.size
+    ? await Admin.find({ _id: { $in: [...adminIds] } }, { name: 1 }).lean()
+    : [];
+  const nameOf = new Map(admins.map((a) => [String(a._id), a.name]));
+  const name = (id) => (id ? nameOf.get(String(id)) || "—" : null);
+  return rows.map((r) => ({
+    _id: String(r._id),
+    personId: String(r.personId),
+    personName: name(r.personId),
+    departmentId: r.departmentId ? String(r.departmentId) : null,
+    departmentName: r.departmentName || "",
+    addedBy: r.addedBy ? String(r.addedBy) : null,
+    addedByName: name(r.addedBy),
+    addedAt: r.addedAt,
+    activeFrom: r.activeFrom,
+    activeTo: r.activeTo || null,
+    removedBy: r.removedBy ? String(r.removedBy) : null,
+    removedByName: name(r.removedBy),
+    active: !r.activeTo,
+  }));
+};
+
+// Current team + full history for a lead.
+const listRoster = async (leadId) => {
+  if (!mongoose.Types.ObjectId.isValid(leadId)) throw err(400, "Invalid lead id");
+  const [currentRows, historyRows] = await Promise.all([
+    LeadTeamMemberRepository.findCurrentByLead(leadId),
+    LeadTeamMemberRepository.findByLead(leadId),
+  ]);
+  return {
+    current: await decorate(currentRows),
+    history: await decorate(historyRows),
+  };
+};
+
+// Add a member to the roster. Writes an append-only row, a named journey event,
+// and notifies the new member (full-context: they get the WHOLE lead, Slice 4).
+const addMember = async (leadId, { personId, departmentId }, actorId) => {
+  if (!mongoose.Types.ObjectId.isValid(leadId)) throw err(400, "Invalid lead id");
+  if (!personId || !mongoose.Types.ObjectId.isValid(String(personId)))
+    throw err(400, "personId is required");
+
+  const person = await Admin.findById(personId, { name: 1, departmentId: 1, roleId: 1, roleIds: 1 }).lean();
+  if (!person) throw err(404, "Person not found");
+
+  // Resolve which department this person is serving. If they belong to exactly
+  // one, it's implied; otherwise the caller must pick one of theirs.
+  let depId = departmentId && mongoose.Types.ObjectId.isValid(String(departmentId)) ? String(departmentId) : null;
+  const roleIds = roleIdsOf(person);
+  const roles = roleIds.length
+    ? await Role.find({ _id: { $in: roleIds } }, { departmentId: 1 }).lean()
+    : [];
+  const roleById = new Map(roles.map((r) => [String(r._id), r]));
+  const personDepts = departmentsOfAdmin(person, roleById);
+
+  if (depId) {
+    if (personDepts.size && !personDepts.has(depId))
+      throw err(400, "That person does not belong to the chosen department");
+  } else if (personDepts.size === 1) {
+    depId = [...personDepts][0];
+  } else if (personDepts.size > 1) {
+    throw err(400, "This person is in multiple departments — choose which one they serve");
+  }
+
+  let departmentName = "";
+  if (depId) {
+    const dept = await Department.findById(depId, { name: 1 }).lean();
+    if (!dept) throw err(404, "Department not found");
+    departmentName = dept.name;
+  }
+
+  // Append-only dup guard: same person + same department, still active.
+  const existing = await LeadTeamMemberRepository.findActiveMembership(leadId, personId, depId);
+  if (existing) throw err(409, "Already on this lead's team for that department");
+
+  const row = await LeadTeamMemberRepository.create({
+    leadId,
+    personId,
+    departmentId: depId,
+    departmentName,
+    addedBy: actorId || null,
+    addedAt: new Date(),
+    activeFrom: new Date(),
+    activeTo: null,
+  });
+
+  // Journey event (actor-named title built in JourneyService.dynamicTitle).
+  await LeadInternalEventService.record({
+    leadId,
+    type: "team_member_added",
+    actorId,
+    payload: { personId: String(personId), personName: person.name, departmentId: depId, departmentName },
+  });
+
+  // Full-context transfer (Slice 4): the new member is notified and the lead
+  // surfaces on their dashboard — they see the ENTIRE history, never truncated.
+  await AdminNotificationService.notify(personId, {
+    type: "team_added",
+    title: "You've been added to a lead's team",
+    message: departmentName ? `You're on this lead as ${departmentName}.` : "You're on this lead's team.",
+    leadId,
+    payload: { departmentId: depId, departmentName, addedBy: actorId ? String(actorId) : null },
+  });
+
+  return (await decorate([row]))[0];
+};
+
+// Remove a member: close the active row (activeTo + removedBy). History retained.
+const removeMember = async (leadId, memberId, actorId) => {
+  if (!mongoose.Types.ObjectId.isValid(memberId)) throw err(400, "Invalid member id");
+  const active = await LeadTeamMemberRepository.findActiveById(memberId);
+  if (!active || String(active.leadId) !== String(leadId))
+    throw err(404, "Active team member not found on this lead");
+
+  const closed = await LeadTeamMemberRepository.close(memberId, actorId, new Date());
+
+  await LeadInternalEventService.record({
+    leadId,
+    type: "team_member_removed",
+    actorId,
+    payload: {
+      personId: String(active.personId),
+      personName: (await Admin.findById(active.personId, { name: 1 }).lean())?.name || "—",
+      departmentId: active.departmentId ? String(active.departmentId) : null,
+      departmentName: active.departmentName || "",
+    },
+  });
+
+  return (await decorate([closed]))[0];
+};
+
+// Lead ids the person is CURRENTLY rostered on (the additive "my team" surface).
+const myTeamLeadIds = async (personId) => LeadTeamMemberRepository.findActiveLeadIdsByPerson(personId);
+
+module.exports = {
+  peopleOptions,
+  listRoster,
+  addMember,
+  removeMember,
+  myTeamLeadIds,
+  departmentsOfAdmin,
+};


### PR DESCRIPTION
Foundation of the Journey Engine. Dedicated LeadTeamMember collection (Enquiry model untouched), dept-grouped member assignment from RBAC multi-role union, soft visibility (roster drives my-team view + notifications, NO hard lockout — requirePermission/Enquiry/auth untouched), append-only history, actor-named journey events. Existing leads:view/edit:own permissions reused (no RBAC vocab change).