### PR TITLE
MB8b Journey Steps + Notes + Mirror Rule: configurable steps (seeded Wedsy pipeline), roster owners, 4 statuses, dependencies, step-notes mirror into lead chat

### DIFF
--- a/controllers/leadStep.js
+++ b/controllers/leadStep.js
@@ -1,0 +1,66 @@
+const mongoose = require("mongoose");
+const Enquiry = require("../models/Enquiry");
+const LeadStepService = require("../services/LeadStepService");
+
+const respond = (res, error) => {
+  const status = error.status || 500;
+  if (status === 500) console.error("[leadStep]", error);
+  res.status(status).json({ message: status === 500 ? "Server error" : error.message });
+};
+
+// Lead-scope guard (mirrors leadTeam/leadChat): the lead must satisfy the
+// caller's scope filter (requirePermission with ownerField assignedTo).
+const assertInScope = async (id, scopeFilter = {}) => {
+  if (!mongoose.Types.ObjectId.isValid(id))
+    throw Object.assign(new Error("Invalid lead id"), { status: 400 });
+  const inScope = await Enquiry.findOne({ $and: [{ _id: id }, scopeFilter || {}] }, { _id: 1 }).lean();
+  if (!inScope) throw Object.assign(new Error("Out of your scope"), { status: 403 });
+};
+
+// GET /enquiry/:_id/steps — all steps (with owners, notes, blocked hints).
+const List = async (req, res) => {
+  try {
+    await assertInScope(req.params._id, req.scopeFilter);
+    res.status(200).json({ list: await LeadStepService.listForLead(req.params._id) });
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// POST /enquiry/:_id/steps/instantiate — idempotent manual instantiation.
+const Instantiate = async (req, res) => {
+  try {
+    await assertInScope(req.params._id, req.scopeFilter);
+    res.status(200).json(await LeadStepService.instantiateForLead(req.params._id, req.auth.user_id));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// PATCH /enquiry/:_id/steps/:stepId — status / ownerIds / dueAt / dependsOn / notApplicable.
+const Patch = async (req, res) => {
+  try {
+    await assertInScope(req.params._id, req.scopeFilter);
+    res.status(200).json(await LeadStepService.patchStep(req.params._id, req.params.stepId, req.body || {}, req.auth.user_id));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// POST /enquiry/:_id/steps/:stepId/notes — add a note (mirrors into the lead chat).
+const AddNote = async (req, res) => {
+  try {
+    await assertInScope(req.params._id, req.scopeFilter);
+    const step = await LeadStepService.addNote(
+      req.params._id,
+      req.params.stepId,
+      req.auth.user_id,
+      { body: req.body?.body, mentions: req.body?.mentions }
+    );
+    res.status(201).json(step);
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+module.exports = { List, Instantiate, Patch, AddNote };

--- a/controllers/stepDefinition.js
+++ b/controllers/stepDefinition.js
@@ -1,0 +1,64 @@
+const StepDefinitionService = require("../services/StepDefinitionService");
+
+const respond = (res, error) => {
+  const status = error.status || 500;
+  if (status === 500) console.error("[stepDefinition]", error);
+  res.status(status).json({ message: status === 500 ? "Server error" : error.message });
+};
+
+// GET /step-definition — list (any admin; the lead page + instantiation read it).
+const GetAll = async (req, res) => {
+  try {
+    const includeArchived = req.query.includeArchived === "true";
+    res.status(200).json({ phases: StepDefinitionService.PHASES, list: await StepDefinitionService.list({ includeArchived }) });
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// POST /step-definition — create a step (settings:edit:all).
+const Create = async (req, res) => {
+  try {
+    res.status(201).json(await StepDefinitionService.create(req.body || {}));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// PUT /step-definition/:id — rename / toggle / re-phase.
+const Update = async (req, res) => {
+  try {
+    res.status(200).json(await StepDefinitionService.update(req.params.id, req.body || {}));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// DELETE /step-definition/:id — archive (soft).
+const Delete = async (req, res) => {
+  try {
+    res.status(200).json(await StepDefinitionService.archive(req.params.id));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// PUT /step-definition/reorder — { orderedIds: [...] }.
+const Reorder = async (req, res) => {
+  try {
+    res.status(200).json({ list: await StepDefinitionService.reorder((req.body || {}).orderedIds) });
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// POST /step-definition/seed — idempotent 3-phase Wedsy seed.
+const Seed = async (req, res) => {
+  try {
+    res.status(200).json(await StepDefinitionService.seed());
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+module.exports = { GetAll, Create, Update, Delete, Reorder, Seed };

--- a/models/LeadChatMessage.js
+++ b/models/LeadChatMessage.js
@@ -25,6 +25,9 @@ const LeadChatMessageSchema = new mongoose.Schema(
     // Per-message read receipts — GET marks the thread read for the caller.
     readBy: { type: [ObjectId], ref: "Admin", default: [] },
     taskId: { type: ObjectId, ref: "LeadTask", default: null },
+    // MB8b Slice 3 — set on a mirrored step-note system message; the chat echo
+    // links back to the step's notes thread. Additive, default null.
+    stepId: { type: ObjectId, ref: "LeadStep", default: null },
     editedAt: { type: Date, default: null },
   },
   { timestamps: true }

--- a/models/LeadStep.js
+++ b/models/LeadStep.js
@@ -1,0 +1,52 @@
+const mongoose = require("mongoose");
+const ObjectId = mongoose.Schema.Types.ObjectId;
+
+// MB8b Slice 2 — per-lead STEP INSTANCES, stamped from StepDefinition when a
+// lead enters the journey (at qualification). Owners come from the MB8a roster
+// (multi-owner allowed). Status is EXACTLY one of four. Optional steps can be
+// marked not-applicable. Dependencies (opt-in) block a step from STARTING until
+// the named steps are complete (cycle-validated, soft guard).
+const STATUSES = ["not_started", "in_progress", "awaiting_client", "complete"];
+
+// A note on the step's own contextual thread. Each note ALSO mirrors into the
+// one lead chat (LeadChatMessage) — see LeadStepService.addNote.
+const StepNoteSchema = new mongoose.Schema(
+  {
+    authorId: { type: ObjectId, ref: "Admin", default: null },
+    body: { type: String, default: "" },
+    mentions: { type: [ObjectId], ref: "Admin", default: [] },
+    // The mirrored chat message id, so the step note links to its chat echo.
+    chatMessageId: { type: ObjectId, ref: "LeadChatMessage", default: null },
+    createdAt: { type: Date, default: Date.now },
+  },
+  { _id: true }
+);
+
+const LeadStepSchema = new mongoose.Schema(
+  {
+    leadId: { type: ObjectId, ref: "Enquiry", required: true, index: true },
+    definitionId: { type: ObjectId, ref: "StepDefinition", default: null },
+    name: { type: String, required: true },
+    phase: { type: String, default: "" },
+    order: { type: Number, default: 0 },
+    // Owners assigned from the lead's current team roster (MB8a). Multi-owner.
+    ownerIds: { type: [{ type: ObjectId, ref: "Admin" }], default: [] },
+    status: { type: String, enum: STATUSES, default: "not_started" },
+    dueAt: { type: Date, default: null },
+    rolling: { type: Boolean, default: false },
+    optional: { type: Boolean, default: false },
+    // Optional steps skipped on this lead. Distinct from the 4 statuses.
+    notApplicable: { type: Boolean, default: false },
+    // Other LeadStep ids that must be complete before this one can start.
+    dependsOn: { type: [{ type: ObjectId, ref: "LeadStep" }], default: [] },
+    notes: { type: [StepNoteSchema], default: [] },
+    startedAt: { type: Date, default: null },
+    completedAt: { type: Date, default: null },
+  },
+  { timestamps: true }
+);
+
+LeadStepSchema.index({ leadId: 1, order: 1 });
+
+module.exports = mongoose.models.LeadStep || mongoose.model("LeadStep", LeadStepSchema);
+module.exports.STATUSES = STATUSES;

--- a/models/StepDefinition.js
+++ b/models/StepDefinition.js
@@ -1,0 +1,35 @@
+const mongoose = require("mongoose");
+
+// MB8b Slice 1 — the configurable journey STEP DEFINITIONS (Settings). An
+// ordered, phase-grouped template set; instances (LeadStep) are stamped per
+// lead from these. Founder / CRM-Admin editable (settings:edit:all). Mirrors the
+// CustomFieldDef pattern: defs are ARCHIVED, never hard-deleted, so already
+// instantiated LeadSteps keep a stable reference.
+const PHASES = [
+  "Lead Understanding",
+  "Client Servicing & Proposal",
+  "Follow Up & Conversion",
+];
+
+const StepDefinitionSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true, trim: true },
+    phase: { type: String, required: true },
+    order: { type: Number, default: 0 }, // global order across all phases
+    // Optional default serving department (a hint for owner assignment).
+    defaultDepartment: { type: String, default: "" },
+    // rolling = recurs throughout the journey (e.g. Client Follow Up); optional =
+    // may be skipped / marked not-applicable on a lead.
+    rolling: { type: Boolean, default: false },
+    optional: { type: Boolean, default: false },
+    status: { type: String, enum: ["active", "archived"], default: "active" },
+    // Stable key for idempotent seeding (seed never clobbers admin edits).
+    systemKey: { type: String, default: "" },
+  },
+  { timestamps: true }
+);
+
+StepDefinitionSchema.index({ status: 1, order: 1 });
+
+module.exports = mongoose.models.StepDefinition || mongoose.model("StepDefinition", StepDefinitionSchema);
+module.exports.PHASES = PHASES;

--- a/repositories/LeadStepRepository.js
+++ b/repositories/LeadStepRepository.js
@@ -1,0 +1,16 @@
+const LeadStep = require("../models/LeadStep");
+
+const findByLead = async (leadId) => LeadStep.find({ leadId }).sort({ order: 1 }).lean();
+
+const countByLead = async (leadId) => LeadStep.countDocuments({ leadId });
+
+const findById = async (id) => LeadStep.findById(id);
+
+const findByIdLean = async (id) => LeadStep.findById(id).lean();
+
+const insertMany = async (rows) => LeadStep.insertMany(rows);
+
+const updateById = async (id, update) =>
+  LeadStep.findByIdAndUpdate(id, update, { new: true, runValidators: true }).lean();
+
+module.exports = { findByLead, countByLead, findById, findByIdLean, insertMany, updateById };

--- a/repositories/StepDefinitionRepository.js
+++ b/repositories/StepDefinitionRepository.js
@@ -1,0 +1,24 @@
+const StepDefinition = require("../models/StepDefinition");
+
+// Active definitions, ordered. Reads power both the Settings editor and per-lead
+// instantiation.
+const findActive = async () => StepDefinition.find({ status: "active" }).sort({ order: 1 }).lean();
+
+const findAll = async () => StepDefinition.find({}).sort({ order: 1 }).lean();
+
+const findById = async (id) => StepDefinition.findById(id);
+
+const findBySystemKey = async (systemKey) => StepDefinition.findOne({ systemKey }).lean();
+
+const create = async (fields) => StepDefinition.create(fields);
+
+const updateById = async (id, fields) =>
+  StepDefinition.findByIdAndUpdate(id, { $set: fields }, { new: true, runValidators: true }).lean();
+
+// Highest current order (so a new step appends to the end).
+const maxOrder = async () => {
+  const top = await StepDefinition.findOne({}, { order: 1 }).sort({ order: -1 }).lean();
+  return top ? top.order || 0 : 0;
+};
+
+module.exports = { findActive, findAll, findById, findBySystemKey, create, updateById, maxOrder };

--- a/routes/enquiry.js
+++ b/routes/enquiry.js
@@ -218,6 +218,36 @@ router.delete(
   leadTeam.Remove
 );
 
+// ── MB8b Slices 2–4 — per-lead JOURNEY STEPS (status, owners, deps, notes) ────
+// Reads gate leads:view scope; mutations gate leads:edit scope. Both via
+// ownerField assignedTo (same model as the roster) — owner manages own lead's
+// steps, broader-scope roles manage across their scope.
+const leadStep = require("../controllers/leadStep");
+router.get(
+  "/:_id/steps",
+  CheckAdminLogin,
+  requirePermission("leads:view:own", { ownerField: "assignedTo" }),
+  leadStep.List
+);
+router.post(
+  "/:_id/steps/instantiate",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own", { ownerField: "assignedTo" }),
+  leadStep.Instantiate
+);
+router.patch(
+  "/:_id/steps/:stepId",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own", { ownerField: "assignedTo" }),
+  leadStep.Patch
+);
+router.post(
+  "/:_id/steps/:stepId/notes",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own", { ownerField: "assignedTo" }),
+  leadStep.AddNote
+);
+
 // ── MB7b Slice 4 — WhatsApp-group one-tap toggle (red-flag → Yes) ─────────────
 const nurture = require("../controllers/nurture");
 router.post(

--- a/routes/router.js
+++ b/routes/router.js
@@ -14,6 +14,7 @@ router.use("/enquiry", require("./enquiry"));
 router.use("/project", require("./project")); // Lifecycle Slice D
 router.use("/settings", require("./settings")); // Settings Suite
 router.use("/custom-field", require("./custom-field")); // Settings Suite
+router.use("/step-definition", require("./step-definition")); // MB8b journey steps
 router.use("/decor", require("./decor"));
 router.use("/decor-package", require("./decor-package"));
 router.use("/search", require("./search"));

--- a/routes/step-definition.js
+++ b/routes/step-definition.js
@@ -1,0 +1,19 @@
+const express = require("express");
+const router = express.Router();
+
+const stepDefinition = require("../controllers/stepDefinition");
+const { CheckAdminLogin } = require("../middlewares/auth");
+const { requirePermission } = require("../middlewares/requirePermission");
+
+// MB8b Slice 1 — configurable journey step definitions (Settings). Reads are
+// open to any admin (the lead page + per-lead instantiation render the defs).
+// Writes are gated settings:edit:all — satisfied by Founder (*:*:all) and
+// CRM-Admin (settings:*:all). No new RBAC vocabulary.
+router.get("/", CheckAdminLogin, stepDefinition.GetAll);
+router.post("/", CheckAdminLogin, requirePermission("settings:edit:all"), stepDefinition.Create);
+router.put("/reorder", CheckAdminLogin, requirePermission("settings:edit:all"), stepDefinition.Reorder);
+router.post("/seed", CheckAdminLogin, requirePermission("settings:edit:all"), stepDefinition.Seed);
+router.put("/:id", CheckAdminLogin, requirePermission("settings:edit:all"), stepDefinition.Update);
+router.delete("/:id", CheckAdminLogin, requirePermission("settings:edit:all"), stepDefinition.Delete);
+
+module.exports = router;

--- a/scripts/seed-step-definitions.js
+++ b/scripts/seed-step-definitions.js
@@ -1,0 +1,16 @@
+/* MB8b — seed the 3-phase Wedsy journey step definitions. Idempotent:
+ * re-running inserts only missing systemKeys; never clobbers admin edits.
+ * Usage: node scripts/seed-step-definitions.js */
+require("dotenv").config();
+const mongoose = require("mongoose");
+
+(async () => {
+  await mongoose.connect(process.env.DATABASE_URL);
+  const StepDefinitionService = require("../services/StepDefinitionService");
+  const r = await StepDefinitionService.seed();
+  console.log(`Step definitions seeded: ${r.created} created (${r.total} in the set).`);
+  await mongoose.disconnect();
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/verify-mb8b.js
+++ b/scripts/verify-mb8b.js
@@ -1,0 +1,165 @@
+/* MB8b — Journey Steps + Notes + Mirror. Verifies: step-definition seed
+ * (idempotent, 3-phase) + CRUD/reorder; per-lead instantiation (endpoint AND
+ * the qualification trigger); 4 statuses only; owners from the roster
+ * (multi-owner, off-roster rejected); dependency soft-block + cycle-validate;
+ * actor-named journey events; step notes mirroring into the lead chat with
+ * back-link + @tag notification; one-direction. Test port 8156. */
+require("dotenv").config();
+const { spawn } = require("child_process");
+const mongoose = require("mongoose");
+const jwt = require("jsonwebtoken");
+
+const PORT = 8156; const BASE = `http://localhost:${PORT}`; const MARK = "MB8B";
+let pass = 0, fail = 0; const failures = [];
+const ok = (c, l) => { if (c) { pass++; console.log(`  ✓ ${l}`); } else { fail++; failures.push(l); console.error(`  ✗ ${l}`); } };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const waitFor = async (fn, l, t = 30000) => { const u = Date.now() + t; while (Date.now() < u) { try { const v = await fn(); if (v) return v; } catch (_) {} await sleep(300); } throw new Error(`waitFor: ${l}`); };
+
+(async () => {
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Admin = require("../models/Admin"); const Role = require("../models/Role"); const Department = require("../models/Department");
+  const Enquiry = require("../models/Enquiry"); const LeadStep = require("../models/LeadStep"); const StepDefinition = require("../models/StepDefinition");
+  const LeadTeamMember = require("../models/LeadTeamMember"); const LeadChatMessage = require("../models/LeadChatMessage");
+  const AdminNotification = require("../models/AdminNotification"); const LeadInternalEvent = require("../models/LeadInternalEvent");
+
+  const dept = await Department.create({ name: `${MARK} Dept` });
+  const bossRole = await Role.create({ name: `${MARK} Boss`, departmentId: dept._id, permissions: ["leads:view:all", "leads:edit:all", "settings:edit:all"] });
+  const u = (s) => `9197${String(Date.now()).slice(-7)}${s}`;
+  const BOSS = await Admin.create({ name: `${MARK} Boss`, email: `boss-${Date.now()}@t.local`, phone: u(1), password: "x", roleIds: [bossRole._id], departmentId: dept._id, status: "active" });
+  const MATE = await Admin.create({ name: `${MARK} Mate`, email: `mate-${Date.now()}@t.local`, phone: u(2), password: "x", roleIds: [bossRole._id], departmentId: dept._id, status: "active" });
+  const tok = (a) => jwt.sign({ _id: String(a._id), isAdmin: true }, process.env.JWT_SECRET);
+  const bossT = tok(BOSS);
+
+  const phone1 = `9190${String(Date.now()).slice(-8)}`;
+  const phone2 = `9191${String(Date.now()).slice(-8)}`;
+  const lead = await Enquiry.create({ name: "Steps Couple", phone: phone1, verified: false, source: "Website", stage: "lead", assignedTo: BOSS._id, additionalInfo: {} });
+  // Second lead for the qualification-trigger test. kiaraSummary preset so the
+  // qualified path skips the (Anthropic) summary call and we isolate the trigger.
+  const lead2 = await Enquiry.create({ name: "Trigger Couple", phone: phone2, verified: false, source: "Website", stage: "lead", assignedTo: BOSS._id, additionalInfo: {}, kiaraSummary: { text: "preset", generatedAt: new Date() } });
+
+  // Roster: BOSS + MATE are on lead 1's team (so they can own steps).
+  await LeadTeamMember.create({ leadId: lead._id, personId: BOSS._id, departmentName: `${MARK} Dept`, addedBy: BOSS._id });
+  await LeadTeamMember.create({ leadId: lead._id, personId: MATE._id, departmentName: `${MARK} Dept`, addedBy: BOSS._id });
+  // An admin NOT on the roster (off-roster owner rejection test).
+  const OUTSIDER = await Admin.create({ name: `${MARK} Outsider`, email: `out-${Date.now()}@t.local`, phone: u(3), password: "x", roleIds: [bossRole._id], status: "active" });
+
+  const child = spawn("node", ["server.js"], { cwd: `${__dirname}/..`, env: { ...process.env, PORT: String(PORT) }, stdio: ["ignore", "pipe", "pipe"] });
+  let log = ""; child.stdout.on("data", (d) => (log += d)); child.stderr.on("data", (d) => (log += d));
+  const api = async (m, p, t, b) => { const r = await fetch(`${BASE}${p}`, { method: m, headers: { ...(t ? { Authorization: `Bearer ${t}` } : {}), ...(b ? { "Content-Type": "application/json" } : {}) }, body: b ? JSON.stringify(b) : undefined }); let d = null; try { d = await r.json(); } catch (_) {} return { status: r.status, data: d }; };
+
+  const createdDefIds = [];
+  try {
+    await waitFor(() => fetch(`${BASE}/`).then((r) => r.ok).catch(() => false), "boot");
+
+    console.log("\n── Slice 1: step-definition seed (idempotent, 3-phase) ──");
+    const seed1 = await api("POST", "/step-definition/seed", bossT);
+    ok(seed1.status === 200 && seed1.data.total === 18, "seed reports the 18-step Wedsy set");
+    const seed2 = await api("POST", "/step-definition/seed", bossT);
+    ok(seed2.status === 200 && seed2.data.created === 0, "re-seed is idempotent (creates 0)");
+    const defs = await api("GET", "/step-definition", bossT);
+    ok(defs.status === 200 && defs.data.phases.length === 3, "definitions expose the 3 phases");
+    const active = defs.data.list;
+    const followUps = active.filter((d) => d.name === "Client Follow Up");
+    ok(followUps.length === 2 && followUps.every((d) => d.rolling), "'Client Follow Up' appears in 2 phases, both rolling");
+    const va = active.find((d) => d.name === "Venue Assistance");
+    ok(va && va.rolling && va.optional, "'Venue Assistance' is rolling + optional");
+
+    console.log("\n── Slice 1: definition CRUD + reorder + settings gate ──");
+    const created = await api("POST", "/step-definition", bossT, { name: `${MARK} Custom Step`, phase: "Lead Understanding" });
+    ok(created.status === 201 && created.data._id, "create a step definition");
+    createdDefIds.push(created.data._id);
+    const renamed = await api("PUT", `/step-definition/${created.data._id}`, bossT, { name: `${MARK} Renamed`, rolling: true, optional: true });
+    ok(renamed.status === 200 && renamed.data.name === `${MARK} Renamed` && renamed.data.rolling && renamed.data.optional, "rename + toggle rolling/optional");
+    const archived = await api("DELETE", `/step-definition/${created.data._id}`, bossT);
+    ok(archived.status === 200 && archived.data.status === "archived", "delete archives (soft)");
+    // A roleless admin proves the settings:edit:all gate on definition writes.
+    const nobody = await Admin.create({ name: `${MARK} Nobody`, email: `nob-${Date.now()}@t.local`, phone: u(4), password: "x", roleIds: [], status: "active" });
+    const gate = await api("POST", "/step-definition", jwt.sign({ _id: String(nobody._id), isAdmin: true }, process.env.JWT_SECRET), { name: "x", phase: "Lead Understanding" });
+    ok(gate.status === 403, "no-permission admin cannot edit definitions (settings gate)");
+    await Admin.deleteMany({ _id: nobody._id });
+
+    console.log("\n── Slice 2: per-lead instantiation (endpoint + idempotent) ──");
+    const inst1 = await api("POST", `/enquiry/${lead._id}/steps/instantiate`, bossT);
+    ok(inst1.status === 200 && inst1.data.created > 0, `instantiate stamps steps (${inst1.data.created})`);
+    const inst2 = await api("POST", `/enquiry/${lead._id}/steps/instantiate`, bossT);
+    ok(inst2.status === 200 && inst2.data.created === 0, "instantiate is idempotent (creates 0 the second time)");
+    const steps = (await api("GET", `/enquiry/${lead._id}/steps`, bossT)).data.list;
+    ok(steps.length > 0 && steps.every((s) => s.status === "not_started"), "steps start as not_started");
+    ok(steps.every((s) => ["Lead Understanding", "Client Servicing & Proposal", "Follow Up & Conversion"].includes(s.phase)), "steps carry their phase");
+
+    console.log("\n── Slice 2: qualification TRIGGER instantiates steps ──");
+    const CallCockpitService = require("../services/CallCockpitService");
+    await CallCockpitService.logCall(lead2._id, { startedAt: new Date().toISOString(), durationSeconds: 60, connected: true, outcome: "qualified", notes: "trigger" }, BOSS._id);
+    const trigCount = await waitFor(async () => { const c = await LeadStep.countDocuments({ leadId: lead2._id }); return c > 0 ? c : false; }, "trigger created steps");
+    ok(trigCount > 0, `qualified call instantiated steps on the lead (${trigCount})`);
+
+    console.log("\n── Slice 2: owners from roster (multi) + 4 statuses only ──");
+    const s0 = steps[0], s1 = steps[1], s2 = steps[2];
+    const own = await api("PATCH", `/enquiry/${lead._id}/steps/${s0._id}`, bossT, { ownerIds: [String(BOSS._id), String(MATE._id)] });
+    ok(own.status === 200 && own.data.owners.length === 2, "assign multiple owners from the roster");
+    const offRoster = await api("PATCH", `/enquiry/${lead._id}/steps/${s0._id}`, bossT, { ownerIds: [String(OUTSIDER._id)] });
+    ok(offRoster.status === 400, "off-roster owner rejected");
+    const badStatus = await api("PATCH", `/enquiry/${lead._id}/steps/${s0._id}`, bossT, { status: "blocked" });
+    ok(badStatus.status === 400, "invalid status rejected (only the 4 allowed)");
+    const goodStatus = await api("PATCH", `/enquiry/${lead._id}/steps/${s0._id}`, bossT, { status: "in_progress" });
+    ok(goodStatus.status === 200 && goodStatus.data.status === "in_progress", "valid status accepted");
+
+    console.log("\n── Slice 2: dependencies (soft-block + cycle-validate) ──");
+    const dep = await api("PATCH", `/enquiry/${lead._id}/steps/${s2._id}`, bossT, { dependsOn: [String(s1._id)] });
+    ok(dep.status === 200 && dep.data.blocked === true, "s2 depends on s1 → blocked while s1 incomplete");
+    const blockedStart = await api("PATCH", `/enquiry/${lead._id}/steps/${s2._id}`, bossT, { status: "in_progress" });
+    ok(blockedStart.status === 409, "cannot START a blocked step (soft guard, 409)");
+    await api("PATCH", `/enquiry/${lead._id}/steps/${s1._id}`, bossT, { status: "complete" });
+    const unblockedStart = await api("PATCH", `/enquiry/${lead._id}/steps/${s2._id}`, bossT, { status: "in_progress" });
+    ok(unblockedStart.status === 200, "after the prerequisite completes, the step can start");
+    const cycle = await api("PATCH", `/enquiry/${lead._id}/steps/${s1._id}`, bossT, { dependsOn: [String(s2._id)] });
+    ok(cycle.status === 400, "a dependency that would form a cycle is rejected");
+
+    console.log("\n── Slice 2: journey events are actor-named ──");
+    const journey = (await api("GET", `/enquiry/${lead._id}/journey`, bossT)).data.entries || [];
+    const statusEv = journey.find((e) => e.type === "step_status_changed");
+    ok(statusEv && statusEv.actor === `${MARK} Boss`, "step_status_changed event names the actor");
+    ok(statusEv && /→ (In progress|Complete)/.test(statusEv.title), `status event title reads the step + status ("${statusEv && statusEv.title}")`);
+    const ownerEv = journey.find((e) => e.type === "step_owners_assigned");
+    ok(ownerEv && /Assigned .*Boss.*Mate/.test(ownerEv.title), "step_owners_assigned event names the owners");
+
+    console.log("\n── Slice 3: step note MIRRORS into the lead chat (+ back-link, @tag) ──");
+    const note = await api("POST", `/enquiry/${lead._id}/steps/${s0._id}/notes`, bossT, { body: "Spoke to the couple, sharing decor refs", mentions: [String(MATE._id)] });
+    const noteStep = note.data;
+    ok(note.status === 201 && (noteStep.notes || []).some((n) => /decor refs/.test(n.body)), "note saved on the step");
+
+    const chat = (await api("GET", `/enquiry/${lead._id}/chat`, bossT)).data.messages || [];
+    const mirrored = chat.find((m) => m.systemType === "step_note" && /added a note in .* — Spoke to the couple/.test(m.body));
+    ok(!!mirrored, "note mirrored into the lead chat as a contextualized system message");
+    ok(mirrored && String(mirrored.stepId) === String(s0._id), "mirrored chat message links back to the step (stepId)");
+    ok(mirrored && (mirrored.mentions || []).map(String).includes(String(MATE._id)), "mirror preserves the @tag");
+    const stepNote = (noteStep.notes || []).find((n) => /decor refs/.test(n.body));
+    ok(stepNote && stepNote.chatMessageId, "step note stores its chat echo id (clickable both ways)");
+
+    const mention = await waitFor(async () => { const n = await AdminNotification.findOne({ adminId: MATE._id, type: "chat_mention" }).lean(); return n || false; }, "chat_mention notification");
+    ok(!!mention && String(mention.payload?.stepId) === String(s0._id), "@tag fires a chat_mention notification carrying the stepId");
+
+    console.log("\n── Slice 3: ONE-DIRECTION (chat → step does NOT sync) ──");
+    const beforeNotes = (await api("GET", `/enquiry/${lead._id}/steps`, bossT)).data.list.find((s) => String(s._id) === String(s0._id)).notes.length;
+    await api("POST", `/enquiry/${lead._id}/chat`, bossT, { body: "a plain chat reply" });
+    const afterNotes = (await api("GET", `/enquiry/${lead._id}/steps`, bossT)).data.list.find((s) => String(s._id) === String(s0._id)).notes.length;
+    ok(beforeNotes === afterNotes, "posting in the chat does NOT create a step note (one-direction)");
+  } catch (e) {
+    fail++; failures.push(`fatal: ${e.message}`); console.error("FATAL", e); console.error(log.slice(-2000));
+  } finally {
+    await LeadStep.deleteMany({ leadId: { $in: [lead._id, lead2._id] } });
+    await LeadChatMessage.deleteMany({ leadId: { $in: [lead._id, lead2._id] } });
+    await LeadInternalEvent.deleteMany({ leadId: { $in: [lead._id, lead2._id] } });
+    await LeadTeamMember.deleteMany({ leadId: lead._id });
+    await AdminNotification.deleteMany({ adminId: { $in: [BOSS._id, MATE._id, OUTSIDER._id] } });
+    await Enquiry.deleteMany({ _id: { $in: [lead._id, lead2._id] } });
+    await Admin.deleteMany({ _id: { $in: [BOSS._id, MATE._id, OUTSIDER._id] } });
+    await Role.deleteMany({ _id: bossRole._id });
+    await Department.deleteMany({ _id: dept._id });
+    if (createdDefIds.length) await StepDefinition.deleteMany({ _id: { $in: createdDefIds } });
+    child.kill(); await mongoose.disconnect();
+    console.log(`\n══ RESULT: ${pass} passed, ${fail} failed ══`);
+    if (failures.length) console.log("failures:", failures.join(" | "));
+    process.exit(fail === 0 ? 0 : 1);
+  }
+})();

--- a/services/CallCockpitService.js
+++ b/services/CallCockpitService.js
@@ -164,6 +164,14 @@ const logCall = async (
   // paying for — trigger it (Haiku, once). Fire-safe: never breaks the call log.
   if (outcome === "qualified") {
     await require("./KiaraSummaryService").generateForQualified(enquiryId);
+    // MB8b: qualification is when the lead enters the journey — stamp the
+    // configurable steps (idempotent: a no-op if already instantiated).
+    // Fire-safe: a failure here must never break the call log.
+    try {
+      await require("./LeadStepService").instantiateForLead(enquiryId, actorId);
+    } catch (e) {
+      console.error("LeadStep.instantiateForLead failed:", e.message);
+    }
   }
 
   // Cadence (Slice C): on an unanswered outcome, surface the suggested next attempt

--- a/services/JourneyService.js
+++ b/services/JourneyService.js
@@ -68,6 +68,17 @@ const EVENT_TITLES = {
   // MB8a — lead team roster (Client Journey Engine foundation).
   team_member_added: "Team member added 🤝",
   team_member_removed: "Team member removed",
+  // MB8b — journey steps.
+  journey_started: "Journey steps created",
+  step_status_changed: "Step updated",
+  step_owners_assigned: "Step owners assigned",
+};
+
+const STEP_STATUS_LABEL = {
+  not_started: "Not started",
+  in_progress: "In progress",
+  awaiting_client: "Awaiting client",
+  complete: "Complete",
 };
 
 // Payload keys that carry an Admin id of a SECOND party (not the actor) — these
@@ -113,6 +124,17 @@ const dynamicTitle = (type, payload = {}, nameOf) => {
     case "team_member_removed": {
       const who = payload.personName || id("personId") || "someone";
       return `Removed ${who}${payload.departmentName ? ` (${payload.departmentName})` : ""} from the team`;
+    }
+    // MB8b — name the step + the readable status / owners (actor shown separately).
+    case "step_status_changed": {
+      const to = STEP_STATUS_LABEL[payload.to] || payload.to || "updated";
+      return `${payload.stepName || "Step"} → ${to}`;
+    }
+    case "step_owners_assigned": {
+      const names = Array.isArray(payload.ownerNames) && payload.ownerNames.length
+        ? payload.ownerNames.join(", ")
+        : "no one";
+      return `Assigned ${names} to "${payload.stepName || "a step"}"`;
     }
     default:
       return null;

--- a/services/LeadChatService.js
+++ b/services/LeadChatService.js
@@ -112,9 +112,16 @@ const postMessage = async (leadId, authorId, { body, attachments, mentions } = {
   return enriched;
 };
 
-// System message — task lifecycle narration (Slice 2) + nurture (Slice 4).
-const postSystemMessage = async (leadId, { body, systemType = "", taskId = null } = {}) => {
+// System message — task lifecycle narration (Slice 2) + nurture (Slice 4) +
+// MB8b step-note mirror. `stepId` links the chat echo back to a step; `mentions`
+// carries the original note's @tags so chat_mention notifications still fire
+// even though the message itself is authored by the system.
+const postSystemMessage = async (
+  leadId,
+  { body, systemType = "", taskId = null, stepId = null, mentions = [] } = {}
+) => {
   if (!isId(leadId)) return null;
+  const ments = Array.isArray(mentions) ? mentions.filter((m) => isId(m)).map(String) : [];
   const msg = await LeadChatMessage.create({
     leadId,
     authorId: null,
@@ -122,6 +129,8 @@ const postSystemMessage = async (leadId, { body, systemType = "", taskId = null 
     systemType,
     body: String(body || "").slice(0, MAX_BODY),
     taskId: taskId && isId(taskId) ? taskId : null,
+    stepId: stepId && isId(stepId) ? stepId : null,
+    mentions: ments,
   });
   return msg;
 };

--- a/services/LeadStepService.js
+++ b/services/LeadStepService.js
@@ -1,0 +1,258 @@
+const mongoose = require("mongoose");
+const Admin = require("../models/Admin");
+const Enquiry = require("../models/Enquiry");
+const { STATUSES } = require("../models/LeadStep");
+const LeadStepRepository = require("../repositories/LeadStepRepository");
+const StepDefinitionRepository = require("../repositories/StepDefinitionRepository");
+const LeadTeamMemberRepository = require("../repositories/LeadTeamMemberRepository");
+const LeadInternalEventService = require("./LeadInternalEventService");
+const LeadChatService = require("./LeadChatService");
+const AdminNotificationService = require("./AdminNotificationService");
+
+const err = (status, message) => Object.assign(new Error(message), { status });
+const isId = (v) => mongoose.Types.ObjectId.isValid(v);
+
+const STATUS_LABEL = {
+  not_started: "Not started",
+  in_progress: "In progress",
+  awaiting_client: "Awaiting client",
+  complete: "Complete",
+};
+
+// Instantiate the journey for a lead from the ACTIVE step definitions. Idempotent
+// — a no-op if the lead already has steps (re-qualification won't duplicate).
+const instantiateForLead = async (leadId, actorId) => {
+  if (!isId(leadId)) throw err(400, "Invalid leadId");
+  const existing = await LeadStepRepository.countByLead(leadId);
+  if (existing > 0) return { created: 0, alreadyPresent: existing };
+
+  const defs = await StepDefinitionRepository.findActive();
+  if (!defs.length) return { created: 0, alreadyPresent: 0 };
+
+  const rows = defs.map((d) => ({
+    leadId,
+    definitionId: d._id,
+    name: d.name,
+    phase: d.phase,
+    order: d.order || 0,
+    ownerIds: [],
+    status: "not_started",
+    rolling: !!d.rolling,
+    optional: !!d.optional,
+    dependsOn: [],
+    notes: [],
+  }));
+  const inserted = await LeadStepRepository.insertMany(rows);
+
+  await LeadInternalEventService.record({
+    leadId,
+    type: "journey_started",
+    actorId: actorId || null,
+    payload: { count: inserted.length },
+  });
+  return { created: inserted.length };
+};
+
+// A step is blocked from STARTING if any of its dependencies is not complete.
+const blockedSet = (steps) => {
+  const statusById = new Map(steps.map((s) => [String(s._id), s.status]));
+  const blocked = new Map();
+  for (const s of steps) {
+    const deps = (s.dependsOn || []).map(String);
+    const unmet = deps.filter((d) => statusById.get(d) !== "complete");
+    blocked.set(String(s._id), unmet);
+  }
+  return blocked;
+};
+
+// Decorate steps with owner names, note-author names, and a blocked flag.
+const listForLead = async (leadId) => {
+  if (!isId(leadId)) throw err(400, "Invalid leadId");
+  const steps = await LeadStepRepository.findByLead(leadId);
+
+  const adminIds = new Set();
+  for (const s of steps) {
+    for (const o of s.ownerIds || []) adminIds.add(String(o));
+    for (const n of s.notes || []) {
+      if (n.authorId) adminIds.add(String(n.authorId));
+      for (const m of n.mentions || []) adminIds.add(String(m));
+    }
+  }
+  const admins = adminIds.size ? await Admin.find({ _id: { $in: [...adminIds] } }, { name: 1 }).lean() : [];
+  const nameOf = new Map(admins.map((a) => [String(a._id), a.name]));
+  const name = (id) => (id ? nameOf.get(String(id)) || "—" : null);
+
+  const blocked = blockedSet(steps);
+  return steps.map((s) => ({
+    ...s,
+    owners: (s.ownerIds || []).map((id) => ({ _id: String(id), name: name(id) })),
+    blockedBy: blocked.get(String(s._id)) || [],
+    blocked: (blocked.get(String(s._id)) || []).length > 0,
+    notes: (s.notes || []).map((n) => ({
+      _id: String(n._id),
+      authorId: n.authorId ? String(n.authorId) : null,
+      authorName: name(n.authorId) || "—",
+      body: n.body,
+      mentions: (n.mentions || []).map((m) => ({ _id: String(m), name: name(m) })),
+      chatMessageId: n.chatMessageId ? String(n.chatMessageId) : null,
+      createdAt: n.createdAt,
+    })),
+  }));
+};
+
+// Cycle check: would setting step `id`'s dependsOn to `deps` create a cycle?
+// Build adjacency (step -> its deps) with the proposed edge, DFS for a back-edge.
+const wouldCycle = (steps, id, deps) => {
+  const adj = new Map();
+  for (const s of steps) adj.set(String(s._id), (s.dependsOn || []).map(String));
+  adj.set(String(id), deps.map(String));
+  const WHITE = 0, GRAY = 1, BLACK = 2;
+  const color = new Map([...adj.keys()].map((k) => [k, WHITE]));
+  const dfs = (u) => {
+    color.set(u, GRAY);
+    for (const v of adj.get(u) || []) {
+      if (!color.has(v)) continue; // dep to unknown node — ignore
+      if (color.get(v) === GRAY) return true;
+      if (color.get(v) === WHITE && dfs(v)) return true;
+    }
+    color.set(u, BLACK);
+    return false;
+  };
+  for (const k of adj.keys()) if (color.get(k) === WHITE && dfs(k)) return true;
+  return false;
+};
+
+// PATCH a step: status / ownerIds / dueAt / dependsOn / notApplicable. Emits
+// actor-named journey events for status + owner changes.
+const patchStep = async (leadId, stepId, fields = {}, actorId) => {
+  if (!isId(stepId)) throw err(400, "Invalid stepId");
+  const step = await LeadStepRepository.findByIdLean(stepId);
+  if (!step || String(step.leadId) !== String(leadId)) throw err(404, "Step not found on this lead");
+
+  const allSteps = await LeadStepRepository.findByLead(leadId);
+  const update = {};
+  const events = [];
+
+  // ── Status ──
+  if (fields.status !== undefined) {
+    if (!STATUSES.includes(fields.status)) throw err(400, `status must be one of: ${STATUSES.join(", ")}`);
+    if (fields.status !== step.status) {
+      // Soft dependency guard: can't START a step until its deps are complete.
+      if (step.status === "not_started" && fields.status !== "not_started") {
+        const unmet = (step.dependsOn || [])
+          .map(String)
+          .filter((d) => (allSteps.find((s) => String(s._id) === d) || {}).status !== "complete");
+        if (unmet.length) throw err(409, "Blocked: complete the prerequisite step(s) first");
+      }
+      update.status = fields.status;
+      if (fields.status === "complete") update.completedAt = new Date();
+      if (fields.status === "in_progress" && !step.startedAt) update.startedAt = new Date();
+      if (fields.status !== "complete") update.completedAt = null;
+      events.push({
+        type: "step_status_changed",
+        payload: { stepName: step.name, from: step.status, to: fields.status },
+      });
+    }
+  }
+
+  // ── Owners (must be on the lead's CURRENT roster) ──
+  if (fields.ownerIds !== undefined) {
+    if (!Array.isArray(fields.ownerIds)) throw err(400, "ownerIds must be an array");
+    const ids = [...new Set(fields.ownerIds.map(String))];
+    for (const id of ids) if (!isId(id)) throw err(400, `Invalid owner id: ${id}`);
+    const roster = await LeadTeamMemberRepository.findCurrentByLead(leadId);
+    const rosterIds = new Set(roster.map((r) => String(r.personId)));
+    const offRoster = ids.filter((id) => !rosterIds.has(id));
+    if (offRoster.length) throw err(400, "Owners must be current members of the lead's team");
+    update.ownerIds = ids;
+    const ownerNames = (await Admin.find({ _id: { $in: ids } }, { name: 1 }).lean()).map((a) => a.name);
+    events.push({ type: "step_owners_assigned", payload: { stepName: step.name, ownerIds: ids, ownerNames } });
+  }
+
+  // ── Dependencies (opt-in, cycle-validated) ──
+  if (fields.dependsOn !== undefined) {
+    if (!Array.isArray(fields.dependsOn)) throw err(400, "dependsOn must be an array");
+    const deps = [...new Set(fields.dependsOn.map(String))];
+    for (const d of deps) {
+      if (!isId(d)) throw err(400, `Invalid dependency id: ${d}`);
+      if (d === String(stepId)) throw err(400, "A step cannot depend on itself");
+      if (!allSteps.find((s) => String(s._id) === d)) throw err(400, "Dependency must be another step on this lead");
+    }
+    if (wouldCycle(allSteps, stepId, deps)) throw err(400, "That dependency would create a cycle");
+    update.dependsOn = deps;
+  }
+
+  // ── Due date ──
+  if (fields.dueAt !== undefined) {
+    update.dueAt = fields.dueAt ? new Date(fields.dueAt) : null;
+  }
+
+  // ── Not-applicable (optional steps only) ──
+  if (fields.notApplicable !== undefined) {
+    if (fields.notApplicable && !step.optional) throw err(400, "Only optional steps can be marked not-applicable");
+    update.notApplicable = !!fields.notApplicable;
+  }
+
+  if (!Object.keys(update).length) return (await listForLead(leadId)).find((s) => String(s._id) === String(stepId));
+
+  await LeadStepRepository.updateById(stepId, { $set: update });
+  for (const e of events) {
+    await LeadInternalEventService.record({ leadId, type: e.type, actorId: actorId || null, payload: e.payload });
+  }
+  return (await listForLead(leadId)).find((s) => String(s._id) === String(stepId));
+};
+
+// Add a note to a step AND mirror it into the one lead chat (Slice 3). The chat
+// echo is a contextualized system message linking back to the step; @tags are
+// preserved so the chat_mention notification fires for anyone tagged.
+const addNote = async (leadId, stepId, authorId, { body, mentions } = {}) => {
+  if (!isId(stepId)) throw err(400, "Invalid stepId");
+  const text = typeof body === "string" ? body.trim() : "";
+  if (!text) throw err(400, "A note needs text");
+  const step = await LeadStepRepository.findById(stepId);
+  if (!step || String(step.leadId) !== String(leadId)) throw err(404, "Step not found on this lead");
+
+  const ments = Array.isArray(mentions)
+    ? [...new Set(mentions.filter((m) => isId(m) && String(m) !== String(authorId)).map(String))]
+    : [];
+
+  // 1) Persist the note on the step (its contextual history).
+  const note = { authorId: authorId || null, body: text.slice(0, 5000), mentions: ments, createdAt: new Date() };
+  step.notes.push(note);
+  await step.save();
+  const saved = step.notes[step.notes.length - 1];
+
+  // 2) Mirror into the lead chat as a contextualized system message.
+  const author = await Admin.findById(authorId, { name: 1 }).lean();
+  const authorName = author ? author.name : "Someone";
+  const mirrorBody = `${authorName} added a note in ${step.name} — ${text}`;
+  const chatMsg = await LeadChatService.postSystemMessage(leadId, {
+    body: mirrorBody,
+    systemType: "step_note",
+    stepId: step._id,
+    mentions: ments,
+  });
+
+  // Link the step note to its chat echo (clickable both ways).
+  if (chatMsg) {
+    saved.chatMessageId = chatMsg._id;
+    await step.save();
+  }
+
+  // 3) @tags → the existing chat_mention notification (so a tagged teammate is
+  // pinged via the lead chat even if they never open the step).
+  if (ments.length) {
+    const lead = await Enquiry.findById(leadId, { name: 1 }).lean();
+    await AdminNotificationService.notify(ments, {
+      type: "chat_mention",
+      title: `${authorName} mentioned you on ${lead ? lead.name : "a lead"}`,
+      message: text.slice(0, 160),
+      leadId,
+      payload: { messageId: chatMsg ? String(chatMsg._id) : null, stepId: String(step._id) },
+    });
+  }
+
+  return (await listForLead(leadId)).find((s) => String(s._id) === String(stepId));
+};
+
+module.exports = { instantiateForLead, listForLead, patchStep, addNote, STATUS_LABEL };

--- a/services/StepDefinitionService.js
+++ b/services/StepDefinitionService.js
@@ -1,0 +1,118 @@
+const mongoose = require("mongoose");
+const StepDefinitionRepository = require("../repositories/StepDefinitionRepository");
+const { PHASES } = require("../models/StepDefinition");
+
+const err = (status, message) => Object.assign(new Error(message), { status });
+const isId = (v) => mongoose.Types.ObjectId.isValid(v);
+
+// Wedsy's real step-set (from their Zoho Projects / Bigin), grouped into 3
+// phases. systemKey makes the seed idempotent AND edit-preserving: a re-run
+// inserts only the keys that are missing, never clobbering admin changes. The
+// two "Client Follow Up" rows live in different phases → distinct keys.
+const SEED_SET = [
+  // Phase 1 — Lead Understanding
+  { systemKey: "lu-review-bigin-notes", phase: PHASES[0], name: "Review Bigin Notes" },
+  { systemKey: "lu-internal-team-discussion", phase: PHASES[0], name: "Internal Team Discussion" },
+  { systemKey: "lu-responsibility-allocation", phase: PHASES[0], name: "Responsibility Allocation" },
+  { systemKey: "lu-gmeet-mom-team", phase: PHASES[0], name: "Google Meet MOM - Team Discussion" },
+  { systemKey: "lu-gmeet-mom-client-wa", phase: PHASES[0], name: "Google Meet MOM to client WhatsApp" },
+  // Phase 2 — Client Servicing & Proposal
+  { systemKey: "csp-client-follow-up", phase: PHASES[1], name: "Client Follow Up", rolling: true },
+  { systemKey: "csp-venue-assistance", phase: PHASES[1], name: "Venue Assistance", rolling: true, optional: true },
+  { systemKey: "csp-venue-proposal", phase: PHASES[1], name: "Venue Proposal", optional: true },
+  { systemKey: "csp-client-engagement-content", phase: PHASES[1], name: "Client Engagement Content", rolling: true },
+  { systemKey: "csp-decor-concept-discussion", phase: PHASES[1], name: "Decor Concept Discussion", rolling: true },
+  { systemKey: "csp-vendor-suggestions", phase: PHASES[1], name: "Vendor Suggestions", rolling: true, optional: true },
+  { systemKey: "csp-proposal-preparation", phase: PHASES[1], name: "Proposal Preparation" },
+  { systemKey: "csp-proposal-shared", phase: PHASES[1], name: "Proposal Shared" },
+  // Phase 3 — Follow Up & Conversion
+  { systemKey: "fuc-client-follow-up", phase: PHASES[2], name: "Client Follow Up", rolling: true },
+  { systemKey: "fuc-capture-feedback-team", phase: PHASES[2], name: "Capture Client Feedback & Team Discussion" },
+  { systemKey: "fuc-negotiation-call", phase: PHASES[2], name: "Negotiation Call with Client" },
+  { systemKey: "fuc-send-booking-form", phase: PHASES[2], name: "Send Booking Form (T&Cs)" },
+  { systemKey: "fuc-collect-onboarding-fee", phase: PHASES[2], name: "Collect Onboarding Fee" },
+];
+
+// Idempotent seed: insert any SEED_SET key not already present. Order is the
+// SEED_SET index (×10, leaving gaps for inserts). Returns counts.
+const seed = async () => {
+  let created = 0;
+  for (let i = 0; i < SEED_SET.length; i++) {
+    const def = SEED_SET[i];
+    const existing = await StepDefinitionRepository.findBySystemKey(def.systemKey);
+    if (existing) continue;
+    await StepDefinitionRepository.create({
+      name: def.name,
+      phase: def.phase,
+      order: (i + 1) * 10,
+      rolling: !!def.rolling,
+      optional: !!def.optional,
+      status: "active",
+      systemKey: def.systemKey,
+    });
+    created += 1;
+  }
+  return { created, total: SEED_SET.length };
+};
+
+const list = async ({ includeArchived = false } = {}) =>
+  includeArchived ? StepDefinitionRepository.findAll() : StepDefinitionRepository.findActive();
+
+const PHASE_SET = new Set(PHASES);
+
+const create = async ({ name, phase, defaultDepartment, rolling, optional } = {}) => {
+  if (!name || !String(name).trim()) throw err(400, "name is required");
+  if (!phase || !PHASE_SET.has(phase)) throw err(400, `phase must be one of: ${PHASES.join(", ")}`);
+  const order = (await StepDefinitionRepository.maxOrder()) + 10;
+  return StepDefinitionRepository.create({
+    name: String(name).trim(),
+    phase,
+    order,
+    defaultDepartment: defaultDepartment || "",
+    rolling: !!rolling,
+    optional: !!optional,
+    status: "active",
+  });
+};
+
+// Rename / toggle rolling+optional / re-phase / change default department.
+const update = async (id, fields = {}) => {
+  if (!isId(id)) throw err(400, "Invalid id");
+  const allowed = {};
+  if (fields.name !== undefined) {
+    if (!String(fields.name).trim()) throw err(400, "name cannot be empty");
+    allowed.name = String(fields.name).trim();
+  }
+  if (fields.phase !== undefined) {
+    if (!PHASE_SET.has(fields.phase)) throw err(400, `phase must be one of: ${PHASES.join(", ")}`);
+    allowed.phase = fields.phase;
+  }
+  if (fields.rolling !== undefined) allowed.rolling = !!fields.rolling;
+  if (fields.optional !== undefined) allowed.optional = !!fields.optional;
+  if (fields.defaultDepartment !== undefined) allowed.defaultDepartment = String(fields.defaultDepartment || "");
+  const updated = await StepDefinitionRepository.updateById(id, allowed);
+  if (!updated) throw err(404, "Step definition not found");
+  return updated;
+};
+
+// Soft delete — archive (instantiated LeadSteps keep their reference).
+const archive = async (id) => {
+  if (!isId(id)) throw err(400, "Invalid id");
+  const updated = await StepDefinitionRepository.updateById(id, { status: "archived" });
+  if (!updated) throw err(404, "Step definition not found");
+  return updated;
+};
+
+// Reorder: { orderedIds: [id, ...] } → assigns order 10,20,30…
+const reorder = async (orderedIds) => {
+  if (!Array.isArray(orderedIds) || !orderedIds.length) throw err(400, "orderedIds must be a non-empty array");
+  for (const id of orderedIds) if (!isId(id)) throw err(400, `Invalid id in orderedIds: ${id}`);
+  let order = 10;
+  for (const id of orderedIds) {
+    await StepDefinitionRepository.updateById(id, { order });
+    order += 10;
+  }
+  return list();
+};
+
+module.exports = { SEED_SET, PHASES, seed, list, create, update, archive, reorder };


### PR DESCRIPTION
Engine core on the MB8a roster. StepDefinition (Settings, seeded 18-step Wedsy 3-phase set) + LeadStep (per-lead, 4 statuses, multi-owner from roster, opt-in cycle-validated dependencies, embedded notes). Notes mirror into the one lead chat with @tag + back-link (one-direction). Instantiates at qualification (fire-safe/idempotent). Enquiry/requirePermission/rbacPermissions untouched; LeadChatMessage gains nullable stepId (additive, MB7b regression green). 32/32 + regressions.