### PR TITLE
MB8c-1 Journey Dashboards: My Work (cross-lead steps, scope-aware) + Pipeline Overview (leads by phase, stuck flag), server-aggregated, soft scope

### DIFF
--- a/controllers/journeyDashboard.js
+++ b/controllers/journeyDashboard.js
@@ -1,0 +1,41 @@
+const JourneyDashboardService = require("../services/JourneyDashboardService");
+
+const respond = (res, error) => {
+  const status = error.status || 500;
+  if (status === 500) console.error("[journeyDashboard]", error);
+  res.status(status).json({ message: status === 500 ? "Server error" : error.message });
+};
+
+// GET /enquiry/steps/my-work — the caller's steps across all their leads.
+// requirePermission set req.scope (own/team/department/all) from the caller's
+// existing leads:view grant — reused as-is for breadth (no new gating).
+const MyWork = async (req, res) => {
+  try {
+    const result = await JourneyDashboardService.myWork(req.auth.user_id, req.scope || "own", {
+      status: req.query.status,
+      phase: req.query.phase,
+      overdueOnly: req.query.overdueOnly === "true",
+      includeComplete: req.query.includeComplete === "true",
+    });
+    res.status(200).json(result);
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// GET /enquiry/pipeline-overview — leads grouped by journey phase (or stage),
+// scoped by the caller's existing leads:view scope (all vs roster). Soft.
+const PipelineOverview = async (req, res) => {
+  try {
+    const result = await JourneyDashboardService.pipelineOverview(req.auth.user_id, req.scope || "own", {
+      phase: req.query.phase,
+      stuckOnly: req.query.stuckOnly === "true",
+      memberId: req.query.memberId,
+    });
+    res.status(200).json(result);
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+module.exports = { MyWork, PipelineOverview };

--- a/models/LeadStep.js
+++ b/models/LeadStep.js
@@ -47,6 +47,10 @@ const LeadStepSchema = new mongoose.Schema(
 );
 
 LeadStepSchema.index({ leadId: 1, order: 1 });
+// MB8c-1 — the My Work dashboard reads steps by owner + status; pipeline reads
+// by leadId. These keep the cross-lead aggregations indexed.
+LeadStepSchema.index({ ownerIds: 1, status: 1 });
+LeadStepSchema.index({ dueAt: 1 });
 
 module.exports = mongoose.models.LeadStep || mongoose.model("LeadStep", LeadStepSchema);
 module.exports.STATUSES = STATUSES;

--- a/repositories/LeadStepRepository.js
+++ b/repositories/LeadStepRepository.js
@@ -13,4 +13,26 @@ const insertMany = async (rows) => LeadStep.insertMany(rows);
 const updateById = async (id, update) =>
   LeadStep.findByIdAndUpdate(id, update, { new: true, runValidators: true }).lean();
 
-module.exports = { findByLead, countByLead, findById, findByIdLean, insertMany, updateById };
+// ── MB8c-1 cross-lead dashboard reads (indexed) ──────────────────────────────
+// Steps the caller "works": owned by anyone in ownerIds OR on a roster lead.
+const findByOwnerOrLead = async (ownerIds, leadIds) =>
+  LeadStep.find({ $or: [{ ownerIds: { $in: ownerIds } }, { leadId: { $in: leadIds } }] }).lean();
+
+// Every step (all-scope My Work). Bounded in practice by journey leads.
+const findAllSteps = async () => LeadStep.find({}).lean();
+
+// All steps for a set of leads (pipeline progress + blocked computation).
+const findByLeadIds = async (leadIds) =>
+  LeadStep.find({ leadId: { $in: leadIds } }).sort({ order: 1 }).lean();
+
+module.exports = {
+  findByLead,
+  countByLead,
+  findById,
+  findByIdLean,
+  insertMany,
+  updateById,
+  findByOwnerOrLead,
+  findAllSteps,
+  findByLeadIds,
+};

--- a/repositories/LeadTeamMemberRepository.js
+++ b/repositories/LeadTeamMemberRepository.js
@@ -49,6 +49,17 @@ const findActiveLeadIdsByPerson = async (personId) => {
   return rows.map((r) => r.leadId);
 };
 
+// ── MB8c-1 dashboard reads ───────────────────────────────────────────────────
+// Distinct lead ids any of these persons are CURRENTLY on the team for.
+const findActiveLeadIdsByPersons = async (personIds) => {
+  const rows = await LeadTeamMember.find({ personId: { $in: personIds }, activeTo: null }, { leadId: 1 }).lean();
+  return [...new Set(rows.map((r) => String(r.leadId)))];
+};
+
+// Current members for a set of leads (the pipeline "who's on the team" column).
+const findCurrentByLeadIds = async (leadIds) =>
+  LeadTeamMember.find({ leadId: { $in: leadIds }, activeTo: null }, { leadId: 1, personId: 1 }).lean();
+
 module.exports = {
   create,
   findByLead,
@@ -57,4 +68,6 @@ module.exports = {
   findActiveMembership,
   close,
   findActiveLeadIdsByPerson,
+  findActiveLeadIdsByPersons,
+  findCurrentByLeadIds,
 };

--- a/routes/enquiry.js
+++ b/routes/enquiry.js
@@ -89,6 +89,22 @@ router.get(
   requirePermission("leads:view:own", { ownerField: "assignedTo" }),
   leadTeam.MyLeads
 );
+// ── MB8c-1 — cross-lead journey dashboards. Literal paths: MUST stay above
+// /:_id. The gate sets req.scope from the caller's existing leads:view grant;
+// the service reuses that scope for breadth (own/team/dept/all). No new gating.
+const journeyDashboard = require("../controllers/journeyDashboard");
+router.get(
+  "/steps/my-work",
+  CheckAdminLogin,
+  requirePermission("leads:view:own", { ownerField: "assignedTo" }),
+  journeyDashboard.MyWork
+);
+router.get(
+  "/pipeline-overview",
+  CheckAdminLogin,
+  requirePermission("leads:view:own", { ownerField: "assignedTo" }),
+  journeyDashboard.PipelineOverview
+);
 router.get("/:_id", CheckAdminLogin, requirePermission("leads:view:own", { ownerField: "assignedTo" }), enquiry.Get);
 router.post("/:_id/user", CheckAdminLogin, enquiry.CreateUser);
 router.post("/:_id/conversations", CheckAdminLogin, enquiry.AddConversation);

--- a/scripts/browser-e2e-fixtures.js
+++ b/scripts/browser-e2e-fixtures.js
@@ -29,10 +29,20 @@ const ADMIN_PHONE = "919180000002";
   const Admin = require("../models/Admin");
   const Role = require("../models/Role");
   const Department = require("../models/Department");
+  // MB8a/MB8b/MB8c-1 — clean the journey artifacts the browser suite creates on
+  // the fixture lead so they don't orphan across runs.
+  const LeadStep = require("../models/LeadStep");
+  const LeadTeamMember = require("../models/LeadTeamMember");
+  const LeadChatMessage = require("../models/LeadChatMessage");
 
   const teardown = async () => {
     const lead = await Enquiry.findOne({ phone: LEAD_PHONE }).lean();
-    if (lead) await LeadInternalEvent.deleteMany({ leadId: lead._id });
+    if (lead) {
+      await LeadInternalEvent.deleteMany({ leadId: lead._id });
+      await LeadStep.deleteMany({ leadId: lead._id });
+      await LeadTeamMember.deleteMany({ leadId: lead._id });
+      await LeadChatMessage.deleteMany({ leadId: lead._id });
+    }
     await Enquiry.deleteMany({ phone: LEAD_PHONE });
     await WAConversation.deleteMany({ phone: LEAD_PHONE });
     await WAAgentMessage.deleteMany({ phone: LEAD_PHONE });

--- a/scripts/verify-mb8c1.js
+++ b/scripts/verify-mb8c1.js
@@ -1,0 +1,143 @@
+/* MB8c-1 — Journey Dashboards. Verifies My Work (caller steps across leads,
+ * overdue-first sort, filters, counts, completed-hidden, own/team/all breadth,
+ * empty state) and Pipeline Overview (phase grouping, progress, stuck rule,
+ * scope all-vs-roster, stuck-only, summary). Test port 8157. */
+require("dotenv").config();
+const { spawn } = require("child_process");
+const mongoose = require("mongoose");
+const jwt = require("jsonwebtoken");
+
+const PORT = 8157; const BASE = `http://localhost:${PORT}`; const MARK = "MB8C1";
+let pass = 0, fail = 0; const failures = [];
+const ok = (c, l) => { if (c) { pass++; console.log(`  ✓ ${l}`); } else { fail++; failures.push(l); console.error(`  ✗ ${l}`); } };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const waitFor = async (fn, l, t = 30000) => { const u = Date.now() + t; while (Date.now() < u) { try { const v = await fn(); if (v) return v; } catch (_) {} await sleep(300); } throw new Error(`waitFor: ${l}`); };
+
+(async () => {
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Admin = require("../models/Admin"); const Role = require("../models/Role"); const Department = require("../models/Department");
+  const Enquiry = require("../models/Enquiry"); const LeadStep = require("../models/LeadStep");
+  const LeadTeamMember = require("../models/LeadTeamMember");
+
+  const dept = await Department.create({ name: `${MARK} Dept` });
+  const ownRole = await Role.create({ name: `${MARK} Own`, departmentId: dept._id, permissions: ["leads:view:own", "leads:edit:own"] });
+  const teamRole = await Role.create({ name: `${MARK} Team`, departmentId: dept._id, permissions: ["leads:view:team", "leads:edit:team"] });
+  const allRole = await Role.create({ name: `${MARK} All`, departmentId: dept._id, permissions: ["leads:view:all", "leads:edit:all"] });
+  const u = (s) => `9197${String(Date.now()).slice(-7)}${s}`;
+  const mk = (name, roleIds, mgr) => Admin.create({ name, email: `${name.replace(/\s/g, "")}-${Date.now()}@t.local`, phone: u(Math.floor(Math.random() * 9)), password: "x", roleIds, departmentId: dept._id, reportingManagerId: mgr || null, status: "active" });
+  const MANAGER = await mk(`${MARK} Manager`, [teamRole._id]);
+  const SUB = await mk(`${MARK} Sub`, [ownRole._id], MANAGER._id);
+  const REVHEAD = await mk(`${MARK} RevHead`, [allRole._id]);
+  const OUTSIDER = await mk(`${MARK} Outsider`, [ownRole._id]);
+  const NOBODY = await mk(`${MARK} Nobody`, [ownRole._id]);
+  const tok = (a) => jwt.sign({ _id: String(a._id), isAdmin: true }, process.env.JWT_SECRET);
+
+  const now = Date.now();
+  const ph = (n) => ["Lead Understanding", "Client Servicing & Proposal", "Follow Up & Conversion"][n];
+  const ln = (s) => `9190${String(now).slice(-8)}${s}`;
+  const LeadA = await Enquiry.create({ name: `${MARK} LeadA`, phone: ln(1), verified: false, source: "Website", stage: "lead", assignedTo: SUB._id, additionalInfo: {} });
+  const LeadB = await Enquiry.create({ name: `${MARK} LeadB`, phone: ln(2), verified: false, source: "Website", stage: "lead", assignedTo: OUTSIDER._id, additionalInfo: {} });
+  const LeadC = await Enquiry.create({ name: `${MARK} LeadC`, phone: ln(3), verified: false, source: "Website", stage: "lead", assignedTo: MANAGER._id, additionalInfo: {} });
+  const LeadD = await Enquiry.create({ name: `${MARK} LeadD`, phone: ln(4), verified: false, source: "Website", stage: "lead", assignedTo: MANAGER._id, additionalInfo: {} });
+
+  // Steps. A1 overdue (SUB); A2 blocked on A1 (SUB); B1 due-soon (OUTSIDER);
+  // C1 unowned not_started (LeadC, SUB on roster); D1 no-movement (MANAGER).
+  const A1 = await LeadStep.create({ leadId: LeadA._id, name: "Review Bigin Notes", phase: ph(0), order: 10, ownerIds: [SUB._id], status: "in_progress", dueAt: new Date(now - 1 * 86400000) });
+  const A2 = await LeadStep.create({ leadId: LeadA._id, name: "Internal Team Discussion", phase: ph(0), order: 20, ownerIds: [SUB._id], status: "not_started", dependsOn: [A1._id] });
+  const B1 = await LeadStep.create({ leadId: LeadB._id, name: "Negotiation Call", phase: ph(2), order: 10, ownerIds: [OUTSIDER._id], status: "in_progress", dueAt: new Date(now + 2 * 86400000) });
+  const C1 = await LeadStep.create({ leadId: LeadC._id, name: "Client Follow Up", phase: ph(1), order: 10, ownerIds: [], status: "not_started" });
+  const D1 = await LeadStep.create({ leadId: LeadD._id, name: "Decor Concept Discussion", phase: ph(1), order: 10, ownerIds: [MANAGER._id], status: "in_progress" });
+  // D1 has no movement for 10 days (set updatedAt without bumping it).
+  await LeadStep.updateOne({ _id: D1._id }, { $set: { updatedAt: new Date(now - 10 * 86400000) } }, { timestamps: false });
+  // Roster: SUB on LeadA + LeadC; OUTSIDER on LeadB; MANAGER on LeadD.
+  await LeadTeamMember.create({ leadId: LeadA._id, personId: SUB._id, addedBy: SUB._id });
+  await LeadTeamMember.create({ leadId: LeadC._id, personId: SUB._id, addedBy: MANAGER._id });
+  await LeadTeamMember.create({ leadId: LeadB._id, personId: OUTSIDER._id, addedBy: OUTSIDER._id });
+  await LeadTeamMember.create({ leadId: LeadD._id, personId: MANAGER._id, addedBy: MANAGER._id });
+
+  const child = spawn("node", ["server.js"], { cwd: `${__dirname}/..`, env: { ...process.env, PORT: String(PORT) }, stdio: ["ignore", "pipe", "pipe"] });
+  let log = ""; child.stdout.on("data", (d) => (log += d)); child.stderr.on("data", (d) => (log += d));
+  const api = async (m, p, t) => { const r = await fetch(`${BASE}${p}`, { headers: t ? { Authorization: `Bearer ${t}` } : {} }); let d = null; try { d = await r.json(); } catch (_) {} return { status: r.status, data: d }; };
+  const ids = (rows) => rows.map((r) => String(r._id));
+
+  try {
+    await waitFor(() => fetch(`${BASE}/`).then((r) => r.ok).catch(() => false), "boot");
+
+    console.log("\n── Slice 1: My Work (own scope = SUB) ──");
+    const subWork = await api("GET", "/enquiry/steps/my-work", tok(SUB));
+    ok(subWork.status === 200, "my-work returns 200");
+    const subIds = ids(subWork.data.rows);
+    ok(subIds.includes(String(A1._id)) && subIds.includes(String(A2._id)), "SUB sees their owned steps (A1, A2)");
+    ok(subIds.includes(String(C1._id)), "SUB sees a roster lead's step they don't own (C1, additive)");
+    ok(!subIds.includes(String(B1._id)), "SUB does NOT see another owner's unrelated step (B1)");
+    ok(subWork.data.rows[0]._id === String(A1._id), "overdue step sorts first");
+    ok(subWork.data.counts.overdue === 1 && subWork.data.counts.blocked === 1, `counts: overdue=1, blocked=1 (got ${subWork.data.counts.overdue}/${subWork.data.counts.blocked})`);
+    const a2 = subWork.data.rows.find((r) => r._id === String(A2._id));
+    ok(a2 && a2.blocked === true, "A2 flagged blocked (depends on incomplete A1)");
+
+    console.log("\n── Slice 1: filters + completed-hidden ──");
+    const fStatus = await api("GET", "/enquiry/steps/my-work?status=not_started", tok(SUB));
+    ok(fStatus.data.rows.every((r) => r.status === "not_started"), "status filter");
+    const fPhase = await api("GET", `/enquiry/steps/my-work?phase=${encodeURIComponent(ph(0))}`, tok(SUB));
+    ok(fPhase.data.rows.every((r) => r.phase === ph(0)) && fPhase.data.rows.length === 2, "phase filter (A1, A2)");
+    const fOver = await api("GET", "/enquiry/steps/my-work?overdueOnly=true", tok(SUB));
+    ok(fOver.data.rows.length === 1 && fOver.data.rows[0]._id === String(A1._id), "overdueOnly filter");
+    await LeadStep.updateOne({ _id: C1._id }, { $set: { status: "complete" } });
+    const hidden = await api("GET", "/enquiry/steps/my-work", tok(SUB));
+    ok(!ids(hidden.data.rows).includes(String(C1._id)), "completed step hidden by default");
+    const shown = await api("GET", "/enquiry/steps/my-work?includeComplete=true", tok(SUB));
+    ok(ids(shown.data.rows).includes(String(C1._id)), "completed step shown with includeComplete toggle");
+    await LeadStep.updateOne({ _id: C1._id }, { $set: { status: "not_started" } }); // restore
+
+    console.log("\n── Slice 1: scope breadth (own < team < all) ──");
+    const mgrWork = await api("GET", "/enquiry/steps/my-work", tok(MANAGER));
+    ok(ids(mgrWork.data.rows).includes(String(A1._id)), "MANAGER (team) sees a subordinate's step (A1)");
+    const revWork = await api("GET", "/enquiry/steps/my-work", tok(REVHEAD));
+    ok(ids(revWork.data.rows).includes(String(B1._id)), "REVHEAD (all) sees an out-of-tree step (B1)");
+    ok(!ids(mgrWork.data.rows).includes(String(B1._id)), "MANAGER (team) does NOT see the out-of-tree step (B1) — breadth differs");
+    const nobody = await api("GET", "/enquiry/steps/my-work", tok(NOBODY));
+    ok(nobody.status === 200 && nobody.data.rows.length === 0 && nobody.data.counts.total === 0, "empty state for an admin with no work");
+
+    console.log("\n── Slice 2: Pipeline Overview (all scope = REVHEAD) ──");
+    const pipe = await api("GET", "/enquiry/pipeline-overview", tok(REVHEAD));
+    ok(pipe.status === 200 && Array.isArray(pipe.data.groups), "pipeline returns grouped data");
+    ok(pipe.data.stuckDays === 5, "stuck rule documents N=5 days");
+    const flat = pipe.data.groups.flatMap((g) => g.leads);
+    const byId = Object.fromEntries(flat.map((l) => [l._id, l]));
+    const a = byId[String(LeadA._id)], c = byId[String(LeadC._id)], d = byId[String(LeadD._id)];
+    ok(a && a.bucket === ph(0), "LeadA grouped under its current journey phase (Lead Understanding)");
+    ok(a && a.progress && a.progress.done === 0 && a.progress.total === 2, "LeadA progress 0/2 in current phase");
+    ok(a && a.stuck && a.stuckReason === "overdue step", "LeadA stuck via overdue step");
+    ok(d && d.stuck && /no movement/.test(d.stuckReason), "LeadD stuck via no-movement rule");
+    ok(c && !c.stuck, "LeadC not stuck");
+    ok(a && a.team.some((t) => t._id === String(SUB._id)), "LeadA shows its team (SUB)");
+
+    console.log("\n── Slice 2: scope (own = SUB) + stuck-only filter ──");
+    const subPipe = await api("GET", "/enquiry/pipeline-overview", tok(SUB));
+    const subLeadIds = subPipe.data.groups.flatMap((g) => g.leads).map((l) => l._id);
+    ok(subLeadIds.includes(String(LeadA._id)) && subLeadIds.includes(String(LeadC._id)), "SUB pipeline shows their roster leads (A, C)");
+    ok(!subLeadIds.includes(String(LeadB._id)) && !subLeadIds.includes(String(LeadD._id)), "SUB pipeline excludes non-roster leads (B, D)");
+    const stuckOnly = await api("GET", "/enquiry/pipeline-overview?stuckOnly=true", tok(REVHEAD));
+    const stuckIds = stuckOnly.data.groups.flatMap((g) => g.leads).map((l) => l._id);
+    ok(stuckIds.includes(String(LeadA._id)) && stuckIds.includes(String(LeadD._id)) && !stuckIds.includes(String(LeadC._id)), "stuck-only filter returns only stuck leads");
+    ok(stuckOnly.data.summary.stuck >= 2 && stuckOnly.data.groups.flatMap((g) => g.leads).every((l) => l.stuck), "stuck-only summary + rows all stuck");
+
+    console.log("\n── Slice 2: phase grouping for a member filter ──");
+    const memberFilter = await api("GET", `/enquiry/pipeline-overview?memberId=${String(SUB._id)}`, tok(REVHEAD));
+    const mfIds = memberFilter.data.groups.flatMap((g) => g.leads).map((l) => l._id);
+    ok(mfIds.includes(String(LeadA._id)) && !mfIds.includes(String(LeadD._id)), "memberId filter narrows to that member's leads");
+  } catch (e) {
+    fail++; failures.push(`fatal: ${e.message}`); console.error("FATAL", e); console.error(log.slice(-2000));
+  } finally {
+    await LeadStep.deleteMany({ leadId: { $in: [LeadA._id, LeadB._id, LeadC._id, LeadD._id] } });
+    await LeadTeamMember.deleteMany({ leadId: { $in: [LeadA._id, LeadB._id, LeadC._id, LeadD._id] } });
+    await Enquiry.deleteMany({ _id: { $in: [LeadA._id, LeadB._id, LeadC._id, LeadD._id] } });
+    await Admin.deleteMany({ _id: { $in: [MANAGER._id, SUB._id, REVHEAD._id, OUTSIDER._id, NOBODY._id] } });
+    await Role.deleteMany({ _id: { $in: [ownRole._id, teamRole._id, allRole._id] } });
+    await Department.deleteMany({ _id: dept._id });
+    child.kill(); await mongoose.disconnect();
+    console.log(`\n══ RESULT: ${pass} passed, ${fail} failed ══`);
+    if (failures.length) console.log("failures:", failures.join(" | "));
+    process.exit(fail === 0 ? 0 : 1);
+  }
+})();

--- a/services/JourneyDashboardService.js
+++ b/services/JourneyDashboardService.js
@@ -1,0 +1,225 @@
+const mongoose = require("mongoose");
+const Admin = require("../models/Admin");
+const Enquiry = require("../models/Enquiry");
+const { PHASES } = require("../models/StepDefinition");
+const LeadStepRepository = require("../repositories/LeadStepRepository");
+const LeadTeamMemberRepository = require("../repositories/LeadTeamMemberRepository");
+const { getSubordinateIds, getDepartmentMemberIds } = require("../middlewares/requirePermission");
+
+const DAY = 24 * 60 * 60 * 1000;
+const WEEK = 7 * DAY;
+// STUCK rule (documented): a journey lead is "stuck" if it has any overdue step
+// (a non-complete, non-N/A step whose dueAt is in the past) OR no step movement
+// in STUCK_DAYS days (its most-recently-updated step is older than that).
+const STUCK_DAYS = 5;
+
+const idStr = (v) => String(v);
+
+// The set of owner ids a caller's dashboard covers, by their (existing) lead
+// scope — reused verbatim, no new gating:
+//   own → just them · team → them + subordinates · department → dept members ·
+//   all → null sentinel (unrestricted, i.e. the whole org's work).
+const ownerScopeIds = async (adminId, scope) => {
+  if (scope === "all") return null;
+  if (scope === "team") return [adminId, ...(await getSubordinateIds(adminId))];
+  if (scope === "department") {
+    const admin = await Admin.findById(adminId, { departmentId: 1 }).lean();
+    const members = await getDepartmentMemberIds(admin && admin.departmentId);
+    return [...new Set([idStr(adminId), ...members.map(idStr)])].map((s) => new mongoose.Types.ObjectId(s));
+  }
+  return [adminId];
+};
+
+// Current journey phase of a lead from its steps: the phase of the first step
+// (in order) not yet complete/N-A; "Completed" if all done; null if no steps.
+const currentPhase = (steps) => {
+  const open = steps.find((s) => s.status !== "complete" && !s.notApplicable);
+  if (!steps.length) return null;
+  return open ? open.phase || "—" : "Completed";
+};
+
+const isOverdueStep = (s, now) =>
+  s.dueAt && new Date(s.dueAt) < now && s.status !== "complete" && !s.notApplicable;
+
+// ── SLICE 1: MY WORK ─────────────────────────────────────────────────────────
+const myWork = async (adminId, scope, { status, phase, overdueOnly, includeComplete } = {}) => {
+  const now = new Date();
+  const me = new mongoose.Types.ObjectId(adminId);
+  const rosterLeadIds = await LeadTeamMemberRepository.findActiveLeadIdsByPerson(me);
+
+  // The caller's candidate steps (server-computed, not raw-everything).
+  let candidates;
+  if (scope === "all") {
+    candidates = await LeadStepRepository.findAllSteps();
+  } else {
+    const owners = await ownerScopeIds(adminId, scope);
+    candidates = await LeadStepRepository.findByOwnerOrLead(owners, rosterLeadIds);
+  }
+  // N/A steps are not work.
+  candidates = candidates.filter((s) => !s.notApplicable);
+
+  // Full step sets of the involved leads → statuses for blocked + lead names.
+  const leadIds = [...new Set(candidates.map((s) => idStr(s.leadId)))];
+  const [fullSteps, leads] = await Promise.all([
+    LeadStepRepository.findByLeadIds(leadIds.map((id) => new mongoose.Types.ObjectId(id))),
+    Enquiry.find({ _id: { $in: leadIds } }, { name: 1, stage: 1 }).lean(),
+  ]);
+  const statusById = new Map(fullSteps.map((s) => [idStr(s._id), s.status]));
+  const leadName = new Map(leads.map((l) => [idStr(l._id), l.name]));
+
+  const decorate = (s) => {
+    const unmet = (s.dependsOn || []).map(idStr).filter((d) => statusById.get(d) !== "complete");
+    const overdue = isOverdueStep(s, now);
+    const dueSoon = !overdue && s.dueAt && new Date(s.dueAt) >= now && new Date(s.dueAt) <= new Date(+now + WEEK);
+    return {
+      _id: idStr(s._id),
+      leadId: idStr(s.leadId),
+      leadName: leadName.get(idStr(s.leadId)) || "—",
+      name: s.name,
+      phase: s.phase || "",
+      status: s.status,
+      dueAt: s.dueAt || null,
+      rolling: !!s.rolling,
+      optional: !!s.optional,
+      blocked: unmet.length > 0,
+      overdue,
+      dueSoon,
+    };
+  };
+  const decorated = candidates.map(decorate);
+
+  // Summary is computed over the actionable (non-complete) set, before UI filters.
+  const actionable = decorated.filter((r) => r.status !== "complete");
+  const counts = {
+    total: actionable.length,
+    overdue: actionable.filter((r) => r.overdue).length,
+    dueThisWeek: actionable.filter((r) => r.dueSoon).length,
+    blocked: actionable.filter((r) => r.blocked).length,
+  };
+
+  // UI filters.
+  let rows = decorated;
+  if (!includeComplete) rows = rows.filter((r) => r.status !== "complete");
+  if (status) rows = rows.filter((r) => r.status === status);
+  if (phase) rows = rows.filter((r) => r.phase === phase);
+  if (overdueOnly) rows = rows.filter((r) => r.overdue);
+
+  // DEFAULT SORT: overdue → due-soon → blocked → rest; then dueAt asc (nulls
+  // last), then lead name.
+  const rank = (r) => (r.overdue ? 0 : r.dueSoon ? 1 : r.blocked ? 2 : 3);
+  rows.sort((a, b) => {
+    const ra = rank(a), rb = rank(b);
+    if (ra !== rb) return ra - rb;
+    const da = a.dueAt ? +new Date(a.dueAt) : Infinity;
+    const db = b.dueAt ? +new Date(b.dueAt) : Infinity;
+    if (da !== db) return da - db;
+    return a.leadName.localeCompare(b.leadName);
+  });
+
+  return { rows, counts, scope };
+};
+
+// ── SLICE 2: PIPELINE OVERVIEW ───────────────────────────────────────────────
+const pipelineOverview = async (adminId, scope, { phase, stuckOnly, memberId } = {}) => {
+  const now = new Date();
+
+  // Lead set: all-scope → all active leads; otherwise → leads the caller's scope
+  // people are on the roster for (soft, MB8a-consistent — no new 403).
+  let leads;
+  if (scope === "all") {
+    leads = await Enquiry.find(
+      { isLost: { $ne: true }, "recycled.isRecycled": { $ne: true } },
+      { name: 1, stage: 1, assignedTo: 1 }
+    ).lean();
+  } else {
+    const owners = await ownerScopeIds(adminId, scope);
+    const leadIds = await LeadTeamMemberRepository.findActiveLeadIdsByPersons(owners);
+    leads = await Enquiry.find({ _id: { $in: leadIds } }, { name: 1, stage: 1, assignedTo: 1 }).lean();
+  }
+
+  const leadIds = leads.map((l) => l._id);
+  const [allSteps, rosterRows] = await Promise.all([
+    LeadStepRepository.findByLeadIds(leadIds),
+    LeadTeamMemberRepository.findCurrentByLeadIds(leadIds),
+  ]);
+
+  const stepsByLead = new Map();
+  for (const s of allSteps) {
+    const k = idStr(s.leadId);
+    if (!stepsByLead.has(k)) stepsByLead.set(k, []);
+    stepsByLead.get(k).push(s);
+  }
+  const teamByLead = new Map();
+  for (const r of rosterRows) {
+    const k = idStr(r.leadId);
+    if (!teamByLead.has(k)) teamByLead.set(k, []);
+    teamByLead.get(k).push(idStr(r.personId));
+  }
+
+  // Resolve roster member names in one query.
+  const memberIds = [...new Set(rosterRows.map((r) => idStr(r.personId)))];
+  const members = memberIds.length ? await Admin.find({ _id: { $in: memberIds } }, { name: 1 }).lean() : [];
+  const nameOf = new Map(members.map((a) => [idStr(a._id), a.name]));
+
+  let rows = leads.map((l) => {
+    const steps = (stepsByLead.get(idStr(l._id)) || []).sort((a, b) => (a.order || 0) - (b.order || 0));
+    const phaseName = currentPhase(steps); // null when pre-journey
+    const bucket = phaseName === null ? `Stage: ${l.stage || "new"}` : phaseName;
+
+    // Progress within the current phase (complete + N/A counts as done).
+    let progress = null;
+    if (phaseName && phaseName !== "Completed") {
+      const inPhase = steps.filter((s) => (s.phase || "—") === phaseName);
+      const done = inPhase.filter((s) => s.status === "complete" || s.notApplicable).length;
+      progress = { done, total: inPhase.length, phase: phaseName };
+    } else if (phaseName === "Completed") {
+      progress = { done: steps.length, total: steps.length, phase: "Completed" };
+    }
+
+    const overdue = steps.some((s) => isOverdueStep(s, now));
+    const lastMove = steps.reduce((mx, s) => Math.max(mx, +new Date(s.updatedAt || 0)), 0);
+    const noMovement = steps.length > 0 && lastMove > 0 && lastMove < +now - STUCK_DAYS * DAY;
+    const stuck = steps.length > 0 && (overdue || noMovement);
+
+    const team = (teamByLead.get(idStr(l._id)) || []).map((pid) => ({ _id: pid, name: nameOf.get(pid) || "—" }));
+    return {
+      _id: idStr(l._id),
+      name: l.name,
+      stage: l.stage || "new",
+      assignedTo: l.assignedTo ? idStr(l.assignedTo) : null,
+      bucket,
+      hasJourney: steps.length > 0,
+      progress,
+      team,
+      stuck,
+      stuckReason: stuck ? (overdue ? "overdue step" : `no movement in ${STUCK_DAYS}d`) : null,
+    };
+  });
+
+  // Filters.
+  if (phase) rows = rows.filter((r) => r.bucket === phase);
+  if (stuckOnly) rows = rows.filter((r) => r.stuck);
+  if (memberId) rows = rows.filter((r) => r.assignedTo === String(memberId) || r.team.some((t) => t._id === String(memberId)));
+
+  // Group by bucket, ordered: the 3 journey phases, Completed, then stage buckets.
+  const order = [...PHASES, "Completed"];
+  const groupsMap = new Map();
+  for (const r of rows) {
+    if (!groupsMap.has(r.bucket)) groupsMap.set(r.bucket, []);
+    groupsMap.get(r.bucket).push(r);
+  }
+  const orderedKeys = [
+    ...order.filter((k) => groupsMap.has(k)),
+    ...[...groupsMap.keys()].filter((k) => !order.includes(k)).sort(),
+  ];
+  const groups = orderedKeys.map((bucket) => ({ bucket, count: groupsMap.get(bucket).length, leads: groupsMap.get(bucket) }));
+
+  const summary = {
+    totalLeads: rows.length,
+    stuck: rows.filter((r) => r.stuck).length,
+    byPhase: groups.map((g) => ({ phase: g.bucket, count: g.count })),
+  };
+  return { groups, summary, scope, stuckDays: STUCK_DAYS };
+};
+
+module.exports = { myWork, pipelineOverview, STUCK_DAYS };


### PR DESCRIPTION
Two cross-lead aggregation views on the MB8a roster + MB8b steps. GET /enquiry/steps/my-work (caller's actionable steps across leads, scope-broadened own→team→dept→all + roster-additive, overdue-first sort, filters) and GET /enquiry/pipeline-overview (leads by journey phase, progress, stuck flag N=5). Reuses leads:view gate — Enquiry/requirePermission/rbacPermissions untouched. Server-side aggregation, new LeadStep indexes {ownerIds,status}+{dueAt}. 29/29 + regressions.