### PR TITLE
MB8c-2a-i: per-step tasks (LeadTask + stepId), record-call reuse — backend for the Client Command Center

### DIFF
--- a/controllers/leadStep.js
+++ b/controllers/leadStep.js
@@ -1,6 +1,7 @@
 const mongoose = require("mongoose");
 const Enquiry = require("../models/Enquiry");
 const LeadStepService = require("../services/LeadStepService");
+const LeadTaskService = require("../services/LeadTaskService");
 
 const respond = (res, error) => {
   const status = error.status || 500;
@@ -63,4 +64,49 @@ const AddNote = async (req, res) => {
   }
 };
 
-module.exports = { List, Instantiate, Patch, AddNote };
+// ── MB8c-2a-i — per-step tasks ───────────────────────────────────────────────
+// GET /enquiry/:_id/steps/:stepId/tasks
+const ListTasks = async (req, res) => {
+  try {
+    await assertInScope(req.params._id, req.scopeFilter);
+    res.status(200).json({ list: await LeadTaskService.listForStep(req.params.stepId) });
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// POST /enquiry/:_id/steps/:stepId/tasks — { title, assigneeId?, dueAt? }
+const CreateTask = async (req, res) => {
+  try {
+    await assertInScope(req.params._id, req.scopeFilter);
+    const task = await LeadTaskService.createStepTask(
+      req.params._id,
+      req.params.stepId,
+      { title: req.body?.title, assigneeId: req.body?.assigneeId, dueAt: req.body?.dueAt },
+      req.auth.user_id
+    );
+    res.status(201).json(task);
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// PATCH /enquiry/:_id/steps/:stepId/tasks/:taskId — edit (title/assignee/due) or
+// toggle done (when body.toggle is true).
+const PatchTask = async (req, res) => {
+  try {
+    await assertInScope(req.params._id, req.scopeFilter);
+    const task = req.body && req.body.toggle
+      ? await LeadTaskService.toggleStepTask(req.params.taskId, req.auth.user_id)
+      : await LeadTaskService.editStepTask(req.params.taskId, {
+          title: req.body?.title,
+          assigneeId: req.body?.assigneeId,
+          dueAt: req.body?.dueAt,
+        });
+    res.status(200).json(task);
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+module.exports = { List, Instantiate, Patch, AddNote, ListTasks, CreateTask, PatchTask };

--- a/models/LeadTask.js
+++ b/models/LeadTask.js
@@ -10,10 +10,18 @@ const ObjectId = mongoose.Schema.Types.ObjectId;
 const LeadTaskSchema = new mongoose.Schema(
   {
     leadId: { type: ObjectId, ref: "Enquiry", required: true, index: true },
+    // MB8c-2a-i — optional link to a journey step (LeadStep). Set → a per-step
+    // micro-task surfaced in the step's inline panel; null → a lead-level
+    // collaboration task (MB7b). Reuses this model rather than a parallel one.
+    stepId: { type: ObjectId, ref: "LeadStep", default: null, index: true },
     title: { type: String, required: true },
-    assigneeId: { type: ObjectId, ref: "Admin", required: true, index: true },
+    // assignee/dueAt stay REQUIRED for MB7b collaboration tasks (the createTask
+    // service validates them) but are OPTIONAL at the schema level so step
+    // micro-tasks can start ownerless / undated and pick up an owner from the
+    // roster later.
+    assigneeId: { type: ObjectId, ref: "Admin", default: null, index: true },
     assignerId: { type: ObjectId, ref: "Admin", required: true },
-    dueAt: { type: Date, required: true },
+    dueAt: { type: Date, default: null },
     status: { type: String, enum: ["open", "done"], default: "open", index: true },
     // "task" = born-in-chat / standalone (Slice 2); "nurture" = the rolling CS
     // nurture touch (Slice 4), which carries ready-to-copy text.
@@ -30,5 +38,6 @@ const LeadTaskSchema = new mongoose.Schema(
 
 LeadTaskSchema.index({ assigneeId: 1, status: 1, dueAt: 1 });
 LeadTaskSchema.index({ leadId: 1, kind: 1, status: 1 });
+LeadTaskSchema.index({ stepId: 1, status: 1 });
 
 module.exports = mongoose.models.LeadTask || mongoose.model("LeadTask", LeadTaskSchema);

--- a/routes/enquiry.js
+++ b/routes/enquiry.js
@@ -263,6 +263,25 @@ router.post(
   requirePermission("leads:edit:own", { ownerField: "assignedTo" }),
   leadStep.AddNote
 );
+// ── MB8c-2a-i — per-step tasks (reuses leads:view/edit scope + ownerField). ───
+router.get(
+  "/:_id/steps/:stepId/tasks",
+  CheckAdminLogin,
+  requirePermission("leads:view:own", { ownerField: "assignedTo" }),
+  leadStep.ListTasks
+);
+router.post(
+  "/:_id/steps/:stepId/tasks",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own", { ownerField: "assignedTo" }),
+  leadStep.CreateTask
+);
+router.patch(
+  "/:_id/steps/:stepId/tasks/:taskId",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own", { ownerField: "assignedTo" }),
+  leadStep.PatchTask
+);
 
 // ── MB7b Slice 4 — WhatsApp-group one-tap toggle (red-flag → Yes) ─────────────
 const nurture = require("../controllers/nurture");

--- a/scripts/browser-e2e-fixtures.js
+++ b/scripts/browser-e2e-fixtures.js
@@ -14,6 +14,9 @@ const jwt = require("jsonwebtoken");
 const MARKER = "BROWSER-E2E";
 const LEAD_PHONE = "919180000001";
 const ADMIN_PHONE = "919180000002";
+// MB8c-2a-i — a dedicated QUALIFIED lead (with roster + journey steps + brief
+// facts) so the command-center e2e never has to mutate the pristine LEAD_PHONE.
+const QUALIFIED_LEAD_PHONE = "919180000004";
 
 (async () => {
   const cmd = process.argv[2];
@@ -35,15 +38,21 @@ const ADMIN_PHONE = "919180000002";
   const LeadTeamMember = require("../models/LeadTeamMember");
   const LeadChatMessage = require("../models/LeadChatMessage");
 
+  const LeadTask = require("../models/LeadTask");
+  const cleanLeadArtifacts = async (phone) => {
+    const l = await Enquiry.findOne({ phone }).lean();
+    if (!l) return;
+    await LeadInternalEvent.deleteMany({ leadId: l._id });
+    await LeadStep.deleteMany({ leadId: l._id });
+    await LeadTeamMember.deleteMany({ leadId: l._id });
+    await LeadChatMessage.deleteMany({ leadId: l._id });
+    await LeadTask.deleteMany({ leadId: l._id });
+  };
+
   const teardown = async () => {
-    const lead = await Enquiry.findOne({ phone: LEAD_PHONE }).lean();
-    if (lead) {
-      await LeadInternalEvent.deleteMany({ leadId: lead._id });
-      await LeadStep.deleteMany({ leadId: lead._id });
-      await LeadTeamMember.deleteMany({ leadId: lead._id });
-      await LeadChatMessage.deleteMany({ leadId: lead._id });
-    }
-    await Enquiry.deleteMany({ phone: LEAD_PHONE });
+    await cleanLeadArtifacts(LEAD_PHONE);
+    await cleanLeadArtifacts(QUALIFIED_LEAD_PHONE);
+    await Enquiry.deleteMany({ phone: { $in: [LEAD_PHONE, QUALIFIED_LEAD_PHONE] } });
     await WAConversation.deleteMany({ phone: LEAD_PHONE });
     await WAAgentMessage.deleteMany({ phone: LEAD_PHONE });
     await Admin.deleteMany({ phone: ADMIN_PHONE });
@@ -104,8 +113,28 @@ const ADMIN_PHONE = "919180000002";
     { phone: LEAD_PHONE, role: "assistant", message: "How lovely! Tell me more ✦" },
   ]);
 
+  // ── MB8c-2a-i — a QUALIFIED lead for the command-center e2e ──────────────────
+  // (LeadTeamMember is already required above for teardown.)
+  const StepDefinitionService = require("../services/StepDefinitionService");
+  const LeadStepService = require("../services/LeadStepService");
+  const qLead = await Enquiry.create({
+    name: "Aarav Mehta",
+    phone: QUALIFIED_LEAD_PHONE,
+    verified: true,
+    source: "whatsapp",
+    stage: "qualified",
+    qualified: true,
+    assignedTo: admin._id,
+    qualificationData: { groomName: "Aarav", brideName: "Diya", weddingStyle: "Boho", venueArea: "Goa", venueStatus: "looking", servicesRequired: ["Decor", "Makeup"], budgetAmount: 1500000 },
+    additionalInfo: { adFormAnswers: { city: "Goa", weddingDate: "2026-12-12", guests: "300" } },
+  });
+  // The founder is on the roster (so they can own steps/tasks); seed defs + steps.
+  await LeadTeamMember.create({ leadId: qLead._id, personId: admin._id, departmentName: `${MARKER} Dept`, addedBy: admin._id });
+  await StepDefinitionService.seed();
+  await LeadStepService.instantiateForLead(qLead._id, admin._id);
+
   await mongoose.disconnect();
   console.log(
-    JSON.stringify({ token, leadId: String(lead._id), conversationId: String(conversation._id) })
+    JSON.stringify({ token, leadId: String(lead._id), conversationId: String(conversation._id), qualifiedLeadId: String(qLead._id) })
   );
 })();

--- a/scripts/verify-mb8c2ai-tasks.js
+++ b/scripts/verify-mb8c2ai-tasks.js
@@ -1,0 +1,99 @@
+/* MB8c-2a-i — per-step tasks. Verifies create/list/edit/toggle on a journey
+ * step, owner-from-roster validation, overdue flag, actor-named journey events,
+ * and that the MB7b lead-task + step-note mirror are untouched. Test port 8158. */
+require("dotenv").config();
+const { spawn } = require("child_process");
+const mongoose = require("mongoose");
+const jwt = require("jsonwebtoken");
+
+const PORT = 8158; const BASE = `http://localhost:${PORT}`; const MARK = "MB8C2AI";
+let pass = 0, fail = 0; const failures = [];
+const ok = (c, l) => { if (c) { pass++; console.log(`  ✓ ${l}`); } else { fail++; failures.push(l); console.error(`  ✗ ${l}`); } };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const waitFor = async (fn, l, t = 30000) => { const u = Date.now() + t; while (Date.now() < u) { try { const v = await fn(); if (v) return v; } catch (_) {} await sleep(300); } throw new Error(`waitFor: ${l}`); };
+
+(async () => {
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Admin = require("../models/Admin"); const Role = require("../models/Role"); const Department = require("../models/Department");
+  const Enquiry = require("../models/Enquiry"); const LeadStep = require("../models/LeadStep"); const LeadTask = require("../models/LeadTask");
+  const LeadTeamMember = require("../models/LeadTeamMember"); const LeadInternalEvent = require("../models/LeadInternalEvent");
+  const AdminNotification = require("../models/AdminNotification");
+
+  const dept = await Department.create({ name: `${MARK} Dept` });
+  const role = await Role.create({ name: `${MARK} All`, departmentId: dept._id, permissions: ["leads:view:all", "leads:edit:all"] });
+  const u = (s) => `9197${String(Date.now()).slice(-7)}${s}`;
+  const BOSS = await Admin.create({ name: `${MARK} Boss`, email: `boss-${Date.now()}@t.local`, phone: u(1), password: "x", roleIds: [role._id], departmentId: dept._id, status: "active" });
+  const MATE = await Admin.create({ name: `${MARK} Mate`, email: `mate-${Date.now()}@t.local`, phone: u(2), password: "x", roleIds: [role._id], departmentId: dept._id, status: "active" });
+  const OUTSIDER = await Admin.create({ name: `${MARK} Outsider`, email: `out-${Date.now()}@t.local`, phone: u(3), password: "x", roleIds: [role._id], status: "active" });
+  const bossT = jwt.sign({ _id: String(BOSS._id), isAdmin: true }, process.env.JWT_SECRET);
+
+  const lead = await Enquiry.create({ name: `${MARK} Couple`, phone: `9190${String(Date.now()).slice(-8)}`, verified: false, source: "Website", stage: "lead", assignedTo: BOSS._id, additionalInfo: {} });
+  const step = await LeadStep.create({ leadId: lead._id, name: "Decor Concept Discussion", phase: "Client Servicing & Proposal", order: 10, status: "in_progress" });
+  // BOSS + MATE on the roster (eligible task owners); OUTSIDER is not.
+  await LeadTeamMember.create({ leadId: lead._id, personId: BOSS._id, addedBy: BOSS._id });
+  await LeadTeamMember.create({ leadId: lead._id, personId: MATE._id, addedBy: BOSS._id });
+
+  const child = spawn("node", ["server.js"], { cwd: `${__dirname}/..`, env: { ...process.env, PORT: String(PORT) }, stdio: ["ignore", "pipe", "pipe"] });
+  let log = ""; child.stdout.on("data", (d) => (log += d)); child.stderr.on("data", (d) => (log += d));
+  const api = async (m, p, t, b) => { const r = await fetch(`${BASE}${p}`, { method: m, headers: { ...(t ? { Authorization: `Bearer ${t}` } : {}), ...(b ? { "Content-Type": "application/json" } : {}) }, body: b ? JSON.stringify(b) : undefined }); let d = null; try { d = await r.json(); } catch (_) {} return { status: r.status, data: d }; };
+  const base = `/enquiry/${lead._id}/steps/${step._id}/tasks`;
+
+  try {
+    await waitFor(() => fetch(`${BASE}/`).then((r) => r.ok).catch(() => false), "boot");
+
+    console.log("\n── create / list ──");
+    const t1 = await api("POST", base, bossT, { title: "Draft 3 decor moodboards", assigneeId: String(MATE._id), dueAt: new Date(Date.now() - 86400000).toISOString() });
+    ok(t1.status === 201 && t1.data.title === "Draft 3 decor moodboards" && String(t1.data.stepId) === String(step._id), "create a step task linked to the step");
+    ok(String(t1.data.assigneeId) === String(MATE._id), "owner assigned from the roster");
+    ok(t1.data.overdue === true, "past due + open → overdue");
+    const t2 = await api("POST", base, bossT, { title: "Ownerless undated task" });
+    ok(t2.status === 201 && !t2.data.assigneeId && !t2.data.dueAt && t2.data.overdue === false, "ownerless + undated task allowed (not overdue)");
+    const list = await api("GET", base, bossT);
+    ok(list.status === 200 && list.data.list.length === 2, "list returns the step's tasks");
+
+    console.log("\n── owner must be on the roster ──");
+    const offRoster = await api("POST", base, bossT, { title: "x", assigneeId: String(OUTSIDER._id) });
+    ok(offRoster.status === 400, "off-roster owner rejected");
+
+    console.log("\n── edit ──");
+    const edited = await api("PATCH", `${base}/${t2.data._id}`, bossT, { title: "Renamed task", assigneeId: String(BOSS._id) });
+    ok(edited.status === 200 && edited.data.title === "Renamed task" && String(edited.data.assigneeId) === String(BOSS._id), "edit title + assignee");
+
+    console.log("\n── toggle done / reopen + journey events ──");
+    const done = await api("PATCH", `${base}/${t1.data._id}`, bossT, { toggle: true });
+    ok(done.status === 200 && done.data.status === "done" && !!done.data.completedAt, "toggle → done (completedAt set)");
+    const reopened = await api("PATCH", `${base}/${t1.data._id}`, bossT, { toggle: true });
+    ok(reopened.status === 200 && reopened.data.status === "open" && !reopened.data.completedAt, "toggle again → reopened");
+
+    const journey = (await api("GET", `/enquiry/${lead._id}/journey`, bossT)).data.entries || [];
+    const created = journey.find((e) => e.type === "step_task_created");
+    ok(created && created.actor === `${MARK} Boss` && /Task added: "Draft 3 decor moodboards".*Decor Concept/.test(created.title), `journey step_task_created names actor + task + step ("${created && created.title}")`);
+    ok(journey.some((e) => e.type === "step_task_completed") && journey.some((e) => e.type === "step_task_reopened"), "journey records complete + reopen events");
+
+    console.log("\n── regression: MB7b lead task + step-note mirror intact ──");
+    const leadTask = await api("POST", "/lead-tasks", bossT, { leadId: String(lead._id), title: "MB7b task", assigneeId: String(MATE._id), dueAt: new Date(Date.now() + 86400000).toISOString() });
+    ok(leadTask.status === 201 && !leadTask.data.stepId, "MB7b lead-level task still works (no stepId)");
+    const note = await api("POST", `/enquiry/${lead._id}/steps/${step._id}/notes`, bossT, { body: "decor note", mentions: [String(MATE._id)] });
+    ok(note.status === 201, "MB8b step note still posts");
+    const chat = (await api("GET", `/enquiry/${lead._id}/chat`, bossT)).data.messages || [];
+    ok(chat.some((m) => m.systemType === "step_note" && /decor note/.test(m.body)), "step note still mirrors into the lead chat");
+    ok(!chat.some((m) => m.systemType === "step_task_created"), "step TASKS do NOT post to chat (journey-only, quiet)");
+  } catch (e) {
+    fail++; failures.push(`fatal: ${e.message}`); console.error("FATAL", e); console.error(log.slice(-2000));
+  } finally {
+    await LeadTask.deleteMany({ leadId: lead._id });
+    await LeadStep.deleteMany({ leadId: lead._id });
+    await LeadTeamMember.deleteMany({ leadId: lead._id });
+    await LeadInternalEvent.deleteMany({ leadId: lead._id });
+    await require("../models/LeadChatMessage").deleteMany({ leadId: lead._id });
+    await AdminNotification.deleteMany({ adminId: { $in: [BOSS._id, MATE._id, OUTSIDER._id] } });
+    await Enquiry.deleteMany({ _id: lead._id });
+    await Admin.deleteMany({ _id: { $in: [BOSS._id, MATE._id, OUTSIDER._id] } });
+    await Role.deleteMany({ _id: role._id });
+    await Department.deleteMany({ _id: dept._id });
+    child.kill(); await mongoose.disconnect();
+    console.log(`\n══ RESULT: ${pass} passed, ${fail} failed ══`);
+    if (failures.length) console.log("failures:", failures.join(" | "));
+    process.exit(fail === 0 ? 0 : 1);
+  }
+})();

--- a/services/JourneyService.js
+++ b/services/JourneyService.js
@@ -72,6 +72,10 @@ const EVENT_TITLES = {
   journey_started: "Journey steps created",
   step_status_changed: "Step updated",
   step_owners_assigned: "Step owners assigned",
+  // MB8c-2a-i — per-step tasks.
+  step_task_created: "Task added",
+  step_task_completed: "Task done ✓",
+  step_task_reopened: "Task reopened",
 };
 
 const STEP_STATUS_LABEL = {
@@ -136,6 +140,13 @@ const dynamicTitle = (type, payload = {}, nameOf) => {
         : "no one";
       return `Assigned ${names} to "${payload.stepName || "a step"}"`;
     }
+    // MB8c-2a-i — name the task + its step (actor shown separately).
+    case "step_task_created":
+      return `Task added: "${payload.title || "task"}"${payload.stepName ? ` · ${payload.stepName}` : ""}`;
+    case "step_task_completed":
+      return `Task done: "${payload.title || "task"}" ✓`;
+    case "step_task_reopened":
+      return `Task reopened: "${payload.title || "task"}"`;
     default:
       return null;
   }

--- a/services/LeadTaskService.js
+++ b/services/LeadTaskService.js
@@ -1,11 +1,13 @@
 const mongoose = require("mongoose");
 const LeadTask = require("../models/LeadTask");
+const LeadStep = require("../models/LeadStep");
 const Admin = require("../models/Admin");
 const Role = require("../models/Role");
 const Enquiry = require("../models/Enquiry");
 const LeadInternalEventService = require("./LeadInternalEventService");
 const AdminNotificationService = require("./AdminNotificationService");
 const LeadChatService = require("./LeadChatService");
+const LeadTeamMemberRepository = require("../repositories/LeadTeamMemberRepository");
 
 const httpError = (status, message) => Object.assign(new Error(message), { status });
 const isId = (v) => mongoose.Types.ObjectId.isValid(v);
@@ -129,7 +131,8 @@ const decorate = async (rows) => {
   return rows.map((r) => ({
     ...r,
     lead: r.leadId ? leadById.get(String(r.leadId)) || null : null,
-    overdue: r.status === "open" && new Date(r.dueAt).getTime() < now,
+    // Overdue only when a due date is actually set (step tasks may be undated).
+    overdue: r.status === "open" && !!r.dueAt && new Date(r.dueAt).getTime() < now,
   }));
 };
 
@@ -181,6 +184,117 @@ const escalateOverdue = async (now = new Date()) => {
   return { escalated };
 };
 
+// ── MB8c-2a-i — PER-STEP TASKS ───────────────────────────────────────────────
+// Micro-tasks attached to a journey step (LeadStep). Reuse this model via the
+// optional stepId link. Unlike MB7b collaboration tasks these are quiet in the
+// lead chat (notes are the chat citizens) — they emit journey events only.
+
+const assertStepInLead = async (leadId, stepId) => {
+  if (!isId(leadId) || !isId(stepId)) throw httpError(400, "Invalid id");
+  const step = await LeadStep.findById(stepId, { leadId: 1, name: 1 }).lean();
+  if (!step || String(step.leadId) !== String(leadId)) throw httpError(404, "Step not found on this lead");
+  return step;
+};
+
+// An assignee, when set, must be on the lead's CURRENT roster (MB8a).
+const assertOwnerOnRoster = async (leadId, assigneeId) => {
+  if (!assigneeId) return null;
+  if (!isId(assigneeId)) throw httpError(400, "Invalid owner id");
+  const roster = await LeadTeamMemberRepository.findCurrentByLead(leadId);
+  if (!roster.some((r) => String(r.personId) === String(assigneeId)))
+    throw httpError(400, "The owner must be a current member of the lead's team");
+  return assigneeId;
+};
+
+const createStepTask = async (leadId, stepId, { title, assigneeId, dueAt } = {}, assignerId) => {
+  const step = await assertStepInLead(leadId, stepId);
+  const cleanTitle = String(title || "").trim();
+  if (!cleanTitle) throw httpError(400, "A task needs a title");
+  await assertOwnerOnRoster(leadId, assigneeId);
+  let due = null;
+  if (dueAt) {
+    due = new Date(dueAt);
+    if (Number.isNaN(due.getTime())) throw httpError(400, "Invalid dueAt");
+  }
+
+  const task = await LeadTask.create({
+    leadId,
+    stepId,
+    title: cleanTitle.slice(0, 300),
+    assigneeId: assigneeId || null,
+    assignerId: assignerId || null,
+    dueAt: due,
+    kind: "task",
+  });
+
+  await LeadInternalEventService.record({
+    leadId,
+    type: "step_task_created",
+    actorId: assignerId || null,
+    payload: { taskId: String(task._id), title: cleanTitle, stepId: String(stepId), stepName: step.name, assigneeId: assigneeId ? String(assigneeId) : null },
+  });
+  if (assigneeId) {
+    await AdminNotificationService.notify(assigneeId, {
+      type: "task_assigned",
+      title: `New task: ${cleanTitle}`,
+      message: `On step "${step.name}"`,
+      leadId,
+      payload: { taskId: String(task._id), stepId: String(stepId) },
+    });
+  }
+  return (await decorate([task.toObject()]))[0];
+};
+
+const listForStep = async (stepId) => {
+  if (!isId(stepId)) throw httpError(400, "Invalid stepId");
+  const rows = await LeadTask.find({ stepId }).sort({ status: 1, dueAt: 1, createdAt: 1 }).lean();
+  return decorate(rows);
+};
+
+const editStepTask = async (taskId, { title, assigneeId, dueAt } = {}) => {
+  if (!isId(taskId)) throw httpError(400, "Invalid taskId");
+  const task = await LeadTask.findById(taskId);
+  if (!task || !task.stepId) throw httpError(404, "Step task not found");
+  if (title !== undefined) {
+    const t = String(title).trim();
+    if (!t) throw httpError(400, "Title cannot be empty");
+    task.title = t.slice(0, 300);
+  }
+  if (assigneeId !== undefined) {
+    if (assigneeId) await assertOwnerOnRoster(task.leadId, assigneeId);
+    task.assigneeId = assigneeId || null;
+  }
+  if (dueAt !== undefined) {
+    if (!dueAt) task.dueAt = null;
+    else {
+      const d = new Date(dueAt);
+      if (Number.isNaN(d.getTime())) throw httpError(400, "Invalid dueAt");
+      task.dueAt = d;
+    }
+  }
+  await task.save();
+  return (await decorate([task.toObject()]))[0];
+};
+
+// Toggle open<->done. Step tasks stay quiet in chat; journey event only.
+const toggleStepTask = async (taskId, actorId) => {
+  if (!isId(taskId)) throw httpError(400, "Invalid taskId");
+  const task = await LeadTask.findById(taskId);
+  if (!task || !task.stepId) throw httpError(404, "Step task not found");
+  const toDone = task.status === "open";
+  task.status = toDone ? "done" : "open";
+  task.completedAt = toDone ? new Date() : null;
+  task.completedBy = toDone ? actorId || null : null;
+  await task.save();
+  await LeadInternalEventService.record({
+    leadId: task.leadId,
+    type: toDone ? "step_task_completed" : "step_task_reopened",
+    actorId: actorId || null,
+    payload: { taskId: String(task._id), title: task.title, stepId: String(task.stepId) },
+  });
+  return (await decorate([task.toObject()]))[0];
+};
+
 module.exports = {
   idsByRoleName,
   createTask,
@@ -188,4 +302,8 @@ module.exports = {
   listForLead,
   myTasks,
   escalateOverdue,
+  createStepTask,
+  listForStep,
+  editStepTask,
+  toggleStepTask,
 };


### PR DESCRIPTION
Per-step tasks via additive stepId on the existing MB7b LeadTask (lead-level tasks unchanged); roster-owner enforced; step_task_* journey events; step tasks quiet in chat. Record-call reuses Enquiry.callLog. Enquiry/requirePermission/rbacPermissions/LeadChatMessage untouched; no RBAC vocab change. 15/15 + regressions.