### PR TITLE
MB8c-2a-ii: follow-ups, unified accountability rule (banner + pipeline stuck from one assess()), slash-command endpoints reuse

### DIFF
--- a/controllers/accountability.js
+++ b/controllers/accountability.js
@@ -1,0 +1,43 @@
+const mongoose = require("mongoose");
+const Enquiry = require("../models/Enquiry");
+const AccountabilityService = require("../services/AccountabilityService");
+
+const respond = (res, error) => {
+  const status = error.status || 500;
+  if (status === 500) console.error("[accountability]", error);
+  res.status(status).json({ message: status === 500 ? "Server error" : error.message });
+};
+
+const assertInScope = async (id, scopeFilter = {}) => {
+  if (!mongoose.Types.ObjectId.isValid(id)) throw Object.assign(new Error("Invalid lead id"), { status: 400 });
+  const inScope = await Enquiry.findOne({ $and: [{ _id: id }, scopeFilter || {}] }, { _id: 1 }).lean();
+  if (!inScope) throw Object.assign(new Error("Out of your scope"), { status: 403 });
+};
+
+// GET /enquiry/:_id/accountability — the ONE rule, for the command-center banner.
+// Per-viewer framing is decided client-side from mostUrgent.responsibleId vs me.
+const Assess = async (req, res) => {
+  try {
+    await assertInScope(req.params._id, req.scopeFilter);
+    res.status(200).json(await AccountabilityService.assessLead(req.params._id));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// POST /enquiry/:_id/accountability/nudge — { responsibleId, stepName?, message? }
+const Nudge = async (req, res) => {
+  try {
+    await assertInScope(req.params._id, req.scopeFilter);
+    const r = await AccountabilityService.nudge(
+      req.params._id,
+      { responsibleId: req.body?.responsibleId, stepName: req.body?.stepName, message: req.body?.message },
+      req.auth.user_id
+    );
+    res.status(200).json(r);
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+module.exports = { Assess, Nudge };

--- a/controllers/followup.js
+++ b/controllers/followup.js
@@ -1,0 +1,62 @@
+const mongoose = require("mongoose");
+const Enquiry = require("../models/Enquiry");
+const FollowupService = require("../services/FollowupService");
+
+const respond = (res, error) => {
+  const status = error.status || 500;
+  if (status === 500) console.error("[followup]", error);
+  res.status(status).json({ message: status === 500 ? "Server error" : error.message });
+};
+
+const assertInScope = async (id, scopeFilter = {}) => {
+  if (!mongoose.Types.ObjectId.isValid(id)) throw Object.assign(new Error("Invalid lead id"), { status: 400 });
+  const inScope = await Enquiry.findOne({ $and: [{ _id: id }, scopeFilter || {}] }, { _id: 1 }).lean();
+  if (!inScope) throw Object.assign(new Error("Out of your scope"), { status: 403 });
+};
+
+// GET /enquiry/:_id/followups — list (also sweeps the once-only "due" cards).
+const ListForLead = async (req, res) => {
+  try {
+    await assertInScope(req.params._id, req.scopeFilter);
+    await FollowupService.sweepDueCards(req.params._id);
+    res.status(200).json({ list: await FollowupService.listForLead(req.params._id) });
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// POST /enquiry/:_id/followups — { title, dueAt, ownerId? }
+const Create = async (req, res) => {
+  try {
+    await assertInScope(req.params._id, req.scopeFilter);
+    const f = await FollowupService.create(req.params._id, { title: req.body?.title, dueAt: req.body?.dueAt, ownerId: req.body?.ownerId }, req.auth.user_id);
+    res.status(201).json(f);
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// PATCH /enquiry/:_id/followups/:followupId — { action: "done" | "snooze", until? }
+const Patch = async (req, res) => {
+  try {
+    await assertInScope(req.params._id, req.scopeFilter);
+    const action = req.body?.action;
+    const f = action === "snooze"
+      ? await FollowupService.snooze(req.params.followupId, { until: req.body?.until }, req.auth.user_id)
+      : await FollowupService.complete(req.params.followupId, req.auth.user_id);
+    res.status(200).json(f);
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// GET /enquiry/followups/mine — caller's open follow-ups due soon.
+const Mine = async (req, res) => {
+  try {
+    res.status(200).json({ list: await FollowupService.myDue(req.auth.user_id, { withinDays: Number(req.query.withinDays) || 2 }) });
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+module.exports = { ListForLead, Create, Patch, Mine };

--- a/models/Followup.js
+++ b/models/Followup.js
@@ -1,0 +1,30 @@
+const mongoose = require("mongoose");
+const ObjectId = mongoose.Schema.Types.ObjectId;
+
+// MB8c-2a-ii — a FOLLOW-UP: a scheduled CLIENT touch (someone reaches out to the
+// couple), distinct from a LeadTask (internal work). Follow-ups get chat cards
+// (client-cadence, worth surfacing); tasks stay quiet. status snoozed reverts to
+// open once snoozedUntil passes — normalized at read time in the service.
+const FollowupSchema = new mongoose.Schema(
+  {
+    leadId: { type: ObjectId, ref: "Enquiry", required: true, index: true },
+    title: { type: String, required: true },
+    dueAt: { type: Date, required: true },
+    // Who reaches out — from the lead's roster (MB8a). Optional (can be set later).
+    ownerId: { type: ObjectId, ref: "Admin", default: null, index: true },
+    status: { type: String, enum: ["open", "done", "snoozed"], default: "open", index: true },
+    snoozedUntil: { type: Date, default: null },
+    createdBy: { type: ObjectId, ref: "Admin", default: null },
+    completedAt: { type: Date, default: null },
+    completedBy: { type: ObjectId, ref: "Admin", default: null },
+    // Set once when the "due" chat card is posted, so it surfaces ONCE (not every
+    // poll) — the non-spammy cadence.
+    dueCardPostedAt: { type: Date, default: null },
+  },
+  { timestamps: true }
+);
+
+FollowupSchema.index({ ownerId: 1, status: 1, dueAt: 1 });
+FollowupSchema.index({ leadId: 1, status: 1 });
+
+module.exports = mongoose.models.Followup || mongoose.model("Followup", FollowupSchema);

--- a/models/LeadChatMessage.js
+++ b/models/LeadChatMessage.js
@@ -28,6 +28,9 @@ const LeadChatMessageSchema = new mongoose.Schema(
     // MB8b Slice 3 — set on a mirrored step-note system message; the chat echo
     // links back to the step's notes thread. Additive, default null.
     stepId: { type: ObjectId, ref: "LeadStep", default: null },
+    // MB8c-2a-ii — set on a follow-up event card (set / due); the card's
+    // Mark-done / Snooze actions act on this follow-up. Additive, default null.
+    followupId: { type: ObjectId, ref: "Followup", default: null },
     editedAt: { type: Date, default: null },
   },
   { timestamps: true }

--- a/repositories/FollowupRepository.js
+++ b/repositories/FollowupRepository.js
@@ -1,0 +1,19 @@
+const Followup = require("../models/Followup");
+
+const create = async (fields) => Followup.create(fields);
+const findById = async (id) => Followup.findById(id);
+const findByLead = async (leadId) => Followup.find({ leadId }).sort({ dueAt: 1 }).lean();
+const findByLeadIds = async (leadIds) => Followup.find({ leadId: { $in: leadIds } }).lean();
+
+// Caller's open/snoozed follow-ups due on or before `before`.
+const findMineDue = async (ownerId, before) =>
+  Followup.find({ ownerId, status: { $in: ["open", "snoozed"] }, dueAt: { $lte: before } }).sort({ dueAt: 1 }).lean();
+
+// Newly-due, never-carded follow-ups for a lead (the once-only "due" chat card).
+const findDueUncarded = async (leadId, now) =>
+  Followup.find({ leadId, status: "open", dueAt: { $lte: now }, dueCardPostedAt: null }).lean();
+
+const updateById = async (id, update) =>
+  Followup.findByIdAndUpdate(id, update, { new: true, runValidators: true }).lean();
+
+module.exports = { create, findById, findByLead, findByLeadIds, findMineDue, findDueUncarded, updateById };

--- a/routes/enquiry.js
+++ b/routes/enquiry.js
@@ -105,6 +105,14 @@ router.get(
   requirePermission("leads:view:own", { ownerField: "assignedTo" }),
   journeyDashboard.PipelineOverview
 );
+// MB8c-2a-ii — "my follow-ups due" (literal path, above /:_id).
+const followup = require("../controllers/followup");
+router.get(
+  "/followups/mine",
+  CheckAdminLogin,
+  requirePermission("leads:view:own", { ownerField: "assignedTo" }),
+  followup.Mine
+);
 router.get("/:_id", CheckAdminLogin, requirePermission("leads:view:own", { ownerField: "assignedTo" }), enquiry.Get);
 router.post("/:_id/user", CheckAdminLogin, enquiry.CreateUser);
 router.post("/:_id/conversations", CheckAdminLogin, enquiry.AddConversation);
@@ -281,6 +289,39 @@ router.patch(
   CheckAdminLogin,
   requirePermission("leads:edit:own", { ownerField: "assignedTo" }),
   leadStep.PatchTask
+);
+
+// ── MB8c-2a-ii — client FOLLOW-UPS + the accountability banner/nudge ──────────
+router.get(
+  "/:_id/followups",
+  CheckAdminLogin,
+  requirePermission("leads:view:own", { ownerField: "assignedTo" }),
+  followup.ListForLead
+);
+router.post(
+  "/:_id/followups",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own", { ownerField: "assignedTo" }),
+  followup.Create
+);
+router.patch(
+  "/:_id/followups/:followupId",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own", { ownerField: "assignedTo" }),
+  followup.Patch
+);
+const accountability = require("../controllers/accountability");
+router.get(
+  "/:_id/accountability",
+  CheckAdminLogin,
+  requirePermission("leads:view:own", { ownerField: "assignedTo" }),
+  accountability.Assess
+);
+router.post(
+  "/:_id/accountability/nudge",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own", { ownerField: "assignedTo" }),
+  accountability.Nudge
 );
 
 // ── MB7b Slice 4 — WhatsApp-group one-tap toggle (red-flag → Yes) ─────────────

--- a/scripts/verify-mb8c1.js
+++ b/scripts/verify-mb8c1.js
@@ -49,6 +49,11 @@ const waitFor = async (fn, l, t = 30000) => { const u = Date.now() + t; while (D
   const D1 = await LeadStep.create({ leadId: LeadD._id, name: "Decor Concept Discussion", phase: ph(1), order: 10, ownerIds: [MANAGER._id], status: "in_progress" });
   // D1 has no movement for 10 days (set updatedAt without bumping it).
   await LeadStep.updateOne({ _id: D1._id }, { $set: { updatedAt: new Date(now - 10 * 86400000) } }, { timestamps: false });
+  // MB8c-2a-ii reconcile: the pipeline "stuck" flag now uses the SHARED
+  // accountability rule (stale in_progress step / overdue follow-up / overdue
+  // task) at the shared threshold (3) — overdue STEP DUE-DATE alone no longer
+  // makes a lead stuck. Make LeadA stuck the unified way: A1 stale (no movement).
+  await LeadStep.updateOne({ _id: A1._id }, { $set: { updatedAt: new Date(now - 10 * 86400000) } }, { timestamps: false });
   // Roster: SUB on LeadA + LeadC; OUTSIDER on LeadB; MANAGER on LeadD.
   await LeadTeamMember.create({ leadId: LeadA._id, personId: SUB._id, addedBy: SUB._id });
   await LeadTeamMember.create({ leadId: LeadC._id, personId: SUB._id, addedBy: MANAGER._id });
@@ -101,14 +106,14 @@ const waitFor = async (fn, l, t = 30000) => { const u = Date.now() + t; while (D
     console.log("\n── Slice 2: Pipeline Overview (all scope = REVHEAD) ──");
     const pipe = await api("GET", "/enquiry/pipeline-overview", tok(REVHEAD));
     ok(pipe.status === 200 && Array.isArray(pipe.data.groups), "pipeline returns grouped data");
-    ok(pipe.data.stuckDays === 5, "stuck rule documents N=5 days");
+    ok(pipe.data.stuckDays === 3, "stuck rule uses the shared accountability threshold (3)");
     const flat = pipe.data.groups.flatMap((g) => g.leads);
     const byId = Object.fromEntries(flat.map((l) => [l._id, l]));
     const a = byId[String(LeadA._id)], c = byId[String(LeadC._id)], d = byId[String(LeadD._id)];
     ok(a && a.bucket === ph(0), "LeadA grouped under its current journey phase (Lead Understanding)");
     ok(a && a.progress && a.progress.done === 0 && a.progress.total === 2, "LeadA progress 0/2 in current phase");
-    ok(a && a.stuck && a.stuckReason === "overdue step", "LeadA stuck via overdue step");
-    ok(d && d.stuck && /no movement/.test(d.stuckReason), "LeadD stuck via no-movement rule");
+    ok(a && a.stuck && /no update/.test(a.stuckReason), "LeadA stuck via the stale-step rule (no update)");
+    ok(d && d.stuck && /no update/.test(d.stuckReason), "LeadD stuck via the stale-step rule (no update)");
     ok(c && !c.stuck, "LeadC not stuck");
     ok(a && a.team.some((t) => t._id === String(SUB._id)), "LeadA shows its team (SUB)");
 

--- a/scripts/verify-mb8c2aii.js
+++ b/scripts/verify-mb8c2aii.js
@@ -1,0 +1,149 @@
+/* MB8c-2a-ii — follow-ups + the ONE unified accountability rule + pipeline
+ * reconcile + rate-limited nudge. Verifies the follow-up lifecycle, that the
+ * banner rule fires all three ways, that the threshold setting drives it, that
+ * the pipeline "stuck" flag now agrees with the banner (same rule), and the
+ * nudge rate-limit. Test port 8159. */
+require("dotenv").config();
+const { spawn } = require("child_process");
+const mongoose = require("mongoose");
+const jwt = require("jsonwebtoken");
+
+const PORT = 8159; const BASE = `http://localhost:${PORT}`; const MARK = "MB8C2AII";
+let pass = 0, fail = 0; const failures = [];
+const ok = (c, l) => { if (c) { pass++; console.log(`  ✓ ${l}`); } else { fail++; failures.push(l); console.error(`  ✗ ${l}`); } };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const waitFor = async (fn, l, t = 30000) => { const u = Date.now() + t; while (Date.now() < u) { try { const v = await fn(); if (v) return v; } catch (_) {} await sleep(300); } throw new Error(`waitFor: ${l}`); };
+const DAY = 86400000;
+
+(async () => {
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Admin = require("../models/Admin"); const Role = require("../models/Role"); const Department = require("../models/Department");
+  const Enquiry = require("../models/Enquiry"); const LeadStep = require("../models/LeadStep"); const LeadTask = require("../models/LeadTask");
+  const Followup = require("../models/Followup"); const LeadTeamMember = require("../models/LeadTeamMember");
+  const LeadChatMessage = require("../models/LeadChatMessage"); const LeadInternalEvent = require("../models/LeadInternalEvent");
+  const AdminNotification = require("../models/AdminNotification"); const Setting = require("../models/Setting");
+  const SettingsService = require("../services/SettingsService");
+
+  const dept = await Department.create({ name: `${MARK} Dept` });
+  const role = await Role.create({ name: `${MARK} All`, departmentId: dept._id, permissions: ["*:*:all"] });
+  const u = (s) => `9197${String(Date.now()).slice(-7)}${s}`;
+  const BOSS = await Admin.create({ name: `${MARK} Boss`, email: `boss-${Date.now()}@t.local`, phone: u(1), password: "x", roleIds: [role._id], departmentId: dept._id, status: "active" });
+  const KARAN = await Admin.create({ name: `${MARK} Karan`, email: `karan-${Date.now()}@t.local`, phone: u(2), password: "x", roleIds: [role._id], departmentId: dept._id, status: "active" });
+  const bossT = jwt.sign({ _id: String(BOSS._id), isAdmin: true }, process.env.JWT_SECRET);
+  const karanT = jwt.sign({ _id: String(KARAN._id), isAdmin: true }, process.env.JWT_SECRET);
+
+  // Three leads: F (overdue follow-up), T (overdue task), S (stale step). All
+  // qualified + rostered so the banner/pipeline consider them.
+  const mkLead = async (n) => Enquiry.create({ name: `${MARK} ${n}`, phone: `9190${String(Date.now()).slice(-7)}${n}`, verified: true, source: "Website", stage: "qualified", qualified: true, assignedTo: BOSS._id, additionalInfo: {} });
+  const leadF = await mkLead("F"); const leadT = await mkLead("T"); const leadS = await mkLead("S");
+  for (const l of [leadF, leadT, leadS]) {
+    await LeadTeamMember.create({ leadId: l._id, personId: KARAN._id, addedBy: BOSS._id });
+  }
+  // leadS: a stale in_progress step owned by Karan, not moved for 10 days.
+  const staleStep = await LeadStep.create({ leadId: leadS._id, name: "Decor Concept Discussion", phase: "Client Servicing & Proposal", order: 10, status: "in_progress", ownerIds: [KARAN._id] });
+  await LeadStep.updateOne({ _id: staleStep._id }, { $set: { updatedAt: new Date(Date.now() - 10 * DAY) } }, { timestamps: false });
+  // leadT: an overdue task owned by Karan.
+  await LeadTask.create({ leadId: leadT._id, title: "Send proposal", assigneeId: KARAN._id, assignerId: BOSS._id, dueAt: new Date(Date.now() - 2 * DAY), status: "open", kind: "task" });
+
+  const child = spawn("node", ["server.js"], { cwd: `${__dirname}/..`, env: { ...process.env, PORT: String(PORT) }, stdio: ["ignore", "pipe", "pipe"] });
+  let log = ""; child.stdout.on("data", (d) => (log += d)); child.stderr.on("data", (d) => (log += d));
+  const api = async (m, p, t, b) => { const r = await fetch(`${BASE}${p}`, { method: m, headers: { ...(t ? { Authorization: `Bearer ${t}` } : {}), ...(b ? { "Content-Type": "application/json" } : {}) }, body: b ? JSON.stringify(b) : undefined }); let d = null; try { d = await r.json(); } catch (_) {} return { status: r.status, data: d }; };
+
+  try {
+    await waitFor(() => fetch(`${BASE}/`).then((r) => r.ok).catch(() => false), "boot");
+
+    console.log("\n── Slice 1: follow-up lifecycle ──");
+    const created = await api("POST", `/enquiry/${leadF._id}/followups`, bossT, { title: "Call to discuss decor", dueAt: new Date(Date.now() - 1 * DAY).toISOString(), ownerId: String(KARAN._id) });
+    ok(created.status === 201 && created.data.title === "Call to discuss decor", "create follow-up (owner from roster)");
+    ok(created.data.overdue === true, "open + past dueAt → overdue");
+    const offRoster = await api("POST", `/enquiry/${leadF._id}/followups`, bossT, { title: "x", dueAt: new Date().toISOString(), ownerId: String(BOSS._id) });
+    ok(offRoster.status === 400, "off-roster follow-up owner rejected (Boss not on this roster)");
+    const fid = created.data._id;
+    const snoozed = await api("PATCH", `/enquiry/${leadF._id}/followups/${fid}`, bossT, { action: "snooze", until: new Date(Date.now() + 2 * DAY).toISOString() });
+    ok(snoozed.status === 200 && snoozed.data.status === "snoozed" && !snoozed.data.overdue, "snooze → not overdue while snoozed");
+    const done = await api("PATCH", `/enquiry/${leadF._id}/followups/${fid}`, bossT, { action: "done" });
+    ok(done.status === 200 && done.data.status === "done", "mark done");
+    const journey = (await api("GET", `/enquiry/${leadF._id}/journey`, bossT)).data.entries || [];
+    ok(journey.some((e) => e.type === "followup_created") && journey.some((e) => e.type === "followup_completed"), "journey: followup_created + followup_completed");
+    const mine = await api("GET", `/enquiry/followups/mine`, karanT);
+    ok(mine.status === 200 && Array.isArray(mine.data.list), "my-due follow-ups endpoint works");
+
+    console.log("\n── Slice 3: follow-up chat cards (set on create, due once) ──");
+    // New overdue follow-up on leadT → 'set' card now; GET /followups sweeps a 'due' card once.
+    const f2 = await api("POST", `/enquiry/${leadT._id}/followups`, bossT, { title: "Confirm venue", dueAt: new Date(Date.now() - 1 * DAY).toISOString(), ownerId: String(KARAN._id) });
+    await api("GET", `/enquiry/${leadT._id}/followups`, bossT); // triggers the due sweep
+    await api("GET", `/enquiry/${leadT._id}/followups`, bossT); // second poll must NOT add another due card
+    const chat = (await api("GET", `/enquiry/${leadT._id}/chat`, bossT)).data.messages || [];
+    ok(chat.some((m) => m.systemType === "followup_set" && String(m.followupId) === String(f2.data._id)), "'follow-up set' card posted on create with followupId");
+    ok(chat.filter((m) => m.systemType === "followup_due").length === 1, "'follow-up due' card posted exactly ONCE (non-spammy)");
+    ok(!chat.some((m) => m.systemType === "step_task_created"), "tasks stay quiet in chat (unchanged)");
+
+    console.log("\n── Slice 4: the ONE rule fires all three ways ──");
+    const accF = await api("GET", `/enquiry/${leadT._id}/accountability`, bossT);
+    ok(accF.status === 200 && accF.data.needsAttention && accF.data.mostUrgent.kind === "overdue_followup", "overdue follow-up → needs attention (most urgent)");
+    const accS = await api("GET", `/enquiry/${leadS._id}/accountability`, bossT);
+    ok(accS.data.needsAttention && accS.data.mostUrgent.kind === "stale_step", "stale step → needs attention");
+    ok(accS.data.mostUrgent.responsibleId === String(KARAN._id), "stale step responsible = the step owner (Karan)");
+    ok(accS.data.thresholdDays === 3, "threshold defaults to 3 days");
+    // A fresh lead with nothing pending → no attention.
+    const calm = await mkLead("Calm");
+    const accCalm = await api("GET", `/enquiry/${calm._id}/accountability`, bossT);
+    ok(accCalm.status === 200 && accCalm.data.needsAttention === false, "calm lead → no banner");
+
+    console.log("\n── Slice 4: threshold setting drives the rule ──");
+    // Raise the threshold above the staleness → the stale step no longer fires.
+    await api("PUT", `/settings`, bossT, { key: "accountability.staleDays", value: 20 });
+    const accS20 = await api("GET", `/enquiry/${leadS._id}/accountability`, bossT);
+    ok(accS20.data.needsAttention === false && accS20.data.thresholdDays === 20, "threshold=20 → 10-day-stale step no longer needs attention");
+    await api("PUT", `/settings`, bossT, { key: "accountability.staleDays", value: 3 }); // restore
+
+    console.log("\n── THE RECONCILE: pipeline stuck == the same rule ──");
+    const pipe = await api("GET", `/enquiry/pipeline-overview`, bossT);
+    ok(pipe.status === 200 && pipe.data.stuckDays === 3, "pipeline uses the shared threshold (3)");
+    const flat = pipe.data.groups.flatMap((g) => g.leads);
+    const byId = Object.fromEntries(flat.map((l) => [l._id, l]));
+    ok(byId[String(leadS._id)] && byId[String(leadS._id)].stuck === true, "pipeline marks the stale-step lead STUCK (agrees with banner)");
+    ok(byId[String(leadT._id)] && byId[String(leadT._id)].stuck === true, "pipeline marks the overdue-followup/task lead STUCK");
+    ok(byId[String(calm._id)] && byId[String(calm._id)].stuck === false, "pipeline does NOT mark the calm lead stuck (agrees with banner)");
+
+    console.log("\n── Slice 4: nudge + rate-limit ──");
+    const n1 = await api("POST", `/enquiry/${leadS._id}/accountability/nudge`, bossT, { responsibleId: String(KARAN._id), stepName: "Decor Concept Discussion" });
+    ok(n1.status === 200 && n1.data.ok, "nudge sent");
+    const note = await waitFor(async () => (await AdminNotification.findOne({ adminId: KARAN._id, type: "accountability_nudge" }).lean()) || false, "nudge notification");
+    ok(!!note, "nudge pings the responsible person via AdminNotificationService");
+    const n2 = await api("POST", `/enquiry/${leadS._id}/accountability/nudge`, bossT, { responsibleId: String(KARAN._id) });
+    ok(n2.status === 429, "second nudge within the cooldown is rate-limited (429)");
+
+    console.log("\n── Slash convenience entry points hit the SAME services ──");
+    // (Slash is a frontend affordance; here we prove the underlying endpoints a
+    // slash form calls are the existing ones.)
+    const stepForTask = await LeadStep.create({ leadId: leadS._id, name: "Proposal Shared", phase: "Client Servicing & Proposal", order: 20, status: "not_started" });
+    const slashTask = await api("POST", `/enquiry/${leadS._id}/steps/${stepForTask._id}/tasks`, bossT, { title: "/task created", assigneeId: String(KARAN._id) });
+    ok(slashTask.status === 201 && String(slashTask.data.stepId) === String(stepForTask._id), "/task → existing createStepTask endpoint");
+    const slashStatus = await api("PATCH", `/enquiry/${leadS._id}/steps/${stepForTask._id}`, bossT, { status: "in_progress" });
+    ok(slashStatus.status === 200 && slashStatus.data.status === "in_progress", "/status → existing step status endpoint (the 4)");
+  } catch (e) {
+    fail++; failures.push(`fatal: ${e.message}`); console.error("FATAL", e); console.error(log.slice(-2000));
+  } finally {
+    const leadIds = [leadF._id, leadT._id, leadS._id];
+    const calm = await Enquiry.findOne({ name: `${MARK} Calm` }).lean();
+    if (calm) leadIds.push(calm._id);
+    await Followup.deleteMany({ leadId: { $in: leadIds } });
+    await LeadTask.deleteMany({ leadId: { $in: leadIds } });
+    await LeadStep.deleteMany({ leadId: { $in: leadIds } });
+    await LeadTeamMember.deleteMany({ leadId: { $in: leadIds } });
+    await LeadChatMessage.deleteMany({ leadId: { $in: leadIds } });
+    await LeadInternalEvent.deleteMany({ leadId: { $in: leadIds } });
+    await AdminNotification.deleteMany({ adminId: { $in: [BOSS._id, KARAN._id] } });
+    await Enquiry.deleteMany({ _id: { $in: leadIds } });
+    await Setting.deleteMany({ key: "accountability.staleDays" });
+    await Admin.deleteMany({ _id: { $in: [BOSS._id, KARAN._id] } });
+    await Role.deleteMany({ _id: role._id });
+    await Department.deleteMany({ _id: dept._id });
+    SettingsService.invalidate();
+    child.kill(); await mongoose.disconnect();
+    console.log(`\n══ RESULT: ${pass} passed, ${fail} failed ══`);
+    if (failures.length) console.log("failures:", failures.join(" | "));
+    process.exit(fail === 0 ? 0 : 1);
+  }
+})();

--- a/services/AccountabilityService.js
+++ b/services/AccountabilityService.js
@@ -1,0 +1,165 @@
+const mongoose = require("mongoose");
+const Admin = require("../models/Admin");
+const Enquiry = require("../models/Enquiry");
+const LeadStepRepository = require("../repositories/LeadStepRepository");
+const FollowupRepository = require("../repositories/FollowupRepository");
+const LeadTask = require("../models/LeadTask");
+const SettingsService = require("./SettingsService");
+const AdminNotificationService = require("./AdminNotificationService");
+const LeadChatService = require("./LeadChatService");
+const { effective: followupEffective } = require("./FollowupService");
+
+const err = (status, message) => Object.assign(new Error(message), { status });
+const isId = (v) => mongoose.Types.ObjectId.isValid(v);
+const DAY = 24 * 60 * 60 * 1000;
+const idStr = (v) => String(v);
+
+// The shared threshold (days). Single source — settings, default 3.
+const thresholdDays = async () => Number(await SettingsService.get("accountability.staleDays")) || 3;
+
+// ── THE ONE RULE ─────────────────────────────────────────────────────────────
+// A lead NEEDS ATTENTION if any of:
+//   • a step is in_progress (or assigned & not_started) with NO movement
+//     (status change / note / task activity) in `thresholdDays` days;
+//   • it has an OVERDUE follow-up (open + dueAt past);
+//   • it has an OVERDUE task (open + dueAt past).
+// Pure + batchable: callers pass the already-loaded data so the pipeline can
+// assess many leads without N+1. Returns { needsAttention, items, mostUrgent }.
+const assess = (steps, tasks, followups, now, thresholdMs, assignedTo) => {
+  const items = [];
+
+  // Last task-activity per step (task create/toggle bumps the task's updatedAt).
+  const taskActivityByStep = new Map();
+  for (const t of tasks) {
+    if (!t.stepId) continue;
+    const k = idStr(t.stepId);
+    const ts = +new Date(t.updatedAt || 0);
+    if (ts > (taskActivityByStep.get(k) || 0)) taskActivityByStep.set(k, ts);
+  }
+
+  for (const s of steps) {
+    const assigned = (s.ownerIds || []).length > 0;
+    const active = s.status === "in_progress" || (s.status === "not_started" && assigned);
+    if (!active || s.notApplicable) continue;
+    const lastActivity = Math.max(+new Date(s.updatedAt || 0), taskActivityByStep.get(idStr(s._id)) || 0);
+    if (lastActivity && lastActivity < +now - thresholdMs) {
+      items.push({
+        kind: "stale_step",
+        stepId: idStr(s._id),
+        stepName: s.name,
+        responsibleId: s.ownerIds && s.ownerIds[0] ? idStr(s.ownerIds[0]) : assignedTo ? idStr(assignedTo) : null,
+        magnitude: Math.floor((+now - lastActivity) / DAY), // days stale
+      });
+    }
+  }
+
+  for (const t of tasks) {
+    if (t.status === "open" && t.dueAt && new Date(t.dueAt) < now) {
+      items.push({
+        kind: "overdue_task",
+        taskId: idStr(t._id),
+        stepId: t.stepId ? idStr(t.stepId) : null,
+        title: t.title,
+        responsibleId: t.assigneeId ? idStr(t.assigneeId) : assignedTo ? idStr(assignedTo) : null,
+        magnitude: Math.floor((+now - +new Date(t.dueAt)) / DAY),
+      });
+    }
+  }
+
+  for (const f of followups) {
+    const e = followupEffective(f, now);
+    if (e.open && e.overdue) {
+      items.push({
+        kind: "overdue_followup",
+        followupId: idStr(f._id),
+        title: f.title,
+        responsibleId: f.ownerId ? idStr(f.ownerId) : assignedTo ? idStr(assignedTo) : null,
+        magnitude: Math.floor((+now - +new Date(f.dueAt)) / DAY),
+      });
+    }
+  }
+
+  // Priority: a client-facing overdue follow-up outranks an overdue task, which
+  // outranks a stale step; within a kind, the more overdue/stale wins.
+  const PRIORITY = { overdue_followup: 0, overdue_task: 1, stale_step: 2 };
+  items.sort((a, b) => (PRIORITY[a.kind] - PRIORITY[b.kind]) || (b.magnitude - a.magnitude));
+
+  return { needsAttention: items.length > 0, items, mostUrgent: items[0] || null };
+};
+
+// Single-lead assessment for the command-center banner (resolves names + the
+// per-viewer framing string).
+const assessLead = async (leadId, now = new Date()) => {
+  if (!isId(leadId)) throw err(400, "Invalid leadId");
+  const lead = await Enquiry.findById(leadId, { assignedTo: 1 }).lean();
+  if (!lead) throw err(404, "Lead not found");
+  const [steps, tasks, followups, days] = await Promise.all([
+    LeadStepRepository.findByLead(leadId),
+    LeadTask.find({ leadId }).lean(),
+    FollowupRepository.findByLead(leadId),
+    thresholdDays(),
+  ]);
+  const a = assess(steps, tasks, followups, now, days * DAY, lead.assignedTo);
+  if (!a.needsAttention) return { needsAttention: false, thresholdDays: days, mostUrgent: null, moreCount: 0 };
+
+  // Resolve responsible names for the surfaced items.
+  const respIds = [...new Set(a.items.map((i) => i.responsibleId).filter(Boolean))];
+  const admins = respIds.length ? await Admin.find({ _id: { $in: respIds } }, { name: 1 }).lean() : [];
+  const nameOf = new Map(admins.map((x) => [idStr(x._id), x.name]));
+  const top = a.items[0];
+  const label = (() => {
+    if (top.kind === "overdue_followup") return `Overdue follow-up · ${top.title}`;
+    if (top.kind === "overdue_task") return `Overdue task · ${top.title}`;
+    return `${top.stepName} · no update in ${top.magnitude || days} day${(top.magnitude || days) === 1 ? "" : "s"}`;
+  })();
+  return {
+    needsAttention: true,
+    thresholdDays: days,
+    moreCount: Math.max(0, a.items.length - 1),
+    mostUrgent: {
+      ...top,
+      responsibleName: top.responsibleId ? nameOf.get(top.responsibleId) || "—" : null,
+      label,
+    },
+  };
+};
+
+// ── Rate-limited nudge ───────────────────────────────────────────────────────
+// In-memory per (leadId, responsibleId) cooldown — prevents spam-nudging.
+const NUDGE_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
+const lastNudge = new Map();
+const nudgeKey = (leadId, responsibleId) => `${leadId}:${responsibleId}`;
+
+const nudge = async (leadId, { responsibleId, stepName, message } = {}, actorId) => {
+  if (!isId(leadId)) throw err(400, "Invalid leadId");
+  if (!isId(responsibleId)) throw err(400, "A responsible person is required");
+  const key = nudgeKey(leadId, responsibleId);
+  const prev = lastNudge.get(key);
+  if (prev && Date.now() - prev < NUDGE_COOLDOWN_MS) {
+    const mins = Math.ceil((NUDGE_COOLDOWN_MS - (Date.now() - prev)) / 60000);
+    throw err(429, `Already nudged — try again in ${mins} min`);
+  }
+
+  const lead = await Enquiry.findById(leadId, { name: 1 }).lean();
+  const actor = actorId ? await Admin.findById(actorId, { name: 1 }).lean() : null;
+  const niceMsg = String(message || "").trim() || (stepName ? `Could you post an update on "${stepName}"?` : "Could you post an update?");
+
+  await AdminNotificationService.notify(responsibleId, {
+    type: "accountability_nudge",
+    title: `${actor ? actor.name : "A teammate"} is waiting on an update`,
+    message: `${lead ? lead.name : "A lead"} — ${niceMsg}`,
+    leadId,
+    payload: { from: actorId ? idStr(actorId) : null },
+  });
+  // A gentle chat system line (constructive tone).
+  await LeadChatService.postSystemMessage(leadId, {
+    body: `Nudge sent — ${niceMsg}`,
+    systemType: "accountability_nudge",
+    mentions: [responsibleId],
+  });
+
+  lastNudge.set(key, Date.now());
+  return { ok: true, nudged: idStr(responsibleId) };
+};
+
+module.exports = { thresholdDays, assess, assessLead, nudge, NUDGE_COOLDOWN_MS, _lastNudge: lastNudge, DAY };

--- a/services/FollowupService.js
+++ b/services/FollowupService.js
@@ -1,0 +1,138 @@
+const mongoose = require("mongoose");
+const Admin = require("../models/Admin");
+const Enquiry = require("../models/Enquiry");
+const FollowupRepository = require("../repositories/FollowupRepository");
+const LeadTeamMemberRepository = require("../repositories/LeadTeamMemberRepository");
+const LeadInternalEventService = require("./LeadInternalEventService");
+const LeadChatService = require("./LeadChatService");
+const AdminNotificationService = require("./AdminNotificationService");
+
+const err = (status, message) => Object.assign(new Error(message), { status });
+const isId = (v) => mongoose.Types.ObjectId.isValid(v);
+
+const nameOf = async (id) => (id ? (await Admin.findById(id, { name: 1 }).lean())?.name || "—" : null);
+
+// A snoozed follow-up whose snoozedUntil has passed is effectively OPEN again.
+// Normalize the effective status/overdue at read time (no background job needed).
+const effective = (f, now = new Date()) => {
+  let status = f.status;
+  if (status === "snoozed" && f.snoozedUntil && new Date(f.snoozedUntil) <= now) status = "open";
+  const isOpen = status === "open";
+  const overdue = isOpen && !!f.dueAt && new Date(f.dueAt) < now;
+  return { ...f, effectiveStatus: status, open: isOpen, overdue };
+};
+
+const decorate = async (rows) => {
+  const now = new Date();
+  const ids = [...new Set(rows.flatMap((r) => [r.ownerId, r.createdBy]).filter(Boolean).map(String))];
+  const admins = ids.length ? await Admin.find({ _id: { $in: ids } }, { name: 1 }).lean() : [];
+  const n = new Map(admins.map((a) => [String(a._id), a.name]));
+  return rows.map((r) => {
+    const e = effective(r, now);
+    return {
+      _id: String(r._id), leadId: String(r.leadId), title: r.title, dueAt: r.dueAt,
+      ownerId: r.ownerId ? String(r.ownerId) : null, ownerName: r.ownerId ? n.get(String(r.ownerId)) || "—" : null,
+      status: e.effectiveStatus, snoozedUntil: r.snoozedUntil || null,
+      open: e.open, overdue: e.overdue, completedAt: r.completedAt || null,
+      createdAt: r.createdAt,
+    };
+  });
+};
+
+const assertOwnerOnRoster = async (leadId, ownerId) => {
+  if (!ownerId) return null;
+  if (!isId(ownerId)) throw err(400, "Invalid owner id");
+  const roster = await LeadTeamMemberRepository.findCurrentByLead(leadId);
+  if (!roster.some((r) => String(r.personId) === String(ownerId)))
+    throw err(400, "The follow-up owner must be a current member of the lead's team");
+  return ownerId;
+};
+
+const create = async (leadId, { title, dueAt, ownerId } = {}, createdBy) => {
+  if (!isId(leadId)) throw err(400, "Invalid leadId");
+  const cleanTitle = String(title || "").trim();
+  if (!cleanTitle) throw err(400, "A follow-up needs a title");
+  const due = new Date(dueAt);
+  if (Number.isNaN(due.getTime())) throw err(400, "A valid dueAt is required");
+  await assertOwnerOnRoster(leadId, ownerId);
+
+  const f = await FollowupRepository.create({
+    leadId, title: cleanTitle.slice(0, 300), dueAt: due, ownerId: ownerId || null, createdBy: createdBy || null,
+  });
+
+  const ownerName = await nameOf(ownerId);
+  // One card on create (the non-spammy cadence: set now, due-card later/once).
+  await LeadChatService.postSystemMessage(leadId, {
+    body: `Follow-up set: ${cleanTitle} — ${due.toDateString()}${ownerName ? ` · ${ownerName}` : ""}`,
+    systemType: "followup_set",
+    followupId: f._id,
+  });
+  await LeadInternalEventService.record({
+    leadId, type: "followup_created", actorId: createdBy || null,
+    payload: { followupId: String(f._id), title: cleanTitle, dueAt: due, ownerId: ownerId ? String(ownerId) : null, ownerName },
+  });
+  if (ownerId) {
+    await AdminNotificationService.notify(ownerId, {
+      type: "followup_assigned", title: `Follow-up: ${cleanTitle}`, message: `Due ${due.toDateString()}`,
+      leadId, payload: { followupId: String(f._id) },
+    });
+  }
+  return (await decorate([f.toObject()]))[0];
+};
+
+const complete = async (followupId, actorId) => {
+  if (!isId(followupId)) throw err(400, "Invalid followupId");
+  const f = await FollowupRepository.findById(followupId);
+  if (!f || f.status === "done") throw err(404, "Open follow-up not found");
+  f.status = "done"; f.completedAt = new Date(); f.completedBy = actorId || null;
+  await f.save();
+  await LeadChatService.postSystemMessage(f.leadId, { body: `Follow-up done: ${f.title}`, systemType: "followup_done", followupId: f._id });
+  await LeadInternalEventService.record({
+    leadId: f.leadId, type: "followup_completed", actorId: actorId || null,
+    payload: { followupId: String(f._id), title: f.title },
+  });
+  return (await decorate([f.toObject()]))[0];
+};
+
+const snooze = async (followupId, { until } = {}, actorId) => {
+  if (!isId(followupId)) throw err(400, "Invalid followupId");
+  const f = await FollowupRepository.findById(followupId);
+  if (!f || f.status === "done") throw err(404, "Open follow-up not found");
+  // Default snooze: +1 day from now (or an explicit `until`).
+  const u = until ? new Date(until) : new Date(Date.now() + 24 * 60 * 60 * 1000);
+  if (Number.isNaN(u.getTime())) throw err(400, "Invalid snooze date");
+  f.status = "snoozed"; f.snoozedUntil = u;
+  f.dueCardPostedAt = null; // it can surface a fresh due card when it re-opens
+  await f.save();
+  return (await decorate([f.toObject()]))[0];
+};
+
+const listForLead = async (leadId) => {
+  if (!isId(leadId)) throw err(400, "Invalid leadId");
+  return decorate(await FollowupRepository.findByLead(leadId));
+};
+
+const myDue = async (ownerId, { withinDays = 2 } = {}) => {
+  if (!isId(ownerId)) throw err(400, "Invalid ownerId");
+  const before = new Date(Date.now() + withinDays * 24 * 60 * 60 * 1000);
+  return decorate(await FollowupRepository.findMineDue(ownerId, before));
+};
+
+// Post the once-only "due" chat card for newly-due follow-ups on a lead. Called
+// lazily when the chat / follow-ups are read — stamped so it never repeats.
+const sweepDueCards = async (leadId) => {
+  if (!isId(leadId)) return;
+  const now = new Date();
+  const due = await FollowupRepository.findDueUncarded(leadId, now);
+  for (const f of due) {
+    const ownerName = await nameOf(f.ownerId);
+    await LeadChatService.postSystemMessage(leadId, {
+      body: `Follow-up due: ${f.title}${ownerName ? ` · ${ownerName}` : ""}`,
+      systemType: "followup_due",
+      followupId: f._id,
+    });
+    await FollowupRepository.updateById(f._id, { dueCardPostedAt: now });
+  }
+};
+
+module.exports = { create, complete, snooze, listForLead, myDue, sweepDueCards, decorate, effective };

--- a/services/JourneyDashboardService.js
+++ b/services/JourneyDashboardService.js
@@ -4,14 +4,16 @@ const Enquiry = require("../models/Enquiry");
 const { PHASES } = require("../models/StepDefinition");
 const LeadStepRepository = require("../repositories/LeadStepRepository");
 const LeadTeamMemberRepository = require("../repositories/LeadTeamMemberRepository");
+const FollowupRepository = require("../repositories/FollowupRepository");
+const LeadTask = require("../models/LeadTask");
+const AccountabilityService = require("./AccountabilityService");
 const { getSubordinateIds, getDepartmentMemberIds } = require("../middlewares/requirePermission");
 
 const DAY = 24 * 60 * 60 * 1000;
 const WEEK = 7 * DAY;
-// STUCK rule (documented): a journey lead is "stuck" if it has any overdue step
-// (a non-complete, non-N/A step whose dueAt is in the past) OR no step movement
-// in STUCK_DAYS days (its most-recently-updated step is older than that).
-const STUCK_DAYS = 5;
+// MB8c-2a-ii RECONCILE: the pipeline "stuck" flag now derives from the SINGLE
+// shared accountability rule + threshold (AccountabilityService) — the same rule
+// the command-center banner and chat follow-up cards use. They never disagree.
 
 const idStr = (v) => String(v);
 
@@ -138,16 +140,34 @@ const pipelineOverview = async (adminId, scope, { phase, stuckOnly, memberId } =
   }
 
   const leadIds = leads.map((l) => l._id);
-  const [allSteps, rosterRows] = await Promise.all([
+  // Batch everything the SHARED accountability rule needs (steps + tasks +
+  // follow-ups) so many leads are assessed without N+1.
+  const [allSteps, rosterRows, allTasks, allFollowups, staleDays] = await Promise.all([
     LeadStepRepository.findByLeadIds(leadIds),
     LeadTeamMemberRepository.findCurrentByLeadIds(leadIds),
+    LeadTask.find({ leadId: { $in: leadIds } }).lean(),
+    FollowupRepository.findByLeadIds(leadIds),
+    AccountabilityService.thresholdDays(),
   ]);
+  const thresholdMs = staleDays * DAY;
 
   const stepsByLead = new Map();
   for (const s of allSteps) {
     const k = idStr(s.leadId);
     if (!stepsByLead.has(k)) stepsByLead.set(k, []);
     stepsByLead.get(k).push(s);
+  }
+  const tasksByLead = new Map();
+  for (const t of allTasks) {
+    const k = idStr(t.leadId);
+    if (!tasksByLead.has(k)) tasksByLead.set(k, []);
+    tasksByLead.get(k).push(t);
+  }
+  const followupsByLead = new Map();
+  for (const f of allFollowups) {
+    const k = idStr(f.leadId);
+    if (!followupsByLead.has(k)) followupsByLead.set(k, []);
+    followupsByLead.get(k).push(f);
   }
   const teamByLead = new Map();
   for (const r of rosterRows) {
@@ -176,10 +196,22 @@ const pipelineOverview = async (adminId, scope, { phase, stuckOnly, memberId } =
       progress = { done: steps.length, total: steps.length, phase: "Completed" };
     }
 
-    const overdue = steps.some((s) => isOverdueStep(s, now));
-    const lastMove = steps.reduce((mx, s) => Math.max(mx, +new Date(s.updatedAt || 0)), 0);
-    const noMovement = steps.length > 0 && lastMove > 0 && lastMove < +now - STUCK_DAYS * DAY;
-    const stuck = steps.length > 0 && (overdue || noMovement);
+    // STUCK = the SHARED accountability rule (stale step OR overdue follow-up OR
+    // overdue task), at the SHARED threshold. Identical to the banner's rule.
+    const a = AccountabilityService.assess(
+      steps,
+      tasksByLead.get(idStr(l._id)) || [],
+      followupsByLead.get(idStr(l._id)) || [],
+      now,
+      thresholdMs,
+      l.assignedTo
+    );
+    const reasonFor = (mu) => {
+      if (!mu) return null;
+      if (mu.kind === "overdue_followup") return "overdue follow-up";
+      if (mu.kind === "overdue_task") return "overdue task";
+      return `no update in ${mu.magnitude || staleDays}d`;
+    };
 
     const team = (teamByLead.get(idStr(l._id)) || []).map((pid) => ({ _id: pid, name: nameOf.get(pid) || "—" }));
     return {
@@ -191,8 +223,8 @@ const pipelineOverview = async (adminId, scope, { phase, stuckOnly, memberId } =
       hasJourney: steps.length > 0,
       progress,
       team,
-      stuck,
-      stuckReason: stuck ? (overdue ? "overdue step" : `no movement in ${STUCK_DAYS}d`) : null,
+      stuck: a.needsAttention,
+      stuckReason: reasonFor(a.mostUrgent),
     };
   });
 
@@ -219,7 +251,7 @@ const pipelineOverview = async (adminId, scope, { phase, stuckOnly, memberId } =
     stuck: rows.filter((r) => r.stuck).length,
     byPhase: groups.map((g) => ({ phase: g.bucket, count: g.count })),
   };
-  return { groups, summary, scope, stuckDays: STUCK_DAYS };
+  return { groups, summary, scope, stuckDays: staleDays };
 };
 
-module.exports = { myWork, pipelineOverview, STUCK_DAYS };
+module.exports = { myWork, pipelineOverview };

--- a/services/JourneyService.js
+++ b/services/JourneyService.js
@@ -76,6 +76,9 @@ const EVENT_TITLES = {
   step_task_created: "Task added",
   step_task_completed: "Task done ✓",
   step_task_reopened: "Task reopened",
+  // MB8c-2a-ii — client follow-ups.
+  followup_created: "Follow-up set",
+  followup_completed: "Follow-up done ✓",
 };
 
 const STEP_STATUS_LABEL = {
@@ -147,6 +150,11 @@ const dynamicTitle = (type, payload = {}, nameOf) => {
       return `Task done: "${payload.title || "task"}" ✓`;
     case "step_task_reopened":
       return `Task reopened: "${payload.title || "task"}"`;
+    // MB8c-2a-ii — name the follow-up + its owner (the person who reaches out).
+    case "followup_created":
+      return `Follow-up set: "${payload.title || "touch"}"${payload.ownerName ? ` · ${payload.ownerName}` : ""}`;
+    case "followup_completed":
+      return `Follow-up done: "${payload.title || "touch"}" ✓`;
     default:
       return null;
   }

--- a/services/LeadChatService.js
+++ b/services/LeadChatService.js
@@ -118,7 +118,7 @@ const postMessage = async (leadId, authorId, { body, attachments, mentions } = {
 // even though the message itself is authored by the system.
 const postSystemMessage = async (
   leadId,
-  { body, systemType = "", taskId = null, stepId = null, mentions = [] } = {}
+  { body, systemType = "", taskId = null, stepId = null, followupId = null, mentions = [] } = {}
 ) => {
   if (!isId(leadId)) return null;
   const ments = Array.isArray(mentions) ? mentions.filter((m) => isId(m)).map(String) : [];
@@ -130,6 +130,7 @@ const postSystemMessage = async (
     body: String(body || "").slice(0, MAX_BODY),
     taskId: taskId && isId(taskId) ? taskId : null,
     stepId: stepId && isId(stepId) ? stepId : null,
+    followupId: followupId && isId(followupId) ? followupId : null,
     mentions: ments,
   });
   return msg;

--- a/services/SettingsService.js
+++ b/services/SettingsService.js
@@ -92,6 +92,11 @@ const DEFAULTS = {
   // WhatsApp group). Founder-editable; the rolling nurture task reschedules to
   // now + this many days on every completed touch or couple inbound.
   "nurture.cadenceDays": 2,
+  // MB8c-2a-ii — the ONE accountability threshold. A step in_progress (or
+  // assigned & not_started) with no movement in this many days needs attention.
+  // The command-center banner, the chat follow-up cards, and the Pipeline
+  // "stuck" flag ALL derive from this single value (default 3 days).
+  "accountability.staleDays": 3,
 };
 
 // key → settings permission category. Every write is gated by ITS category.
@@ -131,6 +136,8 @@ const KEY_CATEGORY = {
   "agreement.terms": "settings_agreement",
   "agreement.version": "settings_agreement",
   "nurture.cadenceDays": "settings_nurture",
+  // Accountability threshold rides the SLA settings category.
+  "accountability.staleDays": "settings_sla",
 };
 
 const err = (status, message) => Object.assign(new Error(message), { status });
@@ -179,6 +186,9 @@ const validateValue = (key, value) => {
       return value;
     case "nurture.cadenceDays":
       if (!isIntInRange(value, 1, 30)) throw err(400, "nurture.cadenceDays must be an integer 1–30");
+      return value;
+    case "accountability.staleDays":
+      if (!isIntInRange(value, 1, 30)) throw err(400, "accountability.staleDays must be an integer 1–30");
       return value;
     case "assignment.autoAssignEnabled":
     case "lost.approvalRequired":


### PR DESCRIPTION
New Followup model (client touch, roster-owned, snooze). Slash commands call existing services (no forked logic). LeadChatMessage gains nullable followupId (additive). ONE AccountabilityService.assess() drives both the lead banner and the pipeline stuck flag (reconciled from N=5 to shared settings_sla.staleDays default 3). Nudge via AdminNotificationService (unmodified), rate-limited. Enquiry/requirePermission/rbacPermissions/AdminNotificationService untouched. 25/25 + regressions incl. reconciled dashboards 29/29.