### PR TITLE
MB9a (1-3): two-window lifecycle — qualify hinge (one transition, button+cockpit converge), phase-gated chat, journey born only at qualify

### DIFF
--- a/controllers/enquiry-lifecycle.js
+++ b/controllers/enquiry-lifecycle.js
@@ -43,6 +43,24 @@ const CompleteFollowUp = async (req, res) => {
   }
 };
 
+// POST /enquiry/:_id/qualify — the explicit qualify hinge (assignee OR manager).
+// Scope-checked against the caller's leads:edit scope; converges on the SAME
+// LeadLifecycleService.qualifyLead transition as the cockpit qualified path.
+const Qualify = async (req, res) => {
+  try {
+    const Enquiry = require("../models/Enquiry");
+    const mongoose = require("mongoose");
+    const id = req.params._id;
+    if (!mongoose.Types.ObjectId.isValid(id)) return res.status(400).json({ message: "Invalid lead id" });
+    const inScope = await Enquiry.findOne({ $and: [{ _id: id }, req.scopeFilter || {}] }, { _id: 1 }).lean();
+    if (!inScope) return res.status(403).json({ message: "Out of your scope" });
+    const result = await LeadLifecycleService.qualifyLead(id, req.auth.user_id);
+    res.status(200).json(result);
+  } catch (error) {
+    respondError(res, error);
+  }
+};
+
 // POST /enquiry/:_id/recycle
 const Recycle = async (req, res) => {
   try {
@@ -136,4 +154,4 @@ const BulkTransfer = async (req, res) => {
   }
 };
 
-module.exports = { Dashboard, CompleteFollowUp, Recycle, Convert, Journey, SetCustomFields, SetTags, BulkTransfer, AddNote };
+module.exports = { Dashboard, CompleteFollowUp, Recycle, Convert, Journey, SetCustomFields, SetTags, BulkTransfer, AddNote, Qualify };

--- a/controllers/leadChat.js
+++ b/controllers/leadChat.js
@@ -60,11 +60,12 @@ const Remove = async (req, res) => {
   }
 };
 
-// GET /enquiry/:_id/chat/members — @mention candidates (scope-aware)
+// GET /enquiry/:_id/chat/members — PHASE-GATED chat participants (MB9a Slice 2):
+// pre-qual → assignee + their reporting manager; post-qual → the roster.
 const Members = async (req, res) => {
   try {
     await assertInScope(req.params._id, req.scopeFilter);
-    res.status(200).json({ list: await LeadChatService.mentionCandidates() });
+    res.status(200).json({ list: await LeadChatService.chatMembers(req.params._id) });
   } catch (error) {
     respond(res, error);
   }

--- a/routes/enquiry.js
+++ b/routes/enquiry.js
@@ -376,6 +376,13 @@ router.put(
   requirePermission("leads:edit:own"),
   lifecycle.CompleteFollowUp
 );
+// MB9a — the explicit Qualify hinge (assignee OR their manager; scope-checked).
+router.post(
+  "/:_id/qualify",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own", { ownerField: "assignedTo" }),
+  lifecycle.Qualify
+);
 router.post(
   "/:_id/recycle",
   CheckAdminLogin,

--- a/scripts/browser-e2e-fixtures.js
+++ b/scripts/browser-e2e-fixtures.js
@@ -17,6 +17,9 @@ const ADMIN_PHONE = "919180000002";
 // MB8c-2a-i — a dedicated QUALIFIED lead (with roster + journey steps + brief
 // facts) so the command-center e2e never has to mutate the pristine LEAD_PHONE.
 const QUALIFIED_LEAD_PHONE = "919180000004";
+// MB9a — a dedicated PRE-QUAL intake lead the lifecycle e2e can qualify without
+// touching the shared LEAD_PHONE fixture.
+const INTAKE_LEAD_PHONE = "919180000005";
 
 (async () => {
   const cmd = process.argv[2];
@@ -52,7 +55,8 @@ const QUALIFIED_LEAD_PHONE = "919180000004";
   const teardown = async () => {
     await cleanLeadArtifacts(LEAD_PHONE);
     await cleanLeadArtifacts(QUALIFIED_LEAD_PHONE);
-    await Enquiry.deleteMany({ phone: { $in: [LEAD_PHONE, QUALIFIED_LEAD_PHONE] } });
+    await cleanLeadArtifacts(INTAKE_LEAD_PHONE);
+    await Enquiry.deleteMany({ phone: { $in: [LEAD_PHONE, QUALIFIED_LEAD_PHONE, INTAKE_LEAD_PHONE] } });
     await WAConversation.deleteMany({ phone: LEAD_PHONE });
     await WAAgentMessage.deleteMany({ phone: LEAD_PHONE });
     await Admin.deleteMany({ phone: ADMIN_PHONE });
@@ -133,8 +137,20 @@ const QUALIFIED_LEAD_PHONE = "919180000004";
   await StepDefinitionService.seed();
   await LeadStepService.instantiateForLead(qLead._id, admin._id);
 
+  // ── MB9a — a PRE-QUAL intake lead (assigned to the founder, no journey/roster)
+  // the lifecycle e2e can qualify.
+  const intakeLead = await Enquiry.create({
+    name: "Ishaan Rao",
+    phone: INTAKE_LEAD_PHONE,
+    verified: false,
+    source: "Website",
+    stage: "new",
+    assignedTo: admin._id,
+    additionalInfo: {},
+  });
+
   await mongoose.disconnect();
   console.log(
-    JSON.stringify({ token, leadId: String(lead._id), conversationId: String(conversation._id), qualifiedLeadId: String(qLead._id) })
+    JSON.stringify({ token, leadId: String(lead._id), conversationId: String(conversation._id), qualifiedLeadId: String(qLead._id), intakeLeadId: String(intakeLead._id) })
   );
 })();

--- a/scripts/verify-mb7b-s1.js
+++ b/scripts/verify-mb7b-s1.js
@@ -75,7 +75,9 @@ const waitFor = async (fn, l, t = 30000) => { const u = Date.now() + t; while (D
     const deniedPost = await api("POST", `/enquiry/${lead._id}/chat`, cT, { body: "x" });
     ok(deniedPost.status === 403, "out-of-scope admin → 403 on POST chat");
     const members = await api("GET", `/enquiry/${lead._id}/chat/members`, aT);
-    ok(members.status === 200 && Array.isArray(members.data.list) && members.data.list.length >= 3, "mention candidates list returns active admins");
+    // MB9a: chat membership is now PHASE-GATED. This pre-qual lead is assigned to
+    // A (who has no reporting manager) → members = [A] only.
+    ok(members.status === 200 && Array.isArray(members.data.list) && members.data.list.length === 1 && String(members.data.list[0]._id) === String(A._id), "pre-qual chat members = the assignee (phase-gated, MB9a)");
 
     console.log("\n── Pagination ──");
     for (let i = 0; i < 5; i++) await api("POST", `/enquiry/${lead._id}/chat`, aT, { body: `bulk ${i}` });

--- a/scripts/verify-mb9a.js
+++ b/scripts/verify-mb9a.js
@@ -1,0 +1,112 @@
+/* MB9a Slices 1-3 — the two-window lifecycle hinge. Verifies phase-gated chat
+ * membership (pre-qual = assignee + manager; post-qual = roster), the SINGLE
+ * qualify transition (button OR cockpit converge: marks qualified + journey ONCE
+ * + ownership handoff to the manager), idempotency, and that chat history is
+ * preserved across the transition. Test port 8160. */
+require("dotenv").config();
+const { spawn } = require("child_process");
+const mongoose = require("mongoose");
+const jwt = require("jsonwebtoken");
+
+const PORT = 8160; const BASE = `http://localhost:${PORT}`; const MARK = "MB9A";
+let pass = 0, fail = 0; const failures = [];
+const ok = (c, l) => { if (c) { pass++; console.log(`  ✓ ${l}`); } else { fail++; failures.push(l); console.error(`  ✗ ${l}`); } };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const waitFor = async (fn, l, t = 30000) => { const u = Date.now() + t; while (Date.now() < u) { try { const v = await fn(); if (v) return v; } catch (_) {} await sleep(300); } throw new Error(`waitFor: ${l}`); };
+
+(async () => {
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Admin = require("../models/Admin"); const Role = require("../models/Role"); const Department = require("../models/Department");
+  const Enquiry = require("../models/Enquiry"); const LeadStep = require("../models/LeadStep");
+  const LeadTeamMember = require("../models/LeadTeamMember"); const LeadChatMessage = require("../models/LeadChatMessage");
+  const LeadInternalEvent = require("../models/LeadInternalEvent");
+  const StepDefinitionService = require("../services/StepDefinitionService");
+
+  await StepDefinitionService.seed(); // journey definitions must exist to instantiate
+
+  const dept = await Department.create({ name: `${MARK} Dept` });
+  const role = await Role.create({ name: `${MARK} All`, departmentId: dept._id, permissions: ["*:*:all"] });
+  const u = (s) => `9197${String(Date.now()).slice(-7)}${s}`;
+  const mk = (name, mgr) => Admin.create({ name: `${MARK} ${name}`, email: `${name}-${Date.now()}@t.local`, phone: u(Math.floor(Math.random() * 9)), password: "x", roleIds: [role._id], departmentId: dept._id, reportingManagerId: mgr || null, status: "active" });
+  const MANAGER = await mk("Manager");
+  const INTERN = await mk("Intern", MANAGER._id);     // assignee; reports to MANAGER
+  const OPS = await mk("Ops");                          // a roster add post-qual
+  const internT = jwt.sign({ _id: String(INTERN._id), isAdmin: true }, process.env.JWT_SECRET);
+  const mgrT = jwt.sign({ _id: String(MANAGER._id), isAdmin: true }, process.env.JWT_SECRET);
+
+  // Two pre-qual leads: L1 qualified via the BUTTON, L2 via the COCKPIT path.
+  const mkLead = async (n) => Enquiry.create({ name: `${MARK} ${n}`, phone: `9190${String(Date.now()).slice(-7)}${n}`, verified: false, source: "Website", stage: "new", assignedTo: INTERN._id, additionalInfo: {} });
+  const L1 = await mkLead("L1"); const L2 = await mkLead("L2");
+
+  const child = spawn("node", ["server.js"], { cwd: `${__dirname}/..`, env: { ...process.env, PORT: String(PORT) }, stdio: ["ignore", "pipe", "pipe"] });
+  let log = ""; child.stdout.on("data", (d) => (log += d)); child.stderr.on("data", (d) => (log += d));
+  const api = async (m, p, t, b) => { const r = await fetch(`${BASE}${p}`, { method: m, headers: { ...(t ? { Authorization: `Bearer ${t}` } : {}), ...(b ? { "Content-Type": "application/json" } : {}) }, body: b ? JSON.stringify(b) : undefined }); let d = null; try { d = await r.json(); } catch (_) {} return { status: r.status, data: d }; };
+
+  try {
+    await waitFor(() => fetch(`${BASE}/`).then((r) => r.ok).catch(() => false), "boot");
+
+    console.log("\n── Slice 2: pre-qual chat membership = assignee + manager ──");
+    const m1 = await api("GET", `/enquiry/${L1._id}/chat/members`, mgrT);
+    const ids1 = (m1.data.list || []).map((x) => String(x._id));
+    ok(m1.status === 200 && ids1.length === 2 && ids1.includes(String(INTERN._id)) && ids1.includes(String(MANAGER._id)), "pre-qual chat = the assignee + their reporting manager (2)");
+    ok(!ids1.includes(String(OPS._id)), "pre-qual chat excludes everyone else");
+
+    // Post a pre-qual chat message — history must survive the transition.
+    await api("POST", `/enquiry/${L1._id}/chat`, internT, { body: "pre-qual intake note" });
+
+    console.log("\n── Slice 3: QUALIFY via the button (assignee or manager) ──");
+    const beforeOwner = (await Enquiry.findById(L1._id).lean()).assignedTo;
+    ok(String(beforeOwner) === String(INTERN._id), "pre-qual: owned by the intern (assignee)");
+    const q = await api("POST", `/enquiry/${L1._id}/qualify`, internT, {});
+    ok(q.status === 200 && q.data.lead.qualified === true && q.data.alreadyQualified === false, "qualify button marks the lead qualified");
+    ok(q.data.handedOff === true && String(q.data.lead.assignedTo) === String(MANAGER._id), "ownership handed to the sales lead (the intern's manager)");
+    const stepCount = await waitFor(async () => { const c = await LeadStep.countDocuments({ leadId: L1._id }); return c > 0 ? c : false; }, "journey instantiated");
+    ok(stepCount > 0, `journey BORN at qualify (${stepCount} steps)`);
+
+    console.log("\n── Slice 3: idempotent — re-qualify is a no-op ──");
+    const again = await api("POST", `/enquiry/${L1._id}/qualify`, mgrT, {});
+    ok(again.status === 200 && again.data.alreadyQualified === true, "re-qualify reports alreadyQualified");
+    const stepCount2 = await LeadStep.countDocuments({ leadId: L1._id });
+    ok(stepCount2 === stepCount, "journey NOT re-instantiated (no double)");
+
+    console.log("\n── Slice 2: post-qual chat membership = the roster ──");
+    // Add OPS to the roster; the chat membership now follows the roster.
+    await LeadTeamMember.create({ leadId: L1._id, personId: MANAGER._id, addedBy: MANAGER._id });
+    await LeadTeamMember.create({ leadId: L1._id, personId: OPS._id, addedBy: MANAGER._id });
+    const m2 = await api("GET", `/enquiry/${L1._id}/chat/members`, mgrT);
+    const ids2 = (m2.data.list || []).map((x) => String(x._id));
+    ok(ids2.includes(String(MANAGER._id)) && ids2.includes(String(OPS._id)), "post-qual chat = the roster (manager + ops)");
+    ok(!ids2.includes(String(INTERN._id)) || ids2.length === 2, "post-qual chat is roster-driven (intern only if on the roster)");
+
+    console.log("\n── Slice 2: chat history preserved across the transition ──");
+    const chat = (await api("GET", `/enquiry/${L1._id}/chat`, mgrT)).data.messages || [];
+    ok(chat.some((m) => /pre-qual intake note/.test(m.body)), "the pre-qual chat message is still in the thread post-qual");
+
+    console.log("\n── Slice 3: cockpit qualified path converges on the SAME transition ──");
+    const beforeOwner2 = (await Enquiry.findById(L2._id).lean()).assignedTo;
+    ok(String(beforeOwner2) === String(INTERN._id), "L2 pre-qual owned by the intern");
+    const callRes = await api("POST", `/enquiry/${L2._id}/call-log`, internT, { startedAt: new Date().toISOString(), durationSeconds: 120, connected: true, outcome: "qualified" });
+    ok(callRes.status === 200, "cockpit qualified call logged");
+    const l2 = await waitFor(async () => { const x = await Enquiry.findById(L2._id).lean(); return x.qualified ? x : false; }, "L2 qualified via cockpit");
+    ok(l2.qualified === true, "cockpit qualified path marks qualified (same flag)");
+    ok(String(l2.assignedTo) === String(MANAGER._id), "cockpit path ALSO hands ownership to the manager (no fork)");
+    const l2Steps = await LeadStep.countDocuments({ leadId: L2._id });
+    ok(l2Steps > 0, "cockpit path instantiated the journey once");
+  } catch (e) {
+    fail++; failures.push(`fatal: ${e.message}`); console.error("FATAL", e); console.error(log.slice(-2000));
+  } finally {
+    const leadIds = [L1._id, L2._id];
+    await LeadStep.deleteMany({ leadId: { $in: leadIds } });
+    await LeadTeamMember.deleteMany({ leadId: { $in: leadIds } });
+    await LeadChatMessage.deleteMany({ leadId: { $in: leadIds } });
+    await LeadInternalEvent.deleteMany({ leadId: { $in: leadIds } });
+    await Enquiry.deleteMany({ _id: { $in: leadIds } });
+    await Admin.deleteMany({ _id: { $in: [MANAGER._id, INTERN._id, OPS._id] } });
+    await Role.deleteMany({ _id: role._id });
+    await Department.deleteMany({ _id: dept._id });
+    child.kill(); await mongoose.disconnect();
+    console.log(`\n══ RESULT: ${pass} passed, ${fail} failed ══`);
+    if (failures.length) console.log("failures:", failures.join(" | "));
+    process.exit(fail === 0 ? 0 : 1);
+  }
+})();

--- a/services/CallCockpitService.js
+++ b/services/CallCockpitService.js
@@ -143,8 +143,11 @@ const logCall = async (
     notes: notes || "",
     loggedBy: actorId || null,
   };
-  const extraSet = outcome === "qualified" ? { qualified: true } : {};
-  const updated = await EnquiryRepository.pushCallLogById(enquiryId, entry, extraSet);
+  // MB9a: the qualified flip + journey + handoff + summary now all run through
+  // LeadLifecycleService.qualifyLead (the single hinge) AFTER the call-log write
+  // — so the cockpit and the Qualify button can never diverge. The call-log push
+  // itself no longer sets `qualified`.
+  const updated = await EnquiryRepository.pushCallLogById(enquiryId, entry, {});
 
   // First call on this lead → stamp the TAT anchor (no-op for later calls).
   const stamped = await EnquiryRepository.stampFirstCalledAt(enquiryId);
@@ -160,17 +163,15 @@ const logCall = async (
     },
   });
 
-  // MB7b Slice 3: a qualified call is the moment the Kiara summary is worth
-  // paying for — trigger it (Haiku, once). Fire-safe: never breaks the call log.
+  // A qualified call is the hinge: run the SINGLE qualify transition (marks
+  // qualified, hands ownership to the sales lead, instantiates the journey ONCE,
+  // triggers the Kiara summary). Idempotent + fire-safe — never breaks the log.
+  let qualifyResult = null;
   if (outcome === "qualified") {
-    await require("./KiaraSummaryService").generateForQualified(enquiryId);
-    // MB8b: qualification is when the lead enters the journey — stamp the
-    // configurable steps (idempotent: a no-op if already instantiated).
-    // Fire-safe: a failure here must never break the call log.
     try {
-      await require("./LeadStepService").instantiateForLead(enquiryId, actorId);
+      qualifyResult = await require("./LeadLifecycleService").qualifyLead(enquiryId, actorId);
     } catch (e) {
-      console.error("LeadStep.instantiateForLead failed:", e.message);
+      console.error("[logCall] qualifyLead failed:", e.message);
     }
   }
 
@@ -178,6 +179,12 @@ const logCall = async (
   // (the scheduler pre-fills it) or flag the lead unresponsive at MAX attempts.
   const doc = stamped || updated;
   const leadObj = doc.toObject ? doc.toObject() : doc;
+  // Reflect the qualify transition in the returned object (handoff may have moved
+  // assignedTo) so the caller doesn't see a stale pre-qualify snapshot.
+  if (qualifyResult && qualifyResult.lead) {
+    leadObj.qualified = true;
+    leadObj.assignedTo = qualifyResult.lead.assignedTo;
+  }
   if (UNANSWERED_OUTCOMES.includes(entry.outcome)) {
     const cadCfg = await cadenceConfig();
     const flaggedNow = await flagUnresponsiveIfNeeded(

--- a/services/JourneyService.js
+++ b/services/JourneyService.js
@@ -79,6 +79,8 @@ const EVENT_TITLES = {
   // MB8c-2a-ii — client follow-ups.
   followup_created: "Follow-up set",
   followup_completed: "Follow-up done ✓",
+  // MB9a — the qualify hinge.
+  qualified: "Qualified ✦",
 };
 
 const STEP_STATUS_LABEL = {

--- a/services/LeadChatService.js
+++ b/services/LeadChatService.js
@@ -157,10 +157,44 @@ const deleteMessage = async (messageId, authorId) => {
 };
 
 // Scope-aware @mention candidates: active admins (the picker only needs name+id;
-// the actual notification fires solely to whoever is chosen).
+// the actual notification fires solely to whoever is chosen). Retained for any
+// caller that wants the full roster of admins.
 const mentionCandidates = async () => {
   const admins = await Admin.find({ status: "active" }, { name: 1 }).sort({ name: 1 }).lean();
   return admins.map((a) => ({ _id: a._id, name: a.name }));
+};
+
+// ── MB9a Slice 2 — PHASE-GATED chat membership ───────────────────────────────
+// The lead chat's participants depend on the lifecycle window:
+//   • PRE-QUAL  → the ASSIGNEE + the assignee's REPORTING MANAGER (only). If the
+//     assignee has no manager, just the assignee.
+//   • POST-QUAL → the MB8a roster (the huddle team).
+// History is never touched — this only governs who participates / is mentionable
+// / is notified going forward. Additive to MB7b (the legacy mentionCandidates
+// remains for other callers).
+const chatMembers = async (leadId) => {
+  if (!isId(leadId)) throw httpError(400, "Invalid leadId");
+  const lead = await Enquiry.findById(leadId, { assignedTo: 1, qualified: 1 }).lean();
+  if (!lead) throw httpError(404, "Lead not found");
+
+  let ids = [];
+  if (lead.qualified) {
+    const LeadTeamMemberRepository = require("../repositories/LeadTeamMemberRepository");
+    const roster = await LeadTeamMemberRepository.findCurrentByLead(leadId);
+    ids = roster.map((r) => String(r.personId));
+  } else if (lead.assignedTo) {
+    const assignee = await Admin.findById(lead.assignedTo, { name: 1, reportingManagerId: 1 }).lean();
+    if (assignee) {
+      ids = [String(assignee._id)];
+      if (assignee.reportingManagerId) ids.push(String(assignee.reportingManagerId));
+    }
+  }
+  ids = [...new Set(ids)];
+  if (!ids.length) return [];
+  const admins = await Admin.find({ _id: { $in: ids } }, { name: 1 }).lean();
+  const nameOf = new Map(admins.map((a) => [String(a._id), a.name]));
+  // Preserve the order ids were derived in (assignee first, then manager).
+  return ids.map((id) => ({ _id: id, name: nameOf.get(id) || "—" })).filter((m) => m.name !== undefined);
 };
 
 module.exports = {
@@ -171,4 +205,5 @@ module.exports = {
   editMessage,
   deleteMessage,
   mentionCandidates,
+  chatMembers,
 };

--- a/services/LeadLifecycleService.js
+++ b/services/LeadLifecycleService.js
@@ -403,6 +403,70 @@ const bulkTransfer = async ({ leadIds, toAdminId } = {}, actorId, scopeFilter = 
   return { transferred: leadIds.length, to: String(target._id), toName: target.name };
 };
 
+// ── MB9a Slice 3 — THE QUALIFY HINGE (single source of the qualified transition).
+// Both the Call Cockpit qualified-outcome path AND the explicit Qualify button
+// converge HERE so there is no fork. On the (idempotent) transition:
+//   1. mark the lead qualified;
+//   2. hand ownership to the sales lead — the assignee's reporting manager — or
+//      keep the assignee if they have no manager (they ARE the lead);
+//   3. instantiate the journey steps (MB8b) — the journey is BORN here, and the
+//      MB8b guard keeps it a no-op if steps already exist;
+//   4. trigger the Kiara summary.
+// Fire-safe: the journey/summary side-effects never throw out of the transition.
+const qualifyLead = async (enquiryId, actorId) => {
+  assertValidId(enquiryId);
+  const lead = await Enquiry.findById(enquiryId);
+  if (!lead) throw httpError(404, "Enquiry not found");
+  // Idempotent: qualifying an already-qualified lead is a no-op (no double
+  // journey instantiation, no second handoff).
+  if (lead.qualified) return { lead: lead.toObject(), alreadyQualified: true, handedOff: false };
+
+  // Ownership handoff to the sales lead (the assignee's reporting manager).
+  let newOwnerId = lead.assignedTo || null;
+  if (lead.assignedTo) {
+    const assignee = await Admin.findById(lead.assignedTo, { reportingManagerId: 1 }).lean();
+    if (assignee && assignee.reportingManagerId) newOwnerId = assignee.reportingManagerId;
+  }
+  const handedOff = !!newOwnerId && String(newOwnerId) !== String(lead.assignedTo || "");
+
+  const fields = { qualified: true };
+  if (handedOff) fields.assignedTo = newOwnerId;
+  await EnquiryRepository.updateFieldsById(enquiryId, fields);
+
+  await LeadInternalEventService.record({
+    leadId: enquiryId,
+    type: "qualified",
+    actorId: actorId || null,
+    payload: { handedOff, owner: newOwnerId ? String(newOwnerId) : null },
+  });
+  // The ownership handoff reads as a transfer in the journey (from/to are
+  // name-resolved by JourneyService).
+  if (handedOff) {
+    await LeadInternalEventService.record({
+      leadId: enquiryId,
+      type: "transferred",
+      actorId: actorId || null,
+      payload: { from: String(lead.assignedTo), to: String(newOwnerId), reason: "qualify_handoff" },
+    });
+  }
+
+  // The journey is BORN here (MB8b idempotent guard inside). Fire-safe.
+  try {
+    await require("./LeadStepService").instantiateForLead(enquiryId, actorId);
+  } catch (e) {
+    console.error("[qualifyLead] journey instantiate failed:", e.message);
+  }
+  // Kiara summary — worth paying for once qualified. Fire-safe.
+  try {
+    await require("./KiaraSummaryService").generateForQualified(enquiryId);
+  } catch (e) {
+    console.error("[qualifyLead] summary failed:", e.message);
+  }
+
+  const fresh = await Enquiry.findById(enquiryId).lean();
+  return { lead: fresh, alreadyQualified: false, handedOff };
+};
+
 module.exports = {
   recycleLead,
   resurfaceDueLeads,
@@ -411,6 +475,7 @@ module.exports = {
   setTags,
   bulkTransfer,
   addNote,
+  qualifyLead,
   RECYCLE_REASONS,
   COMPLETION_OUTCOMES,
 };


### PR DESCRIPTION
Single LeadLifecycleService.qualifyLead transition; Qualify button + cockpit converge on it (no fork, journey instantiated once, idempotent); ownership handoff to sales lead; phase-gated chat (pre-qual = assignee+manager, post-qual = roster, history preserved); pre-qual journey/roster entry points removed (journey post-qual only). Enquiry-core/requirePermission/rbacPermissions/AdminNotificationService/CommandCenter untouched. 16/16 + regressions, 33/33 Playwright. Slices 4-5 (golden window + rescue) deferred to MB9a-2.