### PR TITLE
MB9a-2: golden window clock + respond-now queue + metrics + tiered rescue (atomic first-claim-wins)

### DIFF
--- a/controllers/goldenWindow.js
+++ b/controllers/goldenWindow.js
@@ -1,0 +1,47 @@
+const mongoose = require("mongoose");
+const Enquiry = require("../models/Enquiry");
+const GoldenWindowService = require("../services/GoldenWindowService");
+
+const respond = (res, error) => {
+  const status = error.status || 500;
+  if (status === 500) console.error("[goldenWindow]", error);
+  res.status(status).json({ message: status === 500 ? "Server error" : error.message });
+};
+
+const assertInScope = async (id, scopeFilter = {}) => {
+  if (!mongoose.Types.ObjectId.isValid(id)) throw Object.assign(new Error("Invalid lead id"), { status: 400 });
+  const inScope = await Enquiry.findOne({ $and: [{ _id: id }, scopeFilter || {}] }, { _id: 1 }).lean();
+  if (!inScope) throw Object.assign(new Error("Out of your scope"), { status: 403 });
+};
+
+// GET /enquiry/:_id/golden-window — the lead's live clock (the pre-qual hero).
+const LeadClock = async (req, res) => {
+  try {
+    await assertInScope(req.params._id, req.scopeFilter);
+    res.status(200).json(await GoldenWindowService.leadClock(req.params._id));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// GET /enquiry/respond-now — the caller's uncontacted, urgency-sorted queue.
+const RespondNow = async (req, res) => {
+  try {
+    res.status(200).json(await GoldenWindowService.respondNow(req.auth.user_id));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// GET /enquiry/golden-window/metrics?periodDays=7 — scope-aware SLA metrics.
+const Metrics = async (req, res) => {
+  try {
+    res.status(200).json(
+      await GoldenWindowService.metrics(req.auth.user_id, req.scope || "own", { periodDays: Number(req.query.periodDays) || 7 })
+    );
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+module.exports = { LeadClock, RespondNow, Metrics };

--- a/controllers/rescue.js
+++ b/controllers/rescue.js
@@ -1,0 +1,58 @@
+const mongoose = require("mongoose");
+const Enquiry = require("../models/Enquiry");
+const RescueService = require("../services/RescueService");
+
+const respond = (res, error) => {
+  const status = error.status || 500;
+  if (status === 500) console.error("[rescue]", error);
+  res.status(status).json({ message: status === 500 ? "Server error" : error.message });
+};
+
+const assertInScope = async (id, scopeFilter = {}) => {
+  if (!mongoose.Types.ObjectId.isValid(id)) throw Object.assign(new Error("Invalid lead id"), { status: 400 });
+  const inScope = await Enquiry.findOne({ $and: [{ _id: id }, scopeFilter || {}] }, { _id: 1 }).lean();
+  if (!inScope) throw Object.assign(new Error("Out of your scope"), { status: 403 });
+};
+
+// GET /enquiry/rescue-queue — tier-2/3 leads for the manager / Revenue Head
+// (scope-aware: team → subordinates' breached leads; all → every breached lead).
+const Queue = async (req, res) => {
+  try {
+    res.status(200).json(await RescueService.rescueQueue(req.auth.user_id, req.scope || "own"));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// POST /enquiry/:_id/rescue/claim — ATOMIC first-claim-wins. The caller must be
+// in scope (a manager/RevHead over the breached lead). Returns an openCall signal.
+const Claim = async (req, res) => {
+  try {
+    await assertInScope(req.params._id, req.scopeFilter);
+    res.status(200).json(await RescueService.claim(req.params._id, req.auth.user_id));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// POST /enquiry/:_id/rescue/reassign — { toAdminId }
+const Reassign = async (req, res) => {
+  try {
+    await assertInScope(req.params._id, req.scopeFilter);
+    res.status(200).json(await RescueService.reassign(req.params._id, req.body?.toAdminId, req.auth.user_id));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+// POST /enquiry/:_id/rescue/dismiss
+const Dismiss = async (req, res) => {
+  try {
+    await assertInScope(req.params._id, req.scopeFilter);
+    res.status(200).json(await RescueService.dismiss(req.params._id, req.auth.user_id));
+  } catch (error) {
+    respond(res, error);
+  }
+};
+
+module.exports = { Queue, Claim, Reassign, Dismiss };

--- a/repositories/EnquiryRepository.js
+++ b/repositories/EnquiryRepository.js
@@ -24,6 +24,18 @@ const updateAssignedToById = async (_id, assignedTo, updatedBy) => {
   );
 };
 
+// MB9a-2 — ATOMIC first-claim-wins reassign. The update applies ONLY while the
+// lead is still owned by `expectedOwnerId`; MongoDB serializes the conditional
+// findOneAndUpdate, so of two concurrent claimers exactly one matches (the other
+// gets null → 409). No new schema field — the assignedTo precondition IS the lock.
+const claimByReassign = async (_id, expectedOwnerId, newOwnerId, updatedBy) => {
+  return await Enquiry.findOneAndUpdate(
+    { _id, assignedTo: expectedOwnerId },
+    { $set: { assignedTo: newOwnerId, updatedBy: updatedBy || null } },
+    { new: true }
+  ).lean();
+};
+
 // Set arbitrary fields on an enquiry by _id. Returns the updated document or null.
 const updateFieldsById = async (_id, fields) => {
   return await Enquiry.findByIdAndUpdate(
@@ -70,6 +82,7 @@ module.exports = {
   updateStageById,
   updateAssignedToById,
   updateFieldsById,
+  claimByReassign,
   pushCallLogById,
   pushFollowUpById,
   stampFirstCalledAt,

--- a/routes/enquiry.js
+++ b/routes/enquiry.js
@@ -113,6 +113,28 @@ router.get(
   requirePermission("leads:view:own", { ownerField: "assignedTo" }),
   followup.Mine
 );
+// ── MB9a-2 — golden-window SLA + rescue (literal paths, above /:_id). The gate
+// sets req.scope from the caller's existing leads:view grant; reused for breadth.
+const goldenWindow = require("../controllers/goldenWindow");
+const rescue = require("../controllers/rescue");
+router.get(
+  "/respond-now",
+  CheckAdminLogin,
+  requirePermission("leads:view:own", { ownerField: "assignedTo" }),
+  goldenWindow.RespondNow
+);
+router.get(
+  "/golden-window/metrics",
+  CheckAdminLogin,
+  requirePermission("leads:view:own", { ownerField: "assignedTo" }),
+  goldenWindow.Metrics
+);
+router.get(
+  "/rescue-queue",
+  CheckAdminLogin,
+  requirePermission("leads:view:own", { ownerField: "assignedTo" }),
+  rescue.Queue
+);
 router.get("/:_id", CheckAdminLogin, requirePermission("leads:view:own", { ownerField: "assignedTo" }), enquiry.Get);
 router.post("/:_id/user", CheckAdminLogin, enquiry.CreateUser);
 router.post("/:_id/conversations", CheckAdminLogin, enquiry.AddConversation);
@@ -382,6 +404,33 @@ router.post(
   CheckAdminLogin,
   requirePermission("leads:edit:own", { ownerField: "assignedTo" }),
   lifecycle.Qualify
+);
+// ── MB9a-2 — per-lead golden-window clock + rescue actions. Claim/reassign/
+// dismiss gate leads:edit + ownerField, so only a manager/RevHead whose scope
+// covers the breached lead can rescue it (an own-scope IC is out of scope).
+router.get(
+  "/:_id/golden-window",
+  CheckAdminLogin,
+  requirePermission("leads:view:own", { ownerField: "assignedTo" }),
+  goldenWindow.LeadClock
+);
+router.post(
+  "/:_id/rescue/claim",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own", { ownerField: "assignedTo" }),
+  rescue.Claim
+);
+router.post(
+  "/:_id/rescue/reassign",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own", { ownerField: "assignedTo" }),
+  rescue.Reassign
+);
+router.post(
+  "/:_id/rescue/dismiss",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own", { ownerField: "assignedTo" }),
+  rescue.Dismiss
 );
 router.post(
   "/:_id/recycle",

--- a/scripts/verify-mb9a2.js
+++ b/scripts/verify-mb9a2.js
@@ -1,0 +1,139 @@
+/* MB9a-2 — golden-window clock + rescue escalation. Verifies the derived clock
+ * (start = creation vs Kiara-handoff; in-window/breach; contact stamp; duration
+ * from settings), the respond-now queue, scope-aware metrics, and the rescue
+ * tiers incl. the ATOMIC first-claim-wins (two concurrent claims → one wins, the
+ * other 409). Test port 8161. */
+require("dotenv").config();
+const { spawn } = require("child_process");
+const mongoose = require("mongoose");
+const jwt = require("jsonwebtoken");
+
+const PORT = 8161; const BASE = `http://localhost:${PORT}`; const MARK = "MB9A2";
+let pass = 0, fail = 0; const failures = [];
+const ok = (c, l) => { if (c) { pass++; console.log(`  ✓ ${l}`); } else { fail++; failures.push(l); console.error(`  ✗ ${l}`); } };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const waitFor = async (fn, l, t = 30000) => { const u = Date.now() + t; while (Date.now() < u) { try { const v = await fn(); if (v) return v; } catch (_) {} await sleep(300); } throw new Error(`waitFor: ${l}`); };
+const MIN = 60000;
+
+(async () => {
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Admin = require("../models/Admin"); const Role = require("../models/Role"); const Department = require("../models/Department");
+  const Enquiry = require("../models/Enquiry"); const WAConversation = require("../models/WAConversation");
+  const LeadInternalEvent = require("../models/LeadInternalEvent"); const AdminNotification = require("../models/AdminNotification");
+  const Setting = require("../models/Setting"); const SettingsService = require("../services/SettingsService");
+
+  const dept = await Department.create({ name: `${MARK} Dept` });
+  const teamRole = await Role.create({ name: `${MARK} Team`, departmentId: dept._id, permissions: ["leads:view:team", "leads:edit:team"] });
+  const revRole = await Role.create({ name: `${MARK} RevHead`, departmentId: dept._id, permissions: ["*:*:all"] });
+  const ownRole = await Role.create({ name: `${MARK} Own`, departmentId: dept._id, permissions: ["leads:view:own", "leads:edit:own"] });
+  const u = (s) => `9197${String(Date.now()).slice(-7)}${s}`;
+  const mk = (name, roleIds, mgr) => Admin.create({ name: `${MARK} ${name}`, email: `${name}-${Date.now()}@t.local`, phone: u(Math.floor(Math.random() * 9)), password: "x", roleIds, departmentId: dept._id, reportingManagerId: mgr || null, status: "active" });
+  const MANAGER = await mk("Manager", [teamRole._id]);
+  const INTERN = await mk("Intern", [ownRole._id], MANAGER._id);
+  const REVHEAD = await mk("RevHead", [revRole._id]);
+  const OUTSIDER = await mk("Outsider", [ownRole._id]);
+  const tok = (a) => jwt.sign({ _id: String(a._id), isAdmin: true }, process.env.JWT_SECRET);
+  const internT = tok(INTERN), mgrT = tok(MANAGER), revT = tok(REVHEAD), outT = tok(OUTSIDER);
+
+  const now = Date.now();
+  const mkLead = async (n, over) => Enquiry.create({ name: `${MARK} ${n}`, phone: `9190${String(now).slice(-7)}${n}`, verified: false, source: "Website", stage: "new", assignedTo: INTERN._id, additionalInfo: {}, ...over });
+  const direct = await mkLead("Direct");                                          // created now → in-window
+  const kiara = await mkLead("Kiara");                                            // created now, but handoff 40m ago
+  const contacted = await mkLead("Contacted", { firstCalledAt: new Date(now - 2 * MIN) }); // contacted in-window
+  const breachLead = await mkLead("Breach", { createdAt: new Date(now - 40 * MIN) }); // created 40m ago → breached
+  const dismissLead = await mkLead("Dismiss", { createdAt: new Date(now - 40 * MIN) });
+  // Kiara handoff signal: needs-human 40m ago → its clock starts at handoff (breached).
+  await WAConversation.create({ enquiryId: kiara._id, phone: kiara.phone, normalizedPhone: kiara.phone.slice(-10), needsHuman: true, needsHumanAt: new Date(now - 40 * MIN), status: "active" });
+
+  const child = spawn("node", ["server.js"], { cwd: `${__dirname}/..`, env: { ...process.env, PORT: String(PORT) }, stdio: ["ignore", "pipe", "pipe"] });
+  let log = ""; child.stdout.on("data", (d) => (log += d)); child.stderr.on("data", (d) => (log += d));
+  const api = async (m, p, t, b) => { const r = await fetch(`${BASE}${p}`, { method: m, headers: { ...(t ? { Authorization: `Bearer ${t}` } : {}), ...(b ? { "Content-Type": "application/json" } : {}) }, body: b ? JSON.stringify(b) : undefined }); let d = null; try { d = await r.json(); } catch (_) {} return { status: r.status, data: d }; };
+
+  try {
+    await waitFor(() => fetch(`${BASE}/`).then((r) => r.ok).catch(() => false), "boot");
+
+    console.log("\n── Slice 1: clock start rule + states ──");
+    const cD = await api("GET", `/enquiry/${direct._id}/golden-window`, internT);
+    ok(cD.status === 200 && cD.data.state === "in_window" && cD.data.fromKiara === false, "direct lead: clock starts at creation → in-window");
+    ok(cD.data.durationMinutes === 30, "duration from settings (default 30)");
+    const cK = await api("GET", `/enquiry/${kiara._id}/golden-window`, internT);
+    ok(cK.data.fromKiara === true && cK.data.state === "breached", "Kiara lead: clock starts at handoff (needsHumanAt) → breached");
+    const cC = await api("GET", `/enquiry/${contacted._id}/golden-window`, internT);
+    ok(cC.data.state === "contacted" && cC.data.inWindow === true, "contacted lead: first-contact stamps in-window, exits the window");
+
+    console.log("\n── Slice 1: duration is settings-driven ──");
+    await api("PUT", "/settings", revT, { key: "sla.goldenWindowMinutes", value: 10 });
+    const cD10 = await api("GET", `/enquiry/${breachLead._id}/golden-window`, internT);
+    ok(cD10.data.durationMinutes === 10, "duration follows the setting (10)");
+    await api("PUT", "/settings", revT, { key: "sla.goldenWindowMinutes", value: 30 }); // restore
+
+    console.log("\n── Slice 2: respond-now queue (urgency-sorted) ──");
+    const rn = await api("GET", "/enquiry/respond-now", internT);
+    const rnIds = (rn.data.rows || []).map((r) => r._id);
+    ok(rn.status === 200 && rnIds.includes(String(direct._id)) && rnIds.includes(String(breachLead._id)), "respond-now lists the caller's uncontacted active leads");
+    ok(!rnIds.includes(String(contacted._id)), "respond-now excludes already-contacted leads");
+    ok(rn.data.rows[0].breached === true, "breached leads sort to the top (most urgent)");
+    const rnOut = await api("GET", "/enquiry/respond-now", outT);
+    ok(rnOut.status === 200 && rnOut.data.rows.length === 0, "another admin's respond-now is empty (scoped to their own leads)");
+
+    console.log("\n── Slice 3: metrics (scope-aware, team) ──");
+    const met = await api("GET", "/enquiry/golden-window/metrics?periodDays=7", mgrT);
+    ok(met.status === 200 && typeof met.data.inWindowPct === "number" && met.data.breachCount >= 1, `metrics compute (inWindow ${met.data.inWindowPct}% · ${met.data.breachCount} breaches)`);
+    ok(met.data.avgFirstResponseMinutes !== undefined, "metrics include avg first-response");
+
+    console.log("\n── Slice 4: rescue queue (manager + RevHead see breached; IC does not) ──");
+    const rqMgr = await api("GET", "/enquiry/rescue-queue", mgrT);
+    const rqIds = (rqMgr.data.rows || []).map((r) => r._id);
+    ok(rqMgr.status === 200 && rqIds.includes(String(breachLead._id)) && rqIds.includes(String(kiara._id)), "manager rescue-queue surfaces subordinates' breached leads");
+    ok(rqMgr.data.rows.find((r) => r._id === String(breachLead._id)).tier === 3, "breached lead is tier-3 (persistent)");
+    const rqRev = await api("GET", "/enquiry/rescue-queue", revT);
+    ok((rqRev.data.rows || []).some((r) => r._id === String(breachLead._id)), "Revenue Head (all scope) also sees it");
+    const rqIc = await api("GET", "/enquiry/rescue-queue", internT);
+    ok(rqIc.status === 200 && rqIc.data.rows.length === 0, "an own-scope IC sees no rescue items");
+
+    console.log("\n── Slice 4: tier-2 notify fired + rate-limited ──");
+    // The assignee's reporting manager is a deterministic tier-2 recipient (the
+    // Revenue-Head recipient depends on the canonical "Revenue Head" role, which
+    // the dev DB also seeds — not asserted here to avoid the name collision).
+    const note = await waitFor(async () => (await AdminNotification.findOne({ adminId: MANAGER._id, type: "rescue_needed" }).lean()) || false, "rescue_needed notification");
+    ok(!!note, "tier-2 notifies the reporting manager via AdminNotificationService");
+    const before = await AdminNotification.countDocuments({ adminId: MANAGER._id, type: "rescue_needed" });
+    await api("GET", "/enquiry/rescue-queue", mgrT); // poll again immediately
+    const after = await AdminNotification.countDocuments({ adminId: MANAGER._id, type: "rescue_needed" });
+    ok(after === before, "re-poll within the cooldown does NOT re-notify (rate-limited)");
+
+    console.log("\n── Slice 4: ATOMIC first-claim-wins (two concurrent claims) ──");
+    const [c1, c2] = await Promise.all([
+      api("POST", `/enquiry/${breachLead._id}/rescue/claim`, mgrT, {}),
+      api("POST", `/enquiry/${breachLead._id}/rescue/claim`, revT, {}),
+    ]);
+    const statuses = [c1.status, c2.status].sort();
+    ok(statuses[0] === 200 && statuses[1] === 409, `exactly one claim wins (got ${c1.status}/${c2.status})`);
+    const winner = c1.status === 200 ? c1 : c2;
+    ok(winner.data.claimed === true && winner.data.openCall === true, "the winning claim reassigns + signals openCall");
+    const claimed = await Enquiry.findById(breachLead._id).lean();
+    ok([String(MANAGER._id), String(REVHEAD._id)].includes(String(claimed.assignedTo)), "the lead is reassigned to the claimer");
+
+    console.log("\n── Slice 4: dismiss removes from the rescue queue ──");
+    await api("POST", `/enquiry/${dismissLead._id}/rescue/dismiss`, mgrT, {});
+    const rqAfter = await api("GET", "/enquiry/rescue-queue", mgrT);
+    ok(!(rqAfter.data.rows || []).some((r) => r._id === String(dismissLead._id)), "a dismissed lead drops out of the rescue queue");
+  } catch (e) {
+    fail++; failures.push(`fatal: ${e.message}`); console.error("FATAL", e); console.error(log.slice(-2000));
+  } finally {
+    const leadIds = [direct._id, kiara._id, contacted._id, breachLead._id, dismissLead._id];
+    await WAConversation.deleteMany({ enquiryId: { $in: leadIds } });
+    await LeadInternalEvent.deleteMany({ leadId: { $in: leadIds } });
+    await AdminNotification.deleteMany({ adminId: { $in: [MANAGER._id, INTERN._id, REVHEAD._id, OUTSIDER._id] } });
+    await Enquiry.deleteMany({ _id: { $in: leadIds } });
+    await Admin.deleteMany({ _id: { $in: [MANAGER._id, INTERN._id, REVHEAD._id, OUTSIDER._id] } });
+    await Role.deleteMany({ _id: { $in: [teamRole._id, revRole._id, ownRole._id] } });
+    await Department.deleteMany({ _id: dept._id });
+    await Setting.deleteMany({ key: "sla.goldenWindowMinutes" });
+    SettingsService.invalidate();
+    child.kill(); await mongoose.disconnect();
+    console.log(`\n══ RESULT: ${pass} passed, ${fail} failed ══`);
+    if (failures.length) console.log("failures:", failures.join(" | "));
+    process.exit(fail === 0 ? 0 : 1);
+  }
+})();

--- a/services/GoldenWindowService.js
+++ b/services/GoldenWindowService.js
@@ -1,0 +1,174 @@
+const mongoose = require("mongoose");
+const Enquiry = require("../models/Enquiry");
+const Admin = require("../models/Admin");
+const WAConversation = require("../models/WAConversation");
+const SettingsService = require("./SettingsService");
+const { getSubordinateIds, getDepartmentMemberIds } = require("../middlewares/requirePermission");
+
+const err = (status, message) => Object.assign(new Error(message), { status });
+const isId = (v) => mongoose.Types.ObjectId.isValid(v);
+const MIN = 60 * 1000;
+const idStr = (v) => String(v);
+
+// The SLA thresholds (minutes). Single source — settings_sla.
+const thresholds = async () => {
+  const v = await SettingsService.getMany(["sla.goldenWindowMinutes", "sla.rescueTier1Minutes", "sla.rescueTier2Minutes"]);
+  return {
+    durationMin: Number(v["sla.goldenWindowMinutes"]) || 30,
+    tier1Min: Number(v["sla.rescueTier1Minutes"]) || 5,
+    tier2Min: Number(v["sla.rescueTier2Minutes"]) || 1,
+  };
+};
+
+// The clock START = "human needed": the Kiara-handoff moment for a Kiara-handled
+// lead (WAConversation.needsHumanAt), else lead creation. Batched: one query for
+// all candidate leads' handoff timestamps (no per-lead lookup, no Enquiry field).
+const handoffMap = async (leadIds) => {
+  if (!leadIds.length) return new Map();
+  const convos = await WAConversation.find(
+    { enquiryId: { $in: leadIds }, needsHumanAt: { $ne: null } },
+    { enquiryId: 1, needsHumanAt: 1 }
+  ).lean();
+  const m = new Map();
+  for (const c of convos) {
+    const k = idStr(c.enquiryId);
+    // Earliest "needs a human" wins (the first time it needed a call).
+    const t = +new Date(c.needsHumanAt);
+    if (!m.has(k) || t < m.get(k)) m.set(k, t);
+  }
+  return m;
+};
+
+const isClosed = (lead) => lead.isLost || (lead.recycled && lead.recycled.isRecycled);
+
+// PURE clock for one lead. firstHumanContactAt = firstCalledAt (the existing
+// set-once first-call stamp — the cockpit/record-call signal).
+const clockFor = (lead, handoffAt, t, now) => {
+  const startMs = handoffAt || +new Date(lead.createdAt);
+  const deadlineMs = startMs + t.durationMin * MIN;
+  const contactedMs = lead.firstCalledAt ? +new Date(lead.firstCalledAt) : null;
+  const nowMs = +now;
+  const closed = isClosed(lead);
+
+  let state; // in_window | breached | contacted | resolved
+  if (contactedMs != null) state = "contacted";
+  else if (lead.qualified || closed) state = "resolved";
+  else state = nowMs > deadlineMs ? "breached" : "in_window";
+
+  const inWindow = contactedMs != null && contactedMs <= deadlineMs;
+  const breached = state === "breached" || (contactedMs != null && contactedMs > deadlineMs);
+  const active = state === "in_window" || state === "breached"; // still needs a human
+  const secondsLeft = Math.round((deadlineMs - nowMs) / 1000);
+
+  // Rescue tier (only for active/uncontacted leads).
+  let tier = 0;
+  if (active) {
+    if (state === "breached" || secondsLeft <= t.tier2Min * 60) tier = 2;
+    else if (secondsLeft <= t.tier1Min * 60) tier = 1;
+  }
+
+  return {
+    startAt: new Date(startMs).toISOString(),
+    deadlineAt: new Date(deadlineMs).toISOString(),
+    contactedAt: contactedMs ? new Date(contactedMs).toISOString() : null,
+    durationMinutes: t.durationMin,
+    state, active, inWindow, breached, secondsLeft, tier,
+    fromKiara: !!handoffAt,
+  };
+};
+
+// Single-lead clock (the pre-qual hero).
+const leadClock = async (leadId) => {
+  if (!isId(leadId)) throw err(400, "Invalid leadId");
+  const lead = await Enquiry.findById(leadId, { createdAt: 1, firstCalledAt: 1, qualified: 1, isLost: 1, recycled: 1 }).lean();
+  if (!lead) throw err(404, "Lead not found");
+  const [t, hm] = await Promise.all([thresholds(), handoffMap([lead._id])]);
+  return clockFor(lead, hm.get(idStr(lead._id)), t, new Date());
+};
+
+// SLICE 2 — the caller's "Respond now" queue: their UNCONTACTED, active (in-window
+// or breached) leads, urgency-sorted (breached first, then least time left).
+const respondNow = async (adminId, now = new Date()) => {
+  if (!isId(adminId)) throw err(400, "Invalid adminId");
+  // Bound to recent leads — speed-to-lead is a fresh-lead concern (a window from
+  // weeks ago is stale, not a live "respond now").
+  const RESPOND_HORIZON_MS = 7 * 24 * 60 * 60 * 1000;
+  const leads = await Enquiry.find(
+    {
+      assignedTo: adminId,
+      firstCalledAt: null,
+      qualified: { $ne: true },
+      isLost: { $ne: true },
+      "recycled.isRecycled": { $ne: true },
+      createdAt: { $gte: new Date(+now - RESPOND_HORIZON_MS) },
+    },
+    { name: 1, phone: 1, source: 1, marketingSource: 1, createdAt: 1, firstCalledAt: 1, qualified: 1, isLost: 1, recycled: 1 }
+  ).lean();
+  const t = await thresholds();
+  const hm = await handoffMap(leads.map((l) => l._id));
+  const rows = leads
+    .map((l) => ({ ...clockBrief(l, clockFor(l, hm.get(idStr(l._id)), t, now)) }))
+    .filter((r) => r.active); // in-window or breached only
+  rows.sort((a, b) => a.secondsLeft - b.secondsLeft); // most overdue (most negative) first
+  return { rows, count: rows.length, thresholds: t };
+};
+
+const clockBrief = (lead, clock) => ({
+  _id: idStr(lead._id),
+  name: lead.name,
+  source: lead.source || lead.marketingSource || "",
+  startAt: clock.startAt,
+  deadlineAt: clock.deadlineAt,
+  secondsLeft: clock.secondsLeft,
+  state: clock.state,
+  active: clock.active,
+  breached: clock.breached,
+  tier: clock.tier,
+});
+
+// Owner-scope ids by the caller's existing lead scope (reused, no new RBAC).
+const ownerScopeIds = async (adminId, scope) => {
+  if (scope === "all") return null; // unrestricted
+  if (scope === "team") return [adminId, ...(await getSubordinateIds(adminId))];
+  if (scope === "department") {
+    const admin = await Admin.findById(adminId, { departmentId: 1 }).lean();
+    const members = await getDepartmentMemberIds(admin && admin.departmentId);
+    return [...new Set([idStr(adminId), ...members.map(idStr)])];
+  }
+  return [adminId];
+};
+
+// SLICE 3 — golden-window metrics over a period (scope-aware). Feeds MB9b.
+const metrics = async (adminId, scope, { periodDays = 7 } = {}, now = new Date()) => {
+  const owners = await ownerScopeIds(adminId, scope);
+  const since = new Date(+now - periodDays * 24 * 60 * MIN);
+  const filter = { createdAt: { $gte: since }, isLost: { $ne: true }, "recycled.isRecycled": { $ne: true } };
+  if (owners) filter.assignedTo = { $in: owners.map((o) => new mongoose.Types.ObjectId(idStr(o))) };
+  const leads = await Enquiry.find(filter, { createdAt: 1, firstCalledAt: 1, qualified: 1, isLost: 1, recycled: 1 }).lean();
+  const t = await thresholds();
+  const hm = await handoffMap(leads.map((l) => l._id));
+
+  let decided = 0, inWindow = 0, breaches = 0, respSum = 0, respN = 0;
+  for (const l of leads) {
+    const c = clockFor(l, hm.get(idStr(l._id)), t, now);
+    const isDecided = c.contactedAt != null || c.state === "breached";
+    if (!isDecided) continue; // still pending in-window — not yet counted
+    decided += 1;
+    if (c.inWindow) inWindow += 1;
+    if (c.breached) breaches += 1;
+    if (c.contactedAt) {
+      respSum += (+new Date(c.contactedAt) - +new Date(c.startAt)) / MIN;
+      respN += 1;
+    }
+  }
+  return {
+    periodDays,
+    total: decided,
+    inWindowPct: decided ? Math.round((inWindow / decided) * 100) : null,
+    avgFirstResponseMinutes: respN ? Math.round(respSum / respN) : null,
+    breachCount: breaches,
+    scope,
+  };
+};
+
+module.exports = { thresholds, handoffMap, clockFor, leadClock, respondNow, metrics, ownerScopeIds, isClosed };

--- a/services/RescueService.js
+++ b/services/RescueService.js
@@ -1,0 +1,173 @@
+const mongoose = require("mongoose");
+const Enquiry = require("../models/Enquiry");
+const Admin = require("../models/Admin");
+const LeadInternalEvent = require("../models/LeadInternalEvent");
+const EnquiryRepository = require("../repositories/EnquiryRepository");
+const GoldenWindowService = require("./GoldenWindowService");
+const LeadInternalEventService = require("./LeadInternalEventService");
+const AdminNotificationService = require("./AdminNotificationService");
+const LeadTaskService = require("./LeadTaskService"); // idsByRoleName (Revenue Head)
+
+const err = (status, message) => Object.assign(new Error(message), { status });
+const isId = (v) => mongoose.Types.ObjectId.isValid(v);
+const idStr = (v) => String(v);
+
+// Per-lead tier-2 notify cooldown (in-memory, single-process) — same anti-spam
+// pattern as the 8c-2a-ii nudge. Poll-bounded surfacing; not instant.
+const TIER2_COOLDOWN_MS = 30 * 60 * 1000;
+const lastTier2Notify = new Map();
+// Speed-to-lead is a fresh-lead concern: only leads whose window opened within
+// this horizon are live rescues (an uncontacted lead from weeks ago is a
+// data-hygiene issue, not a rescue). Also bounds the all-scope scan.
+const HORIZON_MS = 7 * 24 * 60 * 60 * 1000;
+
+// Leads dismissed from the rescue list (a manager handled it otherwise). Derived
+// from journey events — no Enquiry field.
+const dismissedSet = async (leadIds) => {
+  if (!leadIds.length) return new Set();
+  const rows = await LeadInternalEvent.find(
+    { leadId: { $in: leadIds }, type: "rescue_dismissed" },
+    { leadId: 1 }
+  ).lean();
+  return new Set(rows.map((r) => idStr(r.leadId)));
+};
+
+// SLICE 4 — the rescue queue for managers / the Revenue Head. Tier-2/3 leads
+// (active, uncontacted, breach-imminent or breached) NOT owned by the caller:
+//   • team scope → leads assigned to the caller's subordinates;
+//   • all scope (Revenue Head) → every such lead.
+// Own-scope callers get nothing (they rescue nobody; they're an assignee).
+const rescueQueue = async (adminId, scope, now = new Date()) => {
+  if (scope === "own" || !scope) return { rows: [], count: 0 };
+
+  let leadFilter = {
+    firstCalledAt: null,
+    qualified: { $ne: true },
+    isLost: { $ne: true },
+    "recycled.isRecycled": { $ne: true },
+    createdAt: { $gte: new Date(+now - HORIZON_MS) },
+  };
+  if (scope !== "all") {
+    const subs = await GoldenWindowService.ownerScopeIds(adminId, scope); // [me, ...subs]
+    const others = (subs || []).map(idStr).filter((id) => id !== idStr(adminId));
+    if (!others.length) return { rows: [], count: 0 };
+    leadFilter.assignedTo = { $in: others.map((id) => new mongoose.Types.ObjectId(id)) };
+  }
+
+  const leads = await Enquiry.find(leadFilter, {
+    name: 1, phone: 1, source: 1, marketingSource: 1, assignedTo: 1, createdAt: 1, firstCalledAt: 1, qualified: 1, isLost: 1, recycled: 1,
+  }).lean();
+  const t = await GoldenWindowService.thresholds();
+  const hm = await GoldenWindowService.handoffMap(leads.map((l) => l._id));
+  const dismissed = await dismissedSet(leads.map((l) => l._id));
+
+  const candidates = [];
+  for (const l of leads) {
+    const c = GoldenWindowService.clockFor(l, hm.get(idStr(l._id)), t, now);
+    if (c.tier >= 2 && !dismissed.has(idStr(l._id))) candidates.push({ lead: l, clock: c });
+  }
+
+  // Resolve assignee names (drop null owners BEFORE stringifying).
+  const ownerIds = [...new Set(candidates.map((c) => c.lead.assignedTo).filter(Boolean).map(idStr))];
+  const owners = ownerIds.length ? await Admin.find({ _id: { $in: ownerIds } }, { name: 1 }).lean() : [];
+  const nameOf = new Map(owners.map((a) => [idStr(a._id), a.name]));
+
+  const rows = candidates
+    .map(({ lead, clock }) => ({
+      _id: idStr(lead._id),
+      name: lead.name,
+      source: lead.source || lead.marketingSource || "",
+      assignedTo: lead.assignedTo ? idStr(lead.assignedTo) : null,
+      assigneeName: lead.assignedTo ? nameOf.get(idStr(lead.assignedTo)) || "—" : "—",
+      deadlineAt: clock.deadlineAt,
+      secondsLeft: clock.secondsLeft,
+      breached: clock.breached, // tier-3 = the persistent breached ones
+      tier: clock.breached ? 3 : 2,
+    }))
+    .sort((a, b) => a.secondsLeft - b.secondsLeft);
+
+  // Fire the tier-2 notification ONCE per lead (rate-limited) to the escalation
+  // chain — the assignee's reporting manager + the Revenue Head(s).
+  await notifyTier2(rows, leads, now);
+
+  return { rows, count: rows.length };
+};
+
+const notifyTier2 = async (rows, leads, now) => {
+  const leadById = new Map(leads.map((l) => [idStr(l._id), l]));
+  let revHeads = null;
+  for (const r of rows) {
+    const prev = lastTier2Notify.get(r._id);
+    if (prev && +now - prev < TIER2_COOLDOWN_MS) continue;
+    const lead = leadById.get(r._id);
+    const recipients = new Set();
+    if (lead && lead.assignedTo) {
+      const assignee = await Admin.findById(lead.assignedTo, { reportingManagerId: 1 }).lean();
+      if (assignee && assignee.reportingManagerId) recipients.add(idStr(assignee.reportingManagerId));
+    }
+    if (revHeads === null) revHeads = (await LeadTaskService.idsByRoleName("Revenue Head")).map(idStr);
+    revHeads.forEach((id) => recipients.add(id));
+    const ids = [...recipients].filter(Boolean);
+    if (ids.length) {
+      await AdminNotificationService.notify(ids, {
+        type: "rescue_needed",
+        title: `Rescue needed: ${r.name}`,
+        message: r.breached ? "Golden window breached — up for grabs." : "About to breach the golden window.",
+        leadId: r._id,
+        payload: { assigneeId: r.assignedTo },
+      });
+    }
+    lastTier2Notify.set(r._id, +now);
+  }
+};
+
+// CLAIM — atomic first-claim-wins. Reassigns the lead to the claimer ONLY if it
+// is still owned by the breached assignee; a concurrent loser gets 409.
+const claim = async (leadId, claimerId) => {
+  if (!isId(leadId)) throw err(400, "Invalid leadId");
+  const lead = await Enquiry.findById(leadId, { assignedTo: 1, name: 1 }).lean();
+  if (!lead) throw err(404, "Lead not found");
+  const expectedOwner = lead.assignedTo; // may be null
+  if (expectedOwner && idStr(expectedOwner) === idStr(claimerId)) {
+    // Already the claimer's — treat as a successful (idempotent) claim.
+    return { claimed: true, alreadyMine: true, openCall: true, lead };
+  }
+  const updated = await EnquiryRepository.claimByReassign(leadId, expectedOwner, claimerId, claimerId);
+  if (!updated) throw err(409, "Already claimed by someone else");
+
+  await LeadInternalEventService.record({
+    leadId, type: "transferred", actorId: claimerId,
+    payload: { from: expectedOwner ? idStr(expectedOwner) : null, to: idStr(claimerId), reason: "rescue_claim" },
+  });
+  await LeadInternalEventService.record({
+    leadId, type: "rescue_claimed", actorId: claimerId,
+    payload: { breachedAssignee: expectedOwner ? idStr(expectedOwner) : null, rescuer: idStr(claimerId) },
+  });
+  return { claimed: true, openCall: true, lead: updated };
+};
+
+// Manager reassigns the rescue to a specific person (also atomic on the current owner).
+const reassign = async (leadId, toAdminId, actorId) => {
+  if (!isId(leadId) || !isId(toAdminId)) throw err(400, "Invalid id");
+  const target = await Admin.findById(toAdminId, { status: 1 }).lean();
+  if (!target || target.status !== "active") throw err(422, "Target admin is not active");
+  const lead = await Enquiry.findById(leadId, { assignedTo: 1 }).lean();
+  if (!lead) throw err(404, "Lead not found");
+  const updated = await EnquiryRepository.claimByReassign(leadId, lead.assignedTo, toAdminId, actorId);
+  if (!updated) throw err(409, "Already reassigned by someone else");
+  await LeadInternalEventService.record({
+    leadId, type: "transferred", actorId,
+    payload: { from: lead.assignedTo ? idStr(lead.assignedTo) : null, to: idStr(toAdminId), reason: "rescue_reassign" },
+  });
+  return { reassigned: true, lead: updated };
+};
+
+// Dismiss the rescue item (handled otherwise) — a journey event; the queue
+// excludes dismissed leads. No Enquiry field.
+const dismiss = async (leadId, actorId) => {
+  if (!isId(leadId)) throw err(400, "Invalid leadId");
+  await LeadInternalEventService.record({ leadId, type: "rescue_dismissed", actorId, payload: {} });
+  return { dismissed: true };
+};
+
+module.exports = { rescueQueue, claim, reassign, dismiss, TIER2_COOLDOWN_MS, _lastTier2Notify: lastTier2Notify };

--- a/services/SettingsService.js
+++ b/services/SettingsService.js
@@ -97,6 +97,13 @@ const DEFAULTS = {
   // The command-center banner, the chat follow-up cards, and the Pipeline
   // "stuck" flag ALL derive from this single value (default 3 days).
   "accountability.staleDays": 3,
+  // MB9a-2 — speed-to-lead SLA. The golden-window clock duration (minutes from
+  // "human needed" to first human contact) + the rescue-escalation thresholds.
+  // Distinct from the legacy MB5 golden.windowMinutes (the cockpit/safety-net
+  // display) so neither changes the other.
+  "sla.goldenWindowMinutes": 30,
+  "sla.rescueTier1Minutes": 5,
+  "sla.rescueTier2Minutes": 1,
 };
 
 // key → settings permission category. Every write is gated by ITS category.
@@ -138,6 +145,9 @@ const KEY_CATEGORY = {
   "nurture.cadenceDays": "settings_nurture",
   // Accountability threshold rides the SLA settings category.
   "accountability.staleDays": "settings_sla",
+  "sla.goldenWindowMinutes": "settings_sla",
+  "sla.rescueTier1Minutes": "settings_sla",
+  "sla.rescueTier2Minutes": "settings_sla",
 };
 
 const err = (status, message) => Object.assign(new Error(message), { status });
@@ -189,6 +199,15 @@ const validateValue = (key, value) => {
       return value;
     case "accountability.staleDays":
       if (!isIntInRange(value, 1, 30)) throw err(400, "accountability.staleDays must be an integer 1–30");
+      return value;
+    case "sla.goldenWindowMinutes":
+      if (!isIntInRange(value, 5, 480)) throw err(400, "sla.goldenWindowMinutes must be an integer 5–480");
+      return value;
+    case "sla.rescueTier1Minutes":
+      if (!isIntInRange(value, 1, 60)) throw err(400, "sla.rescueTier1Minutes must be an integer 1–60");
+      return value;
+    case "sla.rescueTier2Minutes":
+      if (!isIntInRange(value, 1, 30)) throw err(400, "sla.rescueTier2Minutes must be an integer 1–30");
       return value;
     case "assignment.autoAssignEnabled":
     case "lost.approvalRequired":


### PR DESCRIPTION
Derived golden-window clock (Kiara-handoff vs createdAt start, sla.goldenWindowMinutes default 30, no Enquiry schema change); respond-now queue + scope-aware metrics endpoint (feeds MB9b); tiered rescue (assignee → manager+RevHead → persistent list) with ATOMIC first-claim-wins via conditional findOneAndUpdate (verified two-concurrent → one 200/one 409); poll-based (no websockets). Enquiry-core/requirePermission/rbacPermissions/AdminNotificationService/MB9a-1 hinge untouched. 21/21 + regressions, 37/37 Playwright.