### PR TITLE
MB9c API: bulk lead actions (tag/stage/lost/archive) — scope-verified, founder-only soft-delete, audited

### DIFF
--- a/controllers/enquiry.js
+++ b/controllers/enquiry.js
@@ -313,6 +313,8 @@ const GetAll = async (req, res) => {
       dateTo,
     } = req.query;
     const query = {};
+    // MB9c — soft-deleted (archived) leads are excluded from the default list.
+    query.archivedAt = null;
     const sortQuery = {};
     if (source) {
       query.source = source;

--- a/controllers/enquiry.js
+++ b/controllers/enquiry.js
@@ -344,6 +344,17 @@ const GetAll = async (req, res) => {
         // MB5 Slice 4: the triage queue as a leads filter.
         query.triagePending = true;
         query["recycled.isRecycled"] = { $ne: true };
+      } else if (view === "qualified") {
+        // MB9c — the Qualified saved-view segment.
+        query.qualified = true;
+        query["recycled.isRecycled"] = { $ne: true };
+      } else if (view === "golden") {
+        // MB9c — the Golden-window segment: uncontacted, active leads (the same
+        // set Respond-now works from — reconciles).
+        query.firstCalledAt = null;
+        query.qualified = { $ne: true };
+        query.isLost = { $ne: true };
+        query["recycled.isRecycled"] = { $ne: true };
       }
     }
     if (date) {

--- a/controllers/leadBulk.js
+++ b/controllers/leadBulk.js
@@ -1,0 +1,29 @@
+const LeadBulkService = require("../services/LeadBulkService");
+
+const respond = (res, error) => {
+  const status = error.status || 500;
+  if (status === 500) console.error("[leadBulk]", error);
+  res.status(status).json({ message: status === 500 ? "Server error" : error.message });
+};
+
+// All bulk actions are scope-verified inside the service (out-of-scope ⇒ the
+// whole batch is rejected). req.scopeFilter comes from requirePermission.
+const Tag = async (req, res) => {
+  try { res.status(200).json(await LeadBulkService.bulkTag(req.body || {}, req.auth.user_id, req.scopeFilter)); }
+  catch (error) { respond(res, error); }
+};
+const Stage = async (req, res) => {
+  try { res.status(200).json(await LeadBulkService.bulkStage(req.body || {}, req.auth.user_id, req.scopeFilter)); }
+  catch (error) { respond(res, error); }
+};
+const Lost = async (req, res) => {
+  try { res.status(200).json(await LeadBulkService.bulkLost(req.body || {}, req.auth.user_id, req.scopeFilter)); }
+  catch (error) { respond(res, error); }
+};
+// SOFT DELETE — additionally gated to leads:delete:all (founder) at the route.
+const Archive = async (req, res) => {
+  try { res.status(200).json(await LeadBulkService.bulkArchive(req.body || {}, req.auth.user_id, req.scopeFilter)); }
+  catch (error) { respond(res, error); }
+};
+
+module.exports = { Tag, Stage, Lost, Archive };

--- a/controllers/settings.js
+++ b/controllers/settings.js
@@ -60,6 +60,8 @@ const GetPublic = async (req, res) => {
       "whatsapp.templates",
       "tags.available",
       "golden.windowMinutes",
+      // MB9c — the speed-to-lead SLA duration drives the in-row golden-window clock.
+      "sla.goldenWindowMinutes",
       "golden.workStartHour",
       "golden.workEndHour",
       // MB6 Slice 6: the cockpit reads these without settings permissions.

--- a/models/Enquiry.js
+++ b/models/Enquiry.js
@@ -216,6 +216,11 @@ const EnquirySchema = new mongoose.Schema(
       originalOwnerId: { type: ObjectId, ref: "Admin", default: null },
       resurfacedAt: { type: Date, default: null },
     },
+    // ── MB9c (additive, nullable) — SOFT DELETE. The list "Delete" (founder-only)
+    // sets these; archived leads are excluded from default list queries but are
+    // NEVER hard-removed (recoverable). The ONLY Enquiry change in MB9c.
+    archivedAt: { type: Date, default: null },
+    archivedBy: { type: ObjectId, ref: "Admin", default: null },
   },
   { timestamps: true }
 );

--- a/routes/enquiry.js
+++ b/routes/enquiry.js
@@ -79,6 +79,34 @@ router.post(
   requirePermission("leads:edit:team", { ownerField: "assignedTo" }),
   lifecycle.BulkTransfer
 );
+// ── MB9c — list bulk actions (literal paths above /:_id). Scope-verified in the
+// service. tag/stage/lost gate leads:edit; DELETE (soft) gates leads:delete:all
+// (founder by default — existing RBAC vocab, no new permission).
+const leadBulk = require("../controllers/leadBulk");
+router.post(
+  "/bulk-tag",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own", { ownerField: "assignedTo" }),
+  leadBulk.Tag
+);
+router.post(
+  "/bulk-stage",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own", { ownerField: "assignedTo" }),
+  leadBulk.Stage
+);
+router.post(
+  "/bulk-lost",
+  CheckAdminLogin,
+  requirePermission("leads:edit:own", { ownerField: "assignedTo" }),
+  leadBulk.Lost
+);
+router.post(
+  "/bulk-archive",
+  CheckAdminLogin,
+  requirePermission("leads:delete:all", { ownerField: "assignedTo" }),
+  leadBulk.Archive
+);
 // ── MB8a Slice 3 — leads I'm on the team for (additive "my leads" surface).
 // Literal path: MUST stay above /:_id. Roster-scoped inside the controller; no
 // ownerField narrowing (the roster IS the soft grant), no 403 gating added.

--- a/scripts/verify-mb9c.js
+++ b/scripts/verify-mb9c.js
@@ -1,0 +1,88 @@
+/* MB9c — lead-list bulk actions + soft-delete. Verifies bulk tag/stage/lost,
+ * scope rejection of out-of-scope batches, the FOUNDER-only soft-delete (a
+ * non-founder gets 403; soft-delete sets archivedAt, is recoverable/not hard-
+ * removed, excluded from the list, and audited). Test port 8163. */
+require("dotenv").config();
+const { spawn } = require("child_process");
+const mongoose = require("mongoose");
+const jwt = require("jsonwebtoken");
+
+const PORT = 8163; const BASE = `http://localhost:${PORT}`; const MARK = "MB9C";
+let pass = 0, fail = 0; const failures = [];
+const ok = (c, l) => { if (c) { pass++; console.log(`  ✓ ${l}`); } else { fail++; failures.push(l); console.error(`  ✗ ${l}`); } };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const waitFor = async (fn, l, t = 30000) => { const u = Date.now() + t; while (Date.now() < u) { try { const v = await fn(); if (v) return v; } catch (_) {} await sleep(300); } throw new Error(`waitFor: ${l}`); };
+
+(async () => {
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Admin = require("../models/Admin"); const Role = require("../models/Role"); const Department = require("../models/Department");
+  const Enquiry = require("../models/Enquiry"); const ActivityLog = require("../models/ActivityLog"); const LeadInternalEvent = require("../models/LeadInternalEvent");
+
+  const dept = await Department.create({ name: `${MARK} Dept` });
+  const founderRole = await Role.create({ name: `${MARK} Founder`, departmentId: dept._id, permissions: ["*:*:all"] });
+  const ownRole = await Role.create({ name: `${MARK} Own`, departmentId: dept._id, permissions: ["leads:view:own", "leads:edit:own"] });
+  const u = (s) => `9197${String(Date.now()).slice(-7)}${s}`;
+  const FOUNDER = await Admin.create({ name: `${MARK} Founder`, email: `f-${Date.now()}@t.local`, phone: u(1), password: "x", roleIds: [founderRole._id], departmentId: dept._id, status: "active" });
+  const MEMBER = await Admin.create({ name: `${MARK} Member`, email: `m-${Date.now()}@t.local`, phone: u(2), password: "x", roleIds: [ownRole._id], departmentId: dept._id, status: "active" });
+  const OUTSIDER = await Admin.create({ name: `${MARK} Outsider`, email: `o-${Date.now()}@t.local`, phone: u(3), password: "x", roleIds: [ownRole._id], status: "active" });
+  const fT = jwt.sign({ _id: String(FOUNDER._id), isAdmin: true }, process.env.JWT_SECRET);
+  const mT = jwt.sign({ _id: String(MEMBER._id), isAdmin: true }, process.env.JWT_SECRET);
+
+  const now = Date.now();
+  const mk = (n, owner) => Enquiry.create({ name: `${MARK} ${n}`, phone: `9190${String(now).slice(-7)}${n}`, verified: false, source: "Website", stage: "new", assignedTo: owner, additionalInfo: {} });
+  const a = await mk("A", MEMBER._id); const b = await mk("B", MEMBER._id); const c = await mk("C", MEMBER._id);
+  const outLead = await mk("Out", OUTSIDER._id);
+
+  const child = spawn("node", ["server.js"], { cwd: `${__dirname}/..`, env: { ...process.env, PORT: String(PORT) }, stdio: ["ignore", "pipe", "pipe"] });
+  let log = ""; child.stdout.on("data", (d) => (log += d)); child.stderr.on("data", (d) => (log += d));
+  const api = async (m, p, t, bd) => { const r = await fetch(`${BASE}${p}`, { method: m, headers: { ...(t ? { Authorization: `Bearer ${t}` } : {}), ...(bd ? { "Content-Type": "application/json" } : {}) }, body: bd ? JSON.stringify(bd) : undefined }); let d = null; try { d = await r.json(); } catch (_) {} return { status: r.status, data: d }; };
+
+  try {
+    await waitFor(() => fetch(`${BASE}/`).then((r) => r.ok).catch(() => false), "boot");
+
+    console.log("\n── bulk tag / stage / lost (member, own scope) ──");
+    const tag = await api("POST", "/enquiry/bulk-tag", mT, { leadIds: [String(a._id), String(b._id)], tag: "Premium", mode: "add" });
+    ok(tag.status === 200 && tag.data.updated === 2, "bulk-tag adds a tag to the selection");
+    ok((await Enquiry.findById(a._id).lean()).tags.includes("Premium"), "tag persisted on the lead");
+    const untag = await api("POST", "/enquiry/bulk-tag", mT, { leadIds: [String(a._id)], tag: "Premium", mode: "remove" });
+    ok(untag.status === 200 && !(await Enquiry.findById(a._id).lean()).tags.includes("Premium"), "bulk-tag remove works");
+    const stage = await api("POST", "/enquiry/bulk-stage", mT, { leadIds: [String(a._id), String(b._id)], stage: "contacted" });
+    ok(stage.status === 200 && (await Enquiry.findById(a._id).lean()).stage === "contacted", "bulk-stage moves the selection");
+    const lost = await api("POST", "/enquiry/bulk-lost", mT, { leadIds: [String(c._id)], reason: "budget" });
+    const cDoc = await Enquiry.findById(c._id).lean();
+    ok(lost.status === 200 && cDoc.isLost === true && cDoc.lostStatus === "approved", "bulk-lost marks the selection lost");
+
+    console.log("\n── scope rejection (out-of-scope batch) ──");
+    const oos = await api("POST", "/enquiry/bulk-tag", mT, { leadIds: [String(a._id), String(outLead._id)], tag: "X", mode: "add" });
+    ok(oos.status === 403, "a batch containing an out-of-scope lead is rejected (403)");
+    ok(!((await Enquiry.findById(a._id).lean()).tags || []).includes("X"), "no lead in the rejected batch was tagged");
+
+    console.log("\n── soft-delete: FOUNDER-only ──");
+    const memberDel = await api("POST", "/enquiry/bulk-archive", mT, { leadIds: [String(a._id)] });
+    ok(memberDel.status === 403, "a non-founder cannot delete (leads:delete:all gate → 403)");
+    const founderDel = await api("POST", "/enquiry/bulk-archive", fT, { leadIds: [String(a._id), String(b._id)] });
+    ok(founderDel.status === 200 && founderDel.data.archived === 2, "founder soft-deletes the selection");
+
+    console.log("\n── soft-delete: recoverable + excluded + audited ──");
+    const aDoc = await Enquiry.findById(a._id).lean();
+    ok(aDoc && aDoc.archivedAt && String(aDoc.archivedBy) === String(FOUNDER._id), "archivedAt/By set — the doc still exists (NOT hard-deleted, recoverable)");
+    const list = await api("GET", `/enquiry?search=${MARK}%20A&limit=50`, fT);
+    ok(list.status === 200 && !(list.data.list || []).some((l) => String(l._id) === String(a._id)), "archived lead is excluded from the default list");
+    const audit = await ActivityLog.findOne({ entityId: String(a._id), action: "bulk_archive" }).lean();
+    ok(!!audit, "soft-delete is audited (ActivityLog bulk_archive)");
+  } catch (e) {
+    fail++; failures.push(`fatal: ${e.message}`); console.error("FATAL", e); console.error(log.slice(-2000));
+  } finally {
+    const ids = [a._id, b._id, c._id, outLead._id];
+    await ActivityLog.deleteMany({ entityId: { $in: ids.map(String) } });
+    await LeadInternalEvent.deleteMany({ leadId: { $in: ids } });
+    await Enquiry.deleteMany({ _id: { $in: ids } });
+    await Admin.deleteMany({ _id: { $in: [FOUNDER._id, MEMBER._id, OUTSIDER._id] } });
+    await Role.deleteMany({ _id: { $in: [founderRole._id, ownRole._id] } });
+    await Department.deleteMany({ _id: dept._id });
+    child.kill(); await mongoose.disconnect();
+    console.log(`\n══ RESULT: ${pass} passed, ${fail} failed ══`);
+    if (failures.length) console.log("failures:", failures.join(" | "));
+    process.exit(fail === 0 ? 0 : 1);
+  }
+})();

--- a/services/FunnelMetricsService.js
+++ b/services/FunnelMetricsService.js
@@ -66,7 +66,7 @@ const funnel = async (adminId, scope, { period = "week" } = {}, now = new Date()
   const since = new Date(+now - periodDays * DAY);
   const owners = await GoldenWindowService.ownerScopeIds(adminId, scope); // null = all
 
-  const leadFilter = { createdAt: { $gte: since } };
+  const leadFilter = { createdAt: { $gte: since }, archivedAt: null };
   if (owners) leadFilter.assignedTo = { $in: owners.map((o) => new mongoose.Types.ObjectId(idStr(o))) };
   const leads = await Enquiry.find(leadFilter, {
     assignedTo: 1, createdAt: 1, firstCalledAt: 1, qualified: 1, isLost: 1, lostStatus: 1, recycled: 1, name: 1,

--- a/services/GoldenWindowService.js
+++ b/services/GoldenWindowService.js
@@ -100,6 +100,7 @@ const respondNow = async (adminId, now = new Date()) => {
       qualified: { $ne: true },
       isLost: { $ne: true },
       "recycled.isRecycled": { $ne: true },
+      archivedAt: null,
       createdAt: { $gte: new Date(+now - RESPOND_HORIZON_MS) },
     },
     { name: 1, phone: 1, source: 1, marketingSource: 1, createdAt: 1, firstCalledAt: 1, qualified: 1, isLost: 1, recycled: 1 }
@@ -142,7 +143,7 @@ const ownerScopeIds = async (adminId, scope) => {
 const metrics = async (adminId, scope, { periodDays = 7 } = {}, now = new Date()) => {
   const owners = await ownerScopeIds(adminId, scope);
   const since = new Date(+now - periodDays * 24 * 60 * MIN);
-  const filter = { createdAt: { $gte: since }, isLost: { $ne: true }, "recycled.isRecycled": { $ne: true } };
+  const filter = { createdAt: { $gte: since }, isLost: { $ne: true }, "recycled.isRecycled": { $ne: true }, archivedAt: null };
   if (owners) filter.assignedTo = { $in: owners.map((o) => new mongoose.Types.ObjectId(idStr(o))) };
   const leads = await Enquiry.find(filter, { createdAt: 1, firstCalledAt: 1, qualified: 1, isLost: 1, recycled: 1 }).lean();
   const t = await thresholds();

--- a/services/JourneyDashboardService.js
+++ b/services/JourneyDashboardService.js
@@ -130,7 +130,7 @@ const pipelineOverview = async (adminId, scope, { phase, stuckOnly, memberId } =
   let leads;
   if (scope === "all") {
     leads = await Enquiry.find(
-      { isLost: { $ne: true }, "recycled.isRecycled": { $ne: true } },
+      { isLost: { $ne: true }, "recycled.isRecycled": { $ne: true }, archivedAt: null },
       { name: 1, stage: 1, assignedTo: 1 }
     ).lean();
   } else {

--- a/services/LeadBulkService.js
+++ b/services/LeadBulkService.js
@@ -1,0 +1,78 @@
+const mongoose = require("mongoose");
+const Enquiry = require("../models/Enquiry");
+const LeadInternalEventService = require("./LeadInternalEventService");
+const ActivityLogService = require("./ActivityLogService");
+
+const httpError = (status, message) => Object.assign(new Error(message), { status });
+const isId = (v) => mongoose.Types.ObjectId.isValid(v);
+const MAX = 200;
+
+// Validate the id list + verify EVERY lead is within the caller's scope (mirrors
+// LeadLifecycleService.bulkTransfer — out-of-scope ⇒ the whole batch is rejected).
+const assertScopedIds = async (leadIds, scopeFilter) => {
+  if (!Array.isArray(leadIds) || leadIds.length === 0) throw httpError(400, "leadIds must be a non-empty array");
+  if (leadIds.length > MAX) throw httpError(400, `Max ${MAX} leads per action`);
+  for (const id of leadIds) if (!isId(id)) throw httpError(400, `Invalid lead id: ${id}`);
+  const inScope = await Enquiry.find({ $and: [{ _id: { $in: leadIds } }, scopeFilter || {}] }, { _id: 1 }).lean();
+  const inScopeIds = new Set(inScope.map((l) => String(l._id)));
+  const out = leadIds.filter((id) => !inScopeIds.has(String(id)));
+  if (out.length) throw httpError(403, `Out of your scope: ${out.length} lead(s) — batch rejected`);
+  return leadIds;
+};
+
+const audit = async (actorId, action, leadIds, meta) => {
+  for (const id of leadIds) {
+    await ActivityLogService.record({ actorId, action, entityType: "lead", entityId: String(id), summary: meta.summary, meta });
+  }
+};
+
+// Add or remove a tag across the selection (atomic $addToSet / $pull).
+const bulkTag = async ({ leadIds, tag, mode = "add" } = {}, actorId, scopeFilter) => {
+  const clean = String(tag || "").trim();
+  if (!clean) throw httpError(400, "A tag is required");
+  await assertScopedIds(leadIds, scopeFilter);
+  const update = mode === "remove" ? { $pull: { tags: clean } } : { $addToSet: { tags: clean } };
+  await Enquiry.updateMany({ _id: { $in: leadIds } }, update);
+  await audit(actorId, "bulk_tag", leadIds, { summary: `${mode === "remove" ? "Removed" : "Added"} tag "${clean}"`, tag: clean, mode });
+  return { updated: leadIds.length, tag: clean, mode };
+};
+
+// Move the selection to a stage.
+const bulkStage = async ({ leadIds, stage } = {}, actorId, scopeFilter) => {
+  const clean = String(stage || "").trim();
+  if (!clean) throw httpError(400, "A stage is required");
+  await assertScopedIds(leadIds, scopeFilter);
+  await Enquiry.updateMany({ _id: { $in: leadIds } }, { $set: { stage: clean, updatedBy: actorId || null } });
+  for (const id of leadIds) {
+    await LeadInternalEventService.record({ leadId: id, type: "stage_changed", actorId, payload: { stage: clean, bulk: true } });
+  }
+  await audit(actorId, "bulk_stage", leadIds, { summary: `Moved to stage "${clean}"`, stage: clean });
+  return { updated: leadIds.length, stage: clean };
+};
+
+// Mark the selection lost (a direct managerial action — distinct from the
+// single-lead request/approve disqualify flow). Sets the approved-lost state.
+const bulkLost = async ({ leadIds, reason = "" } = {}, actorId, scopeFilter) => {
+  await assertScopedIds(leadIds, scopeFilter);
+  const now = new Date();
+  await Enquiry.updateMany(
+    { _id: { $in: leadIds } },
+    { $set: { isLost: true, lostStatus: "approved", lostReason: String(reason || "").slice(0, 200), lostDecidedBy: actorId || null, lostDecidedAt: now, updatedBy: actorId || null } }
+  );
+  for (const id of leadIds) {
+    await LeadInternalEventService.record({ leadId: id, type: "transferred", actorId, payload: { reason: "bulk_lost", lostReason: reason || "" } });
+  }
+  await audit(actorId, "bulk_lost", leadIds, { summary: `Marked lost${reason ? ` (${reason})` : ""}`, reason });
+  return { updated: leadIds.length };
+};
+
+// SOFT DELETE — recoverable. Sets archivedAt/archivedBy; NEVER hard-removes.
+// Route-gated to leads:delete:all (founder) on top of this.
+const bulkArchive = async ({ leadIds } = {}, actorId, scopeFilter) => {
+  await assertScopedIds(leadIds, scopeFilter);
+  await Enquiry.updateMany({ _id: { $in: leadIds } }, { $set: { archivedAt: new Date(), archivedBy: actorId || null } });
+  await audit(actorId, "bulk_archive", leadIds, { summary: "Soft-deleted (archived, recoverable)" });
+  return { archived: leadIds.length };
+};
+
+module.exports = { assertScopedIds, bulkTag, bulkStage, bulkLost, bulkArchive };

--- a/services/RescueService.js
+++ b/services/RescueService.js
@@ -45,6 +45,7 @@ const rescueQueue = async (adminId, scope, now = new Date()) => {
     qualified: { $ne: true },
     isLost: { $ne: true },
     "recycled.isRecycled": { $ne: true },
+    archivedAt: null,
     createdAt: { $gte: new Date(+now - HORIZON_MS) },
   };
   if (scope !== "all") {


### PR DESCRIPTION
LeadBulkService: bulk tag/stage/lost + founder-only soft-delete (archivedAt/archivedBy, recoverable, never hard-removed). Each action scope-verified (out-of-scope lead rejects whole batch 403), audited via ActivityLogService. Delete gated requirePermission('leads:delete:all') (existing founder wildcard, no new vocab). Archived excluded from list + golden/pipeline/funnel/rescue aggregations. Only Enquiry change: additive nullable archivedAt/archivedBy. requirePermission/rbacPermissions untouched. 12/12 + regressions (MB8c-1 29/29 undisturbed).