### PR TITLE
MB10: Org & Access — org chart + permission matrix + multi-hat add-person + write-route scope sweep

### DIFF
--- a/controllers/admin.js
+++ b/controllers/admin.js
@@ -5,6 +5,7 @@ const Role = require("../models/Role");
 const Department = require("../models/Department");
 const { CreateHash } = require("../utils/password");
 const ActivityLogService = require("../services/ActivityLogService");
+const PeopleService = require("../services/PeopleService");
 
 // Legacy roles[] kept in sync with the RBAC role's department so legacy gates
 // stay consistent (schema enum: owner|crm|sales|ops|finance).
@@ -38,23 +39,24 @@ const GetAll = async (req, res) => {
   }
 };
 
-// POST /admin — founder-gated via users:create:all
+// POST /admin — founder-gated via users:create:all.
+// MB10: accepts the simple single-hat body OR a hats[] array (multi-hat). Permissions
+// = the UNION of every hat's role (roleIds[]); the primary hat mirrors the live
+// top-level departmentId/roleId/reportingManagerId. Guardrails: reporting cycles,
+// founder-grant (only a founder may assign Founder), email uniqueness.
 const CreateAdmin = async (req, res) => {
   try {
-    const { name, email, password, roleId, departmentId, reportingManagerId } =
-      req.body || {};
+    const { name, email, password } = req.body || {};
 
-    if (!name || !email || !password || !roleId || !departmentId) {
+    if (!name || !email || !password) {
       return res.status(400).json({
-        message: "name, email, password, roleId, and departmentId are required.",
+        message: "name, email, and password are required.",
       });
     }
-    if (
-      !mongoose.isValidObjectId(roleId) ||
-      !mongoose.isValidObjectId(departmentId) ||
-      (reportingManagerId && !mongoose.isValidObjectId(reportingManagerId))
-    ) {
-      return res.status(400).json({ message: "Invalid id format." });
+
+    const rawHats = PeopleService.normalizeHats(req.body || {});
+    if (!rawHats.length) {
+      return res.status(400).json({ message: "At least one (department, role) hat is required." });
     }
 
     const existing = await Admin.findOne({ email: String(email).trim() });
@@ -64,27 +66,12 @@ const CreateAdmin = async (req, res) => {
         .json({ message: "An account with this email already exists." });
     }
 
-    const role = await Role.findById(roleId).lean();
-    if (!role) {
-      return res.status(400).json({ message: "roleId does not match any role." });
-    }
-    const department = await Department.findById(departmentId).lean();
-    if (!department) {
-      return res
-        .status(400)
-        .json({ message: "departmentId does not match any department." });
-    }
+    const resolved = await PeopleService.resolveHats(rawHats);
+    await PeopleService.assertNotGrantingFounder(resolved.roleIds, req.auth.user_id);
+    await PeopleService.assertNoReportingCycle(null, resolved.hats);
 
-    let managerId = null;
-    if (reportingManagerId) {
-      const manager = await Admin.findById(reportingManagerId).lean();
-      if (!manager) {
-        return res
-          .status(400)
-          .json({ message: "reportingManagerId does not match any user." });
-      }
-      managerId = manager._id;
-    }
+    // Legacy roles[] derive from the PRIMARY hat's role/department.
+    const primaryRole = await Role.findById(resolved.primary.roleId).lean();
 
     const hashed = await CreateHash(password);
     const created = await Admin.create({
@@ -92,11 +79,10 @@ const CreateAdmin = async (req, res) => {
       email: String(email).trim(),
       phone: "PENDING",
       password: hashed,
-      roles: await legacyRolesForRole(role),
-      roleId,
-      departmentId,
-      reportingManagerId: managerId,
+      roles: await legacyRolesForRole(primaryRole),
       status: "active",
+      joinedAt: new Date(),
+      ...PeopleService.fieldsFromHats(resolved),
     });
 
     // Invite email (Lifecycle Slice G — ships dark until the template id exists).
@@ -119,6 +105,7 @@ const CreateAdmin = async (req, res) => {
     delete safe.password;
     return res.status(201).json(safe);
   } catch (error) {
+    if (error.status) return res.status(error.status).json({ message: error.message });
     return res.status(500).json({ message: "Server error" });
   }
 };
@@ -139,6 +126,35 @@ const UpdateAdmin = async (req, res) => {
 
     const body = req.body || {};
     const update = {};
+
+    // MB10 multi-hat path: an explicit hats[] replaces the person's (department,
+    // role, manager) hats wholesale. Mirrors the primary hat to the top-level
+    // fields + sets roleIds union. Guardrails: founder-grant + transitive cycle.
+    if (Array.isArray(body.hats)) {
+      const rawHats = PeopleService.normalizeHats(body);
+      const resolved = await PeopleService.resolveHats(rawHats);
+      await PeopleService.assertNotGrantingFounder(resolved.roleIds, req.auth.user_id);
+      await PeopleService.assertNoReportingCycle(target._id, resolved.hats);
+      const primaryRole = await Role.findById(resolved.primary.roleId).lean();
+      Object.assign(update, PeopleService.fieldsFromHats(resolved), {
+        roles: await legacyRolesForRole(primaryRole),
+      });
+      if (body.status !== undefined) {
+        if (!STATUS_VALUES.includes(body.status)) {
+          return res.status(400).json({ message: "status must be one of: active, inactive, on_leave." });
+        }
+        update.status = body.status;
+      }
+      if (body.phone !== undefined && typeof body.phone === "string" && body.phone.trim()) {
+        update.phone = body.phone.trim();
+      }
+      const updatedHats = await Admin.findByIdAndUpdate(
+        id,
+        { $set: update },
+        { new: true, runValidators: true, projection: { password: 0 } }
+      ).lean();
+      return res.status(200).json(updatedHats);
+    }
 
     // Lifecycle Slice I: phone is editable (fixes the seeded "PENDING" phones).
     if (body.phone !== undefined) {
@@ -192,17 +208,16 @@ const UpdateAdmin = async (req, res) => {
         if (!mongoose.isValidObjectId(body.reportingManagerId)) {
           return res.status(400).json({ message: "Invalid reportingManagerId format." });
         }
-        if (String(body.reportingManagerId) === String(target._id)) {
-          return res
-            .status(400)
-            .json({ message: "A user cannot report to themselves." });
-        }
         const manager = await Admin.findById(body.reportingManagerId).lean();
         if (!manager) {
           return res
             .status(400)
             .json({ message: "reportingManagerId does not match any user." });
         }
+        // Transitive cycle guard (A→B→…→A), not just direct self-report.
+        await PeopleService.assertNoReportingCycle(target._id, [
+          { reportingManagerId: manager._id },
+        ]);
         update.reportingManagerId = manager._id;
       }
     }
@@ -214,6 +229,7 @@ const UpdateAdmin = async (req, res) => {
     ).lean();
     return res.status(200).json(updated);
   } catch (error) {
+    if (error.status) return res.status(error.status).json({ message: error.message });
     return res.status(500).json({ message: "Server error" });
   }
 };

--- a/controllers/org.js
+++ b/controllers/org.js
@@ -1,0 +1,24 @@
+const OrgService = require("../services/OrgService");
+
+// GET /org/chart — the reporting tree (read-only). Gated users:view:all.
+const Chart = async (req, res) => {
+  try {
+    const result = await OrgService.chart();
+    res.status(200).json(result);
+  } catch (error) {
+    res.status(error.status || 500).json({ message: error.status ? error.message : "Server error" });
+  }
+};
+
+// GET /org/permission-matrix — roles × resource:action scopes (read-only).
+// Gated roles:view:all. Edits route through the EXISTING PUT /role/:id.
+const PermissionMatrix = async (req, res) => {
+  try {
+    const result = await OrgService.permissionMatrix(req.auth.user_id);
+    res.status(200).json(result);
+  } catch (error) {
+    res.status(error.status || 500).json({ message: error.status ? error.message : "Server error" });
+  }
+};
+
+module.exports = { Chart, PermissionMatrix };

--- a/middlewares/enforceLeadScope.js
+++ b/middlewares/enforceLeadScope.js
@@ -1,0 +1,39 @@
+const mongoose = require("mongoose");
+const Enquiry = require("../models/Enquiry");
+
+// MB10 Slice 4 — per-document scope enforcement for lead WRITE routes.
+//
+// Background: requirePermission already gates that the caller HOLDS the permission
+// and computes req.scope + req.scopeFilter (the same own/team/department/all filter
+// used to scope READS). But a single-lead write addressed by :_id never applied that
+// filter — so an in-scope-on-paper caller who knew an ID could write a lead OUTSIDE
+// their scope. This middleware closes that gap: it runs AFTER
+//   requirePermission("leads:edit:own", { ownerField: "assignedTo" })
+// and rejects the write unless the :_id lead falls within req.scopeFilter.
+//
+// all-scope (founder) ⇒ scopeFilter is {} ⇒ every lead matches ⇒ writes freely.
+// team/department ⇒ matches leads owned within the team/dept. own ⇒ assignedTo self.
+// Fail-closed: a missing/invalid id or a lead outside scope is rejected.
+const enforceLeadScope = (param = "_id") => async (req, res, next) => {
+  try {
+    const id = req.params[param];
+    if (!mongoose.isValidObjectId(id)) {
+      return res.status(400).json({ message: "Invalid lead id." });
+    }
+    const scopeFilter = req.scopeFilter || {};
+    const inScope = await Enquiry.findOne({ $and: [{ _id: id }, scopeFilter] })
+      .select("_id")
+      .lean();
+    if (inScope) return next();
+    // Distinguish out-of-scope (lead exists) from genuinely missing, without
+    // leaking lead data either way.
+    const exists = await Enquiry.exists({ _id: id });
+    return res
+      .status(exists ? 403 : 404)
+      .json({ message: exists ? "Forbidden: lead is outside your scope." : "Lead not found." });
+  } catch (error) {
+    return res.status(500).json({ message: error.message });
+  }
+};
+
+module.exports = { enforceLeadScope };

--- a/models/Admin.js
+++ b/models/Admin.js
@@ -15,6 +15,24 @@ const AdminSchema = new mongoose.Schema(
     roleIds: { type: [{ type: ObjectId, ref: "Role" }], default: [] },
     departmentId: { type: ObjectId, ref: "Department", default: null },
     reportingManagerId: { type: ObjectId, ref: "Admin", default: null },
+    // --- MB10 (additive, optional) — MULTI-HAT. A person can carry >1
+    // (department, role, manager) hat. hats[0] is the PRIMARY hat and ALWAYS
+    // mirrors the live top-level departmentId/roleId/reportingManagerId above,
+    // which remain the single authoritative anchor for scope resolution
+    // (getDepartmentMemberIds(departmentId) + reportingManagerId traversal —
+    // UNCHANGED). Secondary hats only add their role to roleIds[] (the existing
+    // permission UNION) and render as dotted edges in the org chart. Empty hats[]
+    // ⇒ the primary hat is reconstructed from the top-level fields (back-compat).
+    hats: {
+      type: [
+        {
+          departmentId: { type: ObjectId, ref: "Department", default: null },
+          roleId: { type: ObjectId, ref: "Role", default: null },
+          reportingManagerId: { type: ObjectId, ref: "Admin", default: null },
+        },
+      ],
+      default: [],
+    },
     status: { type: String, enum: ["active", "inactive", "on_leave"], default: "active" },
     joinedAt: { type: Date, default: null },
     // Lifecycle (additive): round-robin auto-assignment cursor (least-recently-assigned wins).

--- a/routes/enquiry.js
+++ b/routes/enquiry.js
@@ -10,6 +10,13 @@ const enquiryImport = require("../controllers/enquiry-import");
 const fileUpload = require("express-fileupload");
 const { CheckLogin, CheckAdminLogin } = require("../middlewares/auth");
 const { requirePermission } = require("../middlewares/requirePermission");
+// MB10 Slice 4 — per-document scope check on lead WRITE routes (runs after the
+// requirePermission gate that sets req.scopeFilter via ownerField "assignedTo").
+const { enforceLeadScope } = require("../middlewares/enforceLeadScope");
+const LEADS_EDIT_SCOPED = [
+  requirePermission("leads:edit:own", { ownerField: "assignedTo" }),
+  enforceLeadScope("_id"),
+];
 
 router.post("/", enquiry.CreateNew);
 router.get("/", CheckAdminLogin, requirePermission("leads:view:own", { ownerField: "assignedTo" }), enquiry.GetAll);
@@ -184,9 +191,12 @@ router.delete(
   CheckAdminLogin,
   enquiry.DeleteConversation
 );
-router.put("/:_id/", CheckAdminLogin, enquiry.UpdateLead);
-router.put("/:_id/notes", CheckAdminLogin, enquiry.UpdateNotes);
-router.put("/:_id/call", CheckAdminLogin, enquiry.UpdateCallSchedule);
+// MB10 Slice 4 — write-route scope sweep: these mutate a single lead by :_id and
+// were previously CheckAdminLogin-only (any logged-in admin could write any lead).
+// Now scope-gated consistent with reads.
+router.put("/:_id/", CheckAdminLogin, ...LEADS_EDIT_SCOPED, enquiry.UpdateLead);
+router.put("/:_id/notes", CheckAdminLogin, ...LEADS_EDIT_SCOPED, enquiry.UpdateNotes);
+router.put("/:_id/call", CheckAdminLogin, ...LEADS_EDIT_SCOPED, enquiry.UpdateCallSchedule);
 router.put(
   "/:_id/first-call",
   CheckAdminLogin,
@@ -418,7 +428,7 @@ router.put(
 router.post(
   "/:_id/note",
   CheckAdminLogin,
-  requirePermission("leads:edit:own"),
+  ...LEADS_EDIT_SCOPED,
   lifecycle.AddNote
 );
 router.put(
@@ -480,13 +490,16 @@ router.post(
   requirePermission("leads:edit:own"),
   lifecycle.Convert
 );
-router.put("/:_id/stage", CheckAdminLogin, enquiryPipeline.UpdateStage);
-router.put("/:_id/assign", CheckAdminLogin, enquiryPipeline.UpdateAssignedTo);
-// Requesting a disqualification needs edit rights on the lead (Sales Executive has leads:edit:own).
+// MB10 Slice 4 — stage + assign were CheckAdminLogin-only; now scope-gated.
+router.put("/:_id/stage", CheckAdminLogin, ...LEADS_EDIT_SCOPED, enquiryPipeline.UpdateStage);
+router.put("/:_id/assign", CheckAdminLogin, ...LEADS_EDIT_SCOPED, enquiryPipeline.UpdateAssignedTo);
+// Requesting a disqualification needs edit rights on the lead (Sales Executive has
+// leads:edit:own). MB10 Slice 4: now also scope-checked per-document (ownerField +
+// enforceLeadScope) so an out-of-scope caller cannot mark a lead disqualified.
 router.post(
   "/:_id/disqualify",
   CheckAdminLogin,
-  requirePermission("leads:edit:own"),
+  ...LEADS_EDIT_SCOPED,
   disqualify.RequestDisqualify
 );
 // No requirePermission here — eligibility (manager OR leads:approve) is computed in the controller.

--- a/routes/org.js
+++ b/routes/org.js
@@ -1,0 +1,14 @@
+const express = require("express");
+const router = express.Router();
+
+const org = require("../controllers/org");
+const { CheckAdminLogin } = require("../middlewares/auth");
+const { requirePermission } = require("../middlewares/requirePermission");
+
+// MB10 Org & Access — read-only views over the live RBAC. Existing vocab only:
+// the org chart is user-management info (users:view:all — founder *:*:all + CRM
+// Admin users:*:all); the matrix is role info (roles:view:all — same holders).
+router.get("/chart", CheckAdminLogin, requirePermission("users:view:all"), org.Chart);
+router.get("/permission-matrix", CheckAdminLogin, requirePermission("roles:view:all"), org.PermissionMatrix);
+
+module.exports = router;

--- a/routes/router.js
+++ b/routes/router.js
@@ -75,6 +75,7 @@ router.use("/vendor-review", require("./vendor-review"));
 router.use("/admin", require("./admin"));
 router.use("/department", require("./department"));
 router.use("/role", require("./role"));
+router.use("/org", require("./org")); // MB10 — org chart + permission matrix (read)
 router.use("/stages", require("./stage"));
 router.use("/activity", require("./activity"));
 router.use("/venues", require("./venue"));

--- a/scripts/verify-mb10.js
+++ b/scripts/verify-mb10.js
@@ -1,0 +1,193 @@
+/* MB10 Org & Access — verifies all 4 slices over HTTP on test port 8166.
+ * S1 org chart (tree from reportingManagerId, dept grouping, multi-hat edges + gate).
+ * S2 permission matrix (cells reflect stored scopes; edit routes through PUT /role/:id;
+ *    founder immutable + protected-not-strippable guardrails; read gate).
+ * S3 add/edit person (single + multi-hat union; email-dup; reporting cycle;
+ *    only-founder-assigns-Founder; joinedAt).
+ * S4 write-route scope sweep (own writes own only; team writes team; founder writes all;
+ *    out-of-scope 403; reads unchanged). Self-cleaning. */
+require("dotenv").config();
+const { spawn } = require("child_process");
+const mongoose = require("mongoose");
+const jwt = require("jsonwebtoken");
+
+const PORT = 8166;
+const BASE = `http://localhost:${PORT}`;
+const MARK = "MB10V";
+let pass = 0, fail = 0; const failures = [];
+const ok = (c, l) => { if (c) { pass++; console.log(`  ✓ ${l}`); } else { fail++; failures.push(l); console.error(`  ✗ ${l}`); } };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const waitFor = async (fn, l, t = 30000) => { const u = Date.now() + t; while (Date.now() < u) { try { if (await fn()) return true; } catch (_) {} await sleep(300); } throw new Error(`waitFor: ${l}`); };
+
+(async () => {
+  await mongoose.connect(process.env.DATABASE_URL);
+  const Admin = require("../models/Admin");
+  const Role = require("../models/Role");
+  const Department = require("../models/Department");
+  const Enquiry = require("../models/Enquiry");
+  const { CreateHash } = require("../utils/password");
+
+  const created = { admins: [], roles: [], depts: [], leads: [] };
+  const u = (n) => `9111${String(Date.now()).slice(-6)}${n}`;
+  const pw = await CreateHash("secret123");
+
+  // ── Departments
+  const dF = await Department.create({ name: `${MARK} Founders` });
+  const dS = await Department.create({ name: `${MARK} Sales` });
+  const dO = await Department.create({ name: `${MARK} Ops` });
+  created.depts.push(dF._id, dS._id, dO._id);
+
+  // ── Roles (existing vocab only)
+  const rFounder = await Role.create({ name: `${MARK} Founder`, departmentId: dF._id, permissions: ["*:*:all"], systemKey: "founder", protected: true });
+  const rCrmAdmin = await Role.create({ name: `${MARK} CRM Admin`, departmentId: dF._id, permissions: ["users:*:all", "roles:*:all", "settings:*:all"] });
+  const rMgr = await Role.create({ name: `${MARK} Sales Manager`, departmentId: dS._id, permissions: ["leads:view:team", "leads:edit:team", "leads:assign:team"] });
+  const rExec = await Role.create({ name: `${MARK} Sales Executive`, departmentId: dS._id, permissions: ["leads:view:own", "leads:edit:own"] });
+  const rOps = await Role.create({ name: `${MARK} Ops Exec`, departmentId: dO._id, permissions: ["projects:view:own", "tasks:view:own"] });
+  const rProtected = await Role.create({ name: `${MARK} Protected`, departmentId: dS._id, permissions: ["leads:view:own"], protected: true });
+  created.roles.push(rFounder._id, rCrmAdmin._id, rMgr._id, rExec._id, rOps._id, rProtected._id);
+
+  // ── Admins (the reporting tree)
+  const mk = async (name, roleIds, deptId, mgr) => {
+    const a = await Admin.create({ name: `${MARK} ${name}`, email: `${name.toLowerCase()}-${Date.now()}@mb10.local`, phone: u(name.length), password: pw, roles: ["crm"], roleIds, roleId: roleIds[0], departmentId: deptId, reportingManagerId: mgr || null, status: "active" });
+    created.admins.push(a._id);
+    return a;
+  };
+  const FOUNDER = await mk("Founder", [rFounder._id], dF._id, null);
+  const CRMADMIN = await mk("CrmAdmin", [rCrmAdmin._id], dF._id, FOUNDER._id);
+  const MANAGER = await mk("Manager", [rMgr._id], dS._id, FOUNDER._id);
+  const EXEC_A = await mk("ExecA", [rExec._id], dS._id, MANAGER._id);
+  const EXEC_B = await mk("ExecB", [rExec._id], dS._id, MANAGER._id);
+  const OUTSIDER = await mk("Outsider", [rExec._id], dS._id, FOUNDER._id); // not under MANAGER
+  const tok = (a) => jwt.sign({ _id: String(a._id), isAdmin: true }, process.env.JWT_SECRET);
+
+  // ── Leads
+  const mkLead = async (name, owner) => {
+    const l = await Enquiry.create({ name: `${MARK} ${name}`, phone: u(`L${name.length}`), verified: false, source: "Website", stage: "new", assignedTo: owner._id, additionalInfo: {} });
+    created.leads.push(l._id);
+    return l;
+  };
+  const leadA = await mkLead("LeadA", EXEC_A);
+  const leadB = await mkLead("LeadB", EXEC_B);
+  const leadOut = await mkLead("LeadOut", OUTSIDER);
+
+  const child = spawn("node", ["server.js"], { cwd: `${__dirname}/..`, env: { ...process.env, PORT: String(PORT) }, stdio: ["ignore", "pipe", "pipe"] });
+  let log = ""; child.stdout.on("data", (d) => (log += d)); child.stderr.on("data", (d) => (log += d));
+  const api = async (method, p, token, body) => {
+    const r = await fetch(`${BASE}${p}`, { method, headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }, body: body ? JSON.stringify(body) : undefined });
+    let d = null; try { d = await r.json(); } catch (_) {}
+    return { status: r.status, data: d };
+  };
+
+  try {
+    await waitFor(() => fetch(`${BASE}/`).then((r) => r.ok).catch(() => false), "boot");
+
+    console.log("\n── Slice 1: org chart ──");
+    const chart = await api("GET", "/org/chart", tok(FOUNDER));
+    ok(chart.status === 200, `GET /org/chart 200 for founder (got ${chart.status})`);
+    const nodeIds = new Set((chart.data.nodes || []).map((n) => n._id));
+    ok(nodeIds.has(String(EXEC_A._id)) && nodeIds.has(String(MANAGER._id)), "chart includes our people");
+    const edges = chart.data.edges || [];
+    const hasEdge = (from, to, type) => edges.some((e) => e.from === String(from._id) && e.to === String(to._id) && (!type || e.type === type));
+    ok(hasEdge(MANAGER, FOUNDER, "primary"), "primary edge MANAGER -> FOUNDER");
+    ok(hasEdge(EXEC_A, MANAGER, "primary"), "primary edge EXEC_A -> MANAGER");
+    const salesGroup = (chart.data.departments || []).find((d) => d.departmentId === String(dS._id));
+    ok(salesGroup && salesGroup.members.some((m) => m._id === String(EXEC_A._id)), "department grouping: EXEC_A under Sales");
+    ok((await api("GET", "/org/chart", tok(EXEC_A))).status === 403, "chart gated: EXEC_A (no users:view:all) -> 403");
+
+    // Multi-hat: give EXEC_A a 2nd hat (Ops Exec, reporting to MANAGER) via PUT /admin.
+    const hatEdit = await api("PUT", `/admin/${EXEC_A._id}`, tok(FOUNDER), {
+      hats: [
+        { departmentId: String(dS._id), roleId: String(rExec._id), reportingManagerId: String(MANAGER._id) },
+        { departmentId: String(dO._id), roleId: String(rOps._id), reportingManagerId: String(MANAGER._id) },
+      ],
+    });
+    ok(hatEdit.status === 200, `multi-hat PUT /admin 200 (got ${hatEdit.status})`);
+    ok((hatEdit.data.roleIds || []).length === 2, `roleIds union = 2 (got ${(hatEdit.data.roleIds || []).length})`);
+    ok(String(hatEdit.data.departmentId) === String(dS._id), "primary hat mirrors top-level departmentId (Sales)");
+    const chart2 = await api("GET", "/org/chart", tok(FOUNDER));
+    const execNode = (chart2.data.nodes || []).find((n) => n._id === String(EXEC_A._id));
+    ok(execNode && execNode.hatCount === 2, `EXEC_A renders 2 hats (got ${execNode && execNode.hatCount})`);
+    ok((chart2.data.edges || []).some((e) => e.from === String(EXEC_A._id) && e.type === "secondary"), "secondary (dotted) edge for 2nd hat");
+
+    console.log("\n── Slice 2: permission matrix ──");
+    const mtx = await api("GET", "/org/permission-matrix", tok(FOUNDER));
+    ok(mtx.status === 200, `GET /org/permission-matrix 200 (got ${mtx.status})`);
+    const row = (id) => (mtx.data.roles || []).find((r) => r._id === String(id));
+    ok(row(rMgr._id) && row(rMgr._id).cells["leads:edit"] === "team", `manager cell leads:edit = team (got ${row(rMgr._id) && row(rMgr._id).cells["leads:edit"]})`);
+    ok(row(rExec._id) && row(rExec._id).cells["leads:edit"] === "own", "exec cell leads:edit = own");
+    ok(row(rFounder._id) && row(rFounder._id).locked === true, "founder row locked");
+    ok(row(rFounder._id) && row(rFounder._id).cells["leads:edit"] === "all", "founder *:*:all reads as 'all' in every cell");
+    ok((await api("GET", "/org/permission-matrix", tok(EXEC_A))).status === 403, "matrix gated: EXEC_A (no roles:view:all) -> 403");
+
+    // Edit a cell THROUGH the existing PUT /role/:id (add leads:view:team to exec).
+    const editCell = await api("PUT", `/role/${rExec._id}`, tok(FOUNDER), { permissions: ["leads:view:team", "leads:edit:own"] });
+    ok(editCell.status === 200, `cell edit via PUT /role/:id 200 (got ${editCell.status})`);
+    const mtx2 = await api("GET", "/org/permission-matrix", tok(FOUNDER));
+    ok(mtx2.data.roles.find((r) => r._id === String(rExec._id)).cells["leads:view"] === "team", "matrix reflects the edit (leads:view now team)");
+
+    // Guardrails (already enforced by RoleService — confirm via the same path):
+    ok((await api("PUT", `/role/${rFounder._id}`, tok(FOUNDER), { permissions: ["leads:view:own"] })).status === 422, "founder role immutable (422) even for founder");
+    ok((await api("PUT", `/role/${rProtected._id}`, tok(FOUNDER), { permissions: [] })).status === 403, "protected role cannot be stripped (403)");
+
+    console.log("\n── Slice 3: add / edit person (multi-hat) ──");
+    const single = await api("POST", "/admin", tok(FOUNDER), { name: `${MARK} NewSingle`, email: `single-${Date.now()}@mb10.local`, password: "secret123", departmentId: String(dS._id), roleId: String(rExec._id), reportingManagerId: String(MANAGER._id) });
+    ok(single.status === 201, `single-hat create 201 (got ${single.status})`);
+    if (single.data && single.data._id) created.admins.push(single.data._id);
+    ok(single.data && single.data.joinedAt, "joinedAt stamped on create");
+
+    const multi = await api("POST", "/admin", tok(FOUNDER), { name: `${MARK} NewMulti`, email: `multi-${Date.now()}@mb10.local`, password: "secret123", hats: [ { departmentId: String(dS._id), roleId: String(rExec._id), reportingManagerId: String(MANAGER._id) }, { departmentId: String(dO._id), roleId: String(rOps._id), reportingManagerId: String(MANAGER._id) } ] });
+    ok(multi.status === 201, `multi-hat create 201 (got ${multi.status})`);
+    if (multi.data && multi.data._id) created.admins.push(multi.data._id);
+    ok(multi.data && (multi.data.roleIds || []).length === 2 && (multi.data.hats || []).length === 2, "multi-hat: roleIds union = 2, hats = 2");
+
+    const dup = await api("POST", "/admin", tok(FOUNDER), { name: `${MARK} Dup`, email: single.data.email, password: "secret123", departmentId: String(dS._id), roleId: String(rExec._id) });
+    ok(dup.status === 409, `email uniqueness -> 409 (got ${dup.status})`);
+
+    // Reporting cycle: make MANAGER report to EXEC_A (who reports to MANAGER) -> cycle.
+    const cycle = await api("PUT", `/admin/${MANAGER._id}`, tok(FOUNDER), { reportingManagerId: String(EXEC_A._id) });
+    ok(cycle.status === 400, `reporting cycle rejected (400) (got ${cycle.status})`);
+
+    // Only a founder may assign the Founder role. CRM Admin (users:*:all, NOT founder) -> 403.
+    const crmGrantsFounder = await api("POST", "/admin", tok(CRMADMIN), { name: `${MARK} Sneaky`, email: `sneaky-${Date.now()}@mb10.local`, password: "secret123", departmentId: String(dF._id), roleId: String(rFounder._id) });
+    ok(crmGrantsFounder.status === 403, `non-founder assigning Founder -> 403 (got ${crmGrantsFounder.status})`);
+    const founderGrantsFounder = await api("POST", "/admin", tok(FOUNDER), { name: `${MARK} Heir`, email: `heir-${Date.now()}@mb10.local`, password: "secret123", departmentId: String(dF._id), roleId: String(rFounder._id) });
+    ok(founderGrantsFounder.status === 201, `founder assigning Founder -> 201 (got ${founderGrantsFounder.status})`);
+    if (founderGrantsFounder.data && founderGrantsFounder.data._id) created.admins.push(founderGrantsFounder.data._id);
+    ok(single.data && single.data.permissions === undefined, "permissions live on roles, never per-person (no permissions field on admin)");
+
+    console.log("\n── Slice 4: write-route scope sweep ──");
+    const setNotes = (lead, who) => api("PUT", `/enquiry/${lead._id}/notes`, tok(who), { notes: `${MARK} touched` });
+    ok((await setNotes(leadA, EXEC_A)).status === 200, "EXEC_A writes own lead (leadA) -> 200");
+    ok((await setNotes(leadB, EXEC_A)).status === 403, "EXEC_A writes EXEC_B's lead -> 403 (out of scope)");
+    ok((await setNotes(leadB, MANAGER)).status === 200, "MANAGER writes team lead (leadB, EXEC_B reports to MANAGER) -> 200");
+    ok((await setNotes(leadOut, MANAGER)).status === 403, "MANAGER writes OUTSIDER's lead -> 403 (not in team)");
+    ok((await setNotes(leadA, FOUNDER)).status === 200, "FOUNDER writes any lead -> 200 (all scope)");
+    // stage + assign routes carry the same gate.
+    ok((await api("PUT", `/enquiry/${leadB._id}/stage`, tok(EXEC_A), { stage: "contacted" })).status === 403, "EXEC_A stage on EXEC_B's lead -> 403");
+    ok((await api("PUT", `/enquiry/${leadA._id}/stage`, tok(EXEC_A), { stage: "contacted" })).status === 200, "EXEC_A stage on own lead -> 200");
+    // A role with NO leads:edit at all (Ops Exec: projects/tasks only) -> 403.
+    const opsGuy = await mk("OpsGuy", [rOps._id], dO._id, FOUNDER._id);
+    ok((await setNotes(leadA, opsGuy)).status === 403, "Ops Exec (no leads:edit) write -> 403");
+    // Reads unchanged — the LIST endpoint is the scope-enforced read path (single
+    // GET /:_id was never per-doc scoped; out of MB10's WRITE-only sweep). Confirm
+    // EXEC_A's scoped list shows their own lead but not EXEC_B's / OUTSIDER's.
+    const execList = await api("GET", `/enquiry?limit=200&search=${MARK}&view=active`, tok(EXEC_A));
+    const listIds = new Set((execList.data.list || []).map((l) => String(l._id)));
+    ok(execList.status === 200 && listIds.has(String(leadA._id)), "read scoping unchanged: EXEC_A list includes own lead");
+    ok(!listIds.has(String(leadB._id)) && !listIds.has(String(leadOut._id)), "read scoping unchanged: EXEC_A list excludes out-of-scope leads");
+    const founderList = await api("GET", `/enquiry?limit=200&search=${MARK}&view=active`, tok(FOUNDER));
+    const fIds = new Set((founderList.data.list || []).map((l) => String(l._id)));
+    ok(fIds.has(String(leadA._id)) && fIds.has(String(leadB._id)) && fIds.has(String(leadOut._id)), "read scoping unchanged: founder list sees all leads");
+  } catch (e) {
+    fail++; failures.push(`fatal: ${e.message}`); console.error("FATAL", e); console.error(log.slice(-2500));
+  } finally {
+    await Enquiry.deleteMany({ _id: { $in: created.leads } });
+    await Admin.deleteMany({ _id: { $in: created.admins } });
+    await Role.deleteMany({ _id: { $in: created.roles } });
+    await Department.deleteMany({ _id: { $in: created.depts } });
+    child.kill(); await mongoose.disconnect();
+    console.log(`\n══ RESULT: ${pass} passed, ${fail} failed ══`);
+    if (failures.length) console.log("failures:", failures.join(" | "));
+    process.exit(fail === 0 ? 0 : 1);
+  }
+})();

--- a/services/OrgService.js
+++ b/services/OrgService.js
@@ -1,0 +1,150 @@
+/**
+ * MB10 Org & Access — the read layer over the EXISTING live RBAC (Role/Department/
+ * Admin + requirePermission). This service ONLY reads + shapes; it adds NO new RBAC
+ * vocabulary and flips NO enforcement. Two views:
+ *   - chart(): the reporting tree from Admin.reportingManagerId, department-grouped,
+ *     multi-hat aware (primary hat = top-level dept/role/manager; secondary hats
+ *     carried in Admin.hats[] render as dotted secondary reporting edges).
+ *   - permissionMatrix(): roles × (resource:action) cells, each = the broadest scope
+ *     the role grants (parsed from its stored permissions[]). Founder-row visibility
+ *     + locking reuse RoleService.getAll (no duplicated policy).
+ */
+const Admin = require("../models/Admin");
+const Role = require("../models/Role");
+const Department = require("../models/Department");
+const RoleService = require("./RoleService");
+const { RESOURCES, ACTIONS, SCOPES } = require("../utils/rbacPermissions");
+const { parsePermission, SCOPE_RANK } = require("../middlewares/requirePermission");
+
+// The (department, role, manager) hats a person carries. Always at least the
+// primary hat, reconstructed from the live top-level fields for back-compat with
+// any admin created before MB10 (no hats[] array yet).
+const hatsOf = (admin) => {
+  if (Array.isArray(admin.hats) && admin.hats.length) return admin.hats;
+  return [
+    {
+      departmentId: admin.departmentId || null,
+      roleId: admin.roleId || (Array.isArray(admin.roleIds) && admin.roleIds[0]) || null,
+      reportingManagerId: admin.reportingManagerId || null,
+    },
+  ];
+};
+
+// GET /org/chart — the org tree. Active admins only (status !== inactive, not disabled).
+const chart = async () => {
+  const [admins, roles, departments] = await Promise.all([
+    Admin.find({ isDisabled: { $ne: true } })
+      .select("name email roleId roleIds departmentId reportingManagerId hats status meta")
+      .lean(),
+    Role.find({ deletedAt: null }).select("name departmentId").lean(),
+    Department.find({ deletedAt: null }).select("name").lean(),
+  ]);
+
+  const roleName = new Map(roles.map((r) => [String(r._id), r.name]));
+  const deptName = new Map(departments.map((d) => [String(d._id), d.name]));
+
+  const nodes = admins.map((a) => {
+    const hats = hatsOf(a).map((h) => ({
+      departmentId: h.departmentId ? String(h.departmentId) : null,
+      department: h.departmentId ? deptName.get(String(h.departmentId)) || null : null,
+      roleId: h.roleId ? String(h.roleId) : null,
+      role: h.roleId ? roleName.get(String(h.roleId)) || null : null,
+      reportingManagerId: h.reportingManagerId ? String(h.reportingManagerId) : null,
+    }));
+    return {
+      _id: String(a._id),
+      name: a.name,
+      email: a.email,
+      status: a.status,
+      designation: (a.meta && a.meta.designation) || "",
+      // Primary hat drives the solid reporting line + department grouping (this IS
+      // the live scope-resolution anchor — unchanged).
+      primary: hats[0],
+      // Any extra hats render as dotted secondary reporting edges.
+      secondaryHats: hats.slice(1),
+      hatCount: hats.length,
+    };
+  });
+
+  // Department buckets keyed by each node's PRIMARY department (live grouping).
+  const byDept = departments.map((d) => ({
+    departmentId: String(d._id),
+    department: d.name,
+    members: nodes.filter((n) => n.primary.departmentId === String(d._id)),
+  }));
+  const unassigned = nodes.filter((n) => !n.primary.departmentId);
+  if (unassigned.length) {
+    byDept.push({ departmentId: null, department: "Unassigned", members: unassigned });
+  }
+
+  // Edges: solid = primary reporting line; dotted = each secondary hat's manager.
+  const edges = [];
+  for (const n of nodes) {
+    if (n.primary.reportingManagerId) {
+      edges.push({ from: n._id, to: n.primary.reportingManagerId, type: "primary" });
+    }
+    for (const h of n.secondaryHats) {
+      if (h.reportingManagerId) {
+        edges.push({ from: n._id, to: h.reportingManagerId, type: "secondary" });
+      }
+    }
+  }
+
+  return { nodes, departments: byDept, edges, total: nodes.length };
+};
+
+// GET /org/permission-matrix — roles × (resource:action), each cell = the broadest
+// scope the role grants for that pair (or "none"). Wildcards expand: a role holding
+// `*:*:all` (founder) reads as "all" everywhere. Edits go through PUT /role/:id —
+// this endpoint is READ-ONLY.
+const permissionMatrix = async (callerId) => {
+  // Reuse RoleService.getAll so founder-row visibility + locked:true are identical
+  // to the Roles settings screen (no duplicated policy).
+  const roles = await RoleService.getAll(callerId);
+
+  // The scope a granted permission set confers on one resource:action pair.
+  const scopeFor = (perms, resource, action) => {
+    let bestRank = -1;
+    for (const p of perms || []) {
+      const gp = parsePermission(p);
+      const resourceMatch = gp.resource === "*" || gp.resource === resource;
+      const actionMatch = gp.action === "*" || gp.action === action;
+      if (!resourceMatch || !actionMatch) continue;
+      const r = SCOPE_RANK[gp.scope];
+      if (r === undefined) continue;
+      if (r > bestRank) bestRank = r;
+    }
+    if (bestRank < 0) return "none";
+    return Object.keys(SCOPE_RANK).find((k) => SCOPE_RANK[k] === bestRank);
+  };
+
+  const rows = roles.map((role) => {
+    const cells = {};
+    for (const resource of RESOURCES) {
+      for (const action of ACTIONS) {
+        const scope = scopeFor(role.permissions, resource, action);
+        if (scope !== "none") cells[`${resource}:${action}`] = scope;
+      }
+    }
+    return {
+      _id: String(role._id),
+      name: role.name,
+      departmentId: role.departmentId ? String(role.departmentId) : null,
+      description: role.description || "",
+      protected: role.protected === true,
+      systemKey: role.systemKey || "",
+      // RoleService stamps locked:true on the founder row for founder callers.
+      locked: role.locked === true || RoleService.isFounderRole(role),
+      cells,
+    };
+  });
+
+  return {
+    resources: RESOURCES,
+    actions: ACTIONS,
+    scopes: ["none", ...SCOPES], // none → own → team → department → all
+    roles: rows,
+  };
+};
+
+module.exports = { chart, permissionMatrix, hatsOf };

--- a/services/PeopleService.js
+++ b/services/PeopleService.js
@@ -1,0 +1,122 @@
+/**
+ * MB10 Slice 3 — multi-hat people helpers shared by POST /admin + PUT /admin/:id.
+ * Permissions live on ROLES (never per-person). A person carries one or more
+ * (department, role, manager) HATS:
+ *   - hats[0] = PRIMARY → mirrors the live top-level departmentId/roleId/
+ *     reportingManagerId (the authoritative scope-resolution anchor — unchanged).
+ *   - roleIds[] = the UNION of every hat's role (the existing permission union the
+ *     gate already reads). Single-roleId resolution still works (roleIds falls
+ *     back to roleId when empty).
+ * Guardrails: every dept/role/manager must exist; reporting cycles are rejected
+ * (transitive A→B→A); only a founder may assign the Founder role (incl. to self).
+ */
+const mongoose = require("mongoose");
+const Admin = require("../models/Admin");
+const Role = require("../models/Role");
+const Department = require("../models/Department");
+const RoleService = require("./RoleService");
+const { roleIdsOf } = require("../middlewares/requirePermission");
+
+const err = (status, message) => Object.assign(new Error(message), { status });
+const isId = (v) => mongoose.isValidObjectId(v);
+
+// Accept either the simple single-hat body (roleId/departmentId/reportingManagerId)
+// or an explicit hats[] array. Always returns a non-empty hats[] (primary first).
+const normalizeHats = (body = {}) => {
+  let hats = Array.isArray(body.hats) && body.hats.length
+    ? body.hats
+    : [{ departmentId: body.departmentId, roleId: body.roleId, reportingManagerId: body.reportingManagerId }];
+  hats = hats
+    .map((h) => ({
+      departmentId: h.departmentId || null,
+      roleId: h.roleId || null,
+      reportingManagerId: h.reportingManagerId || h.reportingManagerId === null ? h.reportingManagerId || null : null,
+    }))
+    // A hat is meaningful only with a department + role.
+    .filter((h) => h.departmentId || h.roleId);
+  return hats;
+};
+
+// Validate hat shape + referential integrity. Returns the resolved
+// { hats, roleIds, primary } or throws err(status,...).
+const resolveHats = async (rawHats) => {
+  if (!rawHats.length) throw err(400, "At least one (department, role) hat is required.");
+  const hats = [];
+  const roleIdSet = new Set();
+  for (const h of rawHats) {
+    if (!isId(h.departmentId) || !isId(h.roleId)) {
+      throw err(400, "Each hat needs a valid departmentId and roleId.");
+    }
+    if (h.reportingManagerId && !isId(h.reportingManagerId)) {
+      throw err(400, "Invalid reportingManagerId in a hat.");
+    }
+    const [role, dept] = await Promise.all([
+      Role.findOne({ _id: h.roleId, deletedAt: null }).lean(),
+      Department.findOne({ _id: h.departmentId, deletedAt: null }).lean(),
+    ]);
+    if (!role) throw err(400, "roleId does not match any role.");
+    if (!dept) throw err(400, "departmentId does not match any department.");
+    let managerId = null;
+    if (h.reportingManagerId) {
+      const manager = await Admin.findById(h.reportingManagerId).lean();
+      if (!manager) throw err(400, "reportingManagerId does not match any user.");
+      managerId = manager._id;
+    }
+    hats.push({ departmentId: dept._id, roleId: role._id, reportingManagerId: managerId });
+    roleIdSet.add(String(role._id));
+  }
+  return { hats, roleIds: [...roleIdSet], primary: hats[0] };
+};
+
+// Only a founder caller may assign the Founder role (systemKey "founder" / *:*:all)
+// to anyone — incl. themselves (blocks self-elevation to Founder).
+const assertNotGrantingFounder = async (roleIds, callerId) => {
+  const roles = await Role.find({ _id: { $in: roleIds } }).lean();
+  const grantsFounder = roles.some((r) => RoleService.isFounderRole(r));
+  if (!grantsFounder) return;
+  const caller = await Admin.findById(callerId).lean();
+  const callerRoles = caller ? await Role.find({ _id: { $in: roleIdsOf(caller) } }).lean() : [];
+  const callerIsFounder = callerRoles.some((r) => RoleService.isFounderRole(r));
+  if (!callerIsFounder) throw err(403, "Only a founder can assign the Founder role.");
+};
+
+// Reject a transitive reporting cycle: walking UP from each hat's manager via
+// reportingManagerId must never reach targetId. (On create, targetId is null and
+// no one reports to the new person yet, so a cycle is impossible — still cheap to
+// guard.) Cycle-safe against pre-existing loops via a visited set.
+const assertNoReportingCycle = async (targetId, hats) => {
+  if (!targetId) return;
+  const target = String(targetId);
+  for (const h of hats) {
+    let cursor = h.reportingManagerId ? String(h.reportingManagerId) : null;
+    if (cursor === target) throw err(400, "A user cannot report to themselves.");
+    const visited = new Set();
+    while (cursor && !visited.has(cursor)) {
+      visited.add(cursor);
+      const mgr = await Admin.findById(cursor).select("reportingManagerId").lean();
+      const next = mgr && mgr.reportingManagerId ? String(mgr.reportingManagerId) : null;
+      if (next === target) {
+        throw err(400, "Reporting cycle detected: that manager (directly or indirectly) reports to this user.");
+      }
+      cursor = next;
+    }
+  }
+};
+
+// Build the Admin field patch from resolved hats. Mirrors the primary hat into the
+// authoritative top-level fields (unchanged live resolution) and sets roleIds union.
+const fieldsFromHats = ({ hats, roleIds, primary }) => ({
+  hats,
+  roleIds,
+  roleId: primary.roleId,
+  departmentId: primary.departmentId,
+  reportingManagerId: primary.reportingManagerId,
+});
+
+module.exports = {
+  normalizeHats,
+  resolveHats,
+  assertNotGrantingFounder,
+  assertNoReportingCycle,
+  fieldsFromHats,
+};


### PR DESCRIPTION
Additive admin UI over the EXISTING live RBAC. /org/chart (reporting tree), /org/permission-matrix (reuses PUT /role/:id, no new write path), add-person over POST/PUT /admin (additive Admin.hats[], hats[0] mirrors authoritative top-level fields, single-hat resolution unchanged). Write-route scope sweep: enforceLeadScope middleware on 7 lead write routes (update/notes/note/call/stage/assign/disqualify), reuses existing scope, Founder writes all / manager team / exec own, out-of-scope 403. Journey/chat/step routes deliberately NOT swept (soft-visibility model). Enforcement NOT re-flipped, admins NOT re-migrated, no new RBAC vocab. Guardrails: founder immutable 422, protected 403, reporting-cycle 400, non-founder→Founder 403, email-dup 409. 41/41 + regressions green, 47/47 Playwright.