### PR TITLE
MB11c: data continuity at qualify handoff — qualifiedBy/qualifiedAt (set-once), activity timeline via /journey reuse

### DIFF
--- a/models/Enquiry.js
+++ b/models/Enquiry.js
@@ -194,6 +194,9 @@ const EnquirySchema = new mongoose.Schema(
     // Set-once credit: the intern who booked the meet that triggered the
     // handoff. Their stats keep this lead permanently.
     qualifiedBy: { type: ObjectId, ref: "Admin", default: null },
+    // ── MB11c (additive) ─ Set-once timestamp of the qualify hinge, so the
+    // command center can surface "qualified by X · on date" at the handoff.
+    qualifiedAt: { type: Date, default: null },
     // Lightweight event-team assignments captured at huddle completion.
     eventTeam: {
       type: [

--- a/scripts/browser-e2e-fixtures.js
+++ b/scripts/browser-e2e-fixtures.js
@@ -20,6 +20,10 @@ const QUALIFIED_LEAD_PHONE = "919180000004";
 // MB9a — a dedicated PRE-QUAL intake lead the lifecycle e2e can qualify without
 // touching the shared LEAD_PHONE fixture.
 const INTAKE_LEAD_PHONE = "919180000005";
+// MB11c — a lead qualified THROUGH the hinge, carrying pre-qual history (call
+// logs with notes + a note event) so the continuity e2e can prove the command
+// center surfaces the qualifier's record, "qualified by X", and the timeline.
+const CONTINUITY_LEAD_PHONE = "919180000006";
 
 (async () => {
   const cmd = process.argv[2];
@@ -56,7 +60,8 @@ const INTAKE_LEAD_PHONE = "919180000005";
     await cleanLeadArtifacts(LEAD_PHONE);
     await cleanLeadArtifacts(QUALIFIED_LEAD_PHONE);
     await cleanLeadArtifacts(INTAKE_LEAD_PHONE);
-    await Enquiry.deleteMany({ phone: { $in: [LEAD_PHONE, QUALIFIED_LEAD_PHONE, INTAKE_LEAD_PHONE] } });
+    await cleanLeadArtifacts(CONTINUITY_LEAD_PHONE);
+    await Enquiry.deleteMany({ phone: { $in: [LEAD_PHONE, QUALIFIED_LEAD_PHONE, INTAKE_LEAD_PHONE, CONTINUITY_LEAD_PHONE] } });
     await WAConversation.deleteMany({ phone: LEAD_PHONE });
     await WAAgentMessage.deleteMany({ phone: LEAD_PHONE });
     await Admin.deleteMany({ phone: ADMIN_PHONE });
@@ -149,8 +154,39 @@ const INTAKE_LEAD_PHONE = "919180000005";
     additionalInfo: {},
   });
 
+  // ── MB11c — a lead with PRE-QUAL history, qualified through the real hinge ──
+  // Pre-qual call logs (with notes) + Kiara facts live on the doc; a note event
+  // + the qualifyLead transition give the command center a full timeline and the
+  // "qualified by X · date" credit. qualifyLead sets qualifiedBy/qualifiedAt.
+  const LeadInternalEventService = require("../services/LeadInternalEventService");
+  const LeadLifecycleService = require("../services/LeadLifecycleService");
+  const contLead = await Enquiry.create({
+    name: "Veer & Tara",
+    phone: CONTINUITY_LEAD_PHONE,
+    verified: true,
+    source: "Website",
+    stage: "contacted",
+    assignedTo: admin._id,
+    qualificationData: { groomName: "Veer", brideName: "Tara", weddingStyle: "Classic", venueArea: "Jaipur", servicesRequired: ["Decor"] },
+    additionalInfo: { kiaraAnswers: { city: "Jaipur", budget: "20L" } },
+    callLog: [
+      { startedAt: new Date(Date.now() - 3600000), durationSeconds: 0, connected: false, outcome: "", notes: "No answer — left a voicemail.", loggedBy: admin._id },
+      { startedAt: new Date(Date.now() - 1800000), durationSeconds: 240, connected: true, outcome: "qualified", notes: "Discovery call: 20L budget, Jaipur, Dec wedding.", loggedBy: admin._id },
+    ],
+    updates: { notes: "Keen couple — send the deck before the next call." },
+  });
+  await LeadInternalEventService.record({
+    leadId: contLead._id,
+    type: "commented",
+    actorId: admin._id,
+    payload: { text: "Keen couple — send the deck before the next call." },
+  });
+  // The real hinge: sets qualified + qualifiedBy + qualifiedAt, records the
+  // "qualified" event, instantiates the journey (idempotent).
+  await LeadLifecycleService.qualifyLead(contLead._id, admin._id);
+
   await mongoose.disconnect();
   console.log(
-    JSON.stringify({ token, leadId: String(lead._id), conversationId: String(conversation._id), qualifiedLeadId: String(qLead._id), intakeLeadId: String(intakeLead._id) })
+    JSON.stringify({ token, leadId: String(lead._id), conversationId: String(conversation._id), qualifiedLeadId: String(qLead._id), intakeLeadId: String(intakeLead._id), continuityLeadId: String(contLead._id) })
   );
 })();

--- a/services/LeadLifecycleService.js
+++ b/services/LeadLifecycleService.js
@@ -429,8 +429,16 @@ const qualifyLead = async (enquiryId, actorId) => {
   }
   const handedOff = !!newOwnerId && String(newOwnerId) !== String(lead.assignedTo || "");
 
-  const fields = { qualified: true };
+  // MB11c — carry the qualifier's credit forward at the handoff. qualifiedAt is
+  // set-once here (this branch only runs on the first qualification — the early
+  // idempotent return guards re-entry). qualifiedBy is set-once too: we don't
+  // clobber an existing credit (e.g. the MB5 meet-handoff intern), otherwise we
+  // record whoever fired the hinge. The pre-qual record (callLog, notes,
+  // qualificationData, kiaraAnswers, kiaraSummary) already lives on this same
+  // Enquiry doc and survives untouched — this only adds the missing "who/when".
+  const fields = { qualified: true, qualifiedAt: lead.qualifiedAt || new Date() };
   if (handedOff) fields.assignedTo = newOwnerId;
+  if (!lead.qualifiedBy && actorId) fields.qualifiedBy = actorId;
   await EnquiryRepository.updateFieldsById(enquiryId, fields);
 
   await LeadInternalEventService.record({


### PR DESCRIPTION
Verified pre-qual data already survives qualification (same Enquiry doc) — fix was surfacing, not storage. Added set-once qualifiedAt/qualifiedBy (no-clobber, preserves MB5 meet-handoff credit). Activity timeline reuses GET /enquiry/:id/journey (no new endpoint, no parallel log). Hinge intact (one idempotent transition, journey once). Transfer already gated server-side (bulk-transfer = requirePermission leads:edit:team + per-doc scope) — contributors 403, owner/RevHead/founder pass. 53/53 Playwright + regression.